### PR TITLE
feat: add support for CodeReady Containers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,9 +25,11 @@ It would work analogically also for the cases when the repositories either both 
 
 If you still don't know what to do with e2e tests in some use-cases, go to <<What to do>> section where all use-cases are covered.
 
-==== Prerequisites if running locally on Minishift
-If you are running these tests locally in Minishift, make sure that you have exposed Minishift's docker-env, so deployment can use the locally built image. You can expose it by running the following command.
-`eval $(minishift docker-env)`
+==== Prerequisites if running locally on Minishift or CRC (CodeReady Containers)
+If you are running these tests locally in Minishift or CRC, make sure that you have exposed necessary environments, so deployment can use the locally built image. You can expose it by running the following commands.
+
+* for Minishift `eval $(minishift docker-env)` `eval $(minishift oc-env)`
+* for CodeReady Containers `eval $(crc oc-env)`
 
 
 NOTE: This is not required for openshift-ci environment


### PR DESCRIPTION
when the makefile tries to log in, it first checks if there is running VM via CRC. 
  * If there is, then it tries to log in as `kube:admin`
  * if there is no CRC VM running, then it logs as `system:admin`
