### PR TITLE
fix: let CI build operators images before e2e test execution

### DIFF
--- a/openshift-ci/Dockerfile.host.deploy
+++ b/openshift-ci/Dockerfile.host.deploy
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV OPERATOR=/usr/local/bin/host-operator \
+    USER_UID=1001 \
+    USER_NAME=host-operator \
+    LANG=en_US.utf8
+
+# install operator binary
+COPY host-operator ${OPERATOR}
+
+USER ${USER_UID}
+
+ENTRYPOINT [ "/usr/local/bin/host-operator" ]

--- a/openshift-ci/Dockerfile.member.deploy
+++ b/openshift-ci/Dockerfile.member.deploy
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV OPERATOR=/usr/local/bin/member-operator \
+    USER_UID=1001 \
+    USER_NAME=member-operator \
+    LANG=en_US.utf8
+
+# install operator binary
+COPY member-operator ${OPERATOR}
+
+USER ${USER_UID}
+
+ENTRYPOINT [ "/usr/local/bin/member-operator" ]


### PR DESCRIPTION
We need to let CI build both operators images before the actual e2e test execution so we have correct images to deploy
see this PR: https://github.com/openshift/release/pull/5140