### PR TITLE
fix: add missing delete case

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -256,8 +256,8 @@ func verifyDeletion(awaitility *wait.Awaitility, mur *toolchainv1alpha1.MasterUs
 	assert.NoError(awaitility.T, err, "UserAccount is not deleted")
 
 	err = memberAwait.WaitForDeletedUser(mur.Name)
-	assert.NoError(awaitility.T, err)
+	assert.NoError(awaitility.T, err, "User is not deleted")
 
 	err = memberAwait.WaitForDeletedIdentity(mur.Name)
-	assert.NoError(awaitility.T, err)
+	assert.NoError(awaitility.T, err, "Identity is not deleted")
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -132,6 +132,24 @@ func TestE2EFlow(t *testing.T) {
 		// TODO: verify expected condition when the member operator has a logic that updates NsTemplateSet and its status
 		verifyResources(awaitility, extraMur, nil, expectingUaConditions(toBeProvisioned()))
 	})
+
+	t.Run("delete MasterUserRecord and expect UserAccount to be deleted", func(t *testing.T) {
+		// given
+		currentMur := wait.NewHostAwaitility(awaitility).GetMasterUserRecord(mur.Name)
+
+		// when
+		err := awaitility.Client.Delete(context.TODO(), currentMur)
+
+		// then
+		require.NoError(t, err)
+		t.Logf("MasterUserRecord '%s' deleted", mur.Name)
+
+		verifyDeletion(awaitility, currentMur)
+		assert.NoError(t, err)
+
+		extraMur = wait.NewHostAwaitility(awaitility).GetMasterUserRecord(extraMur.Name)
+		verifyResources(awaitility, extraMur, nil, expectingUaConditions(toBeProvisioned()))
+	})
 }
 
 type murConditionsGetter func() []toolchainv1alpha1.Condition
@@ -225,4 +243,21 @@ func createMasterUserRecord(awaitility *wait.Awaitility, ctx *framework.TestCtx,
 
 func toIdentityName(userID string) string {
 	return fmt.Sprintf("%s:%s", "rhd", userID)
+}
+
+func verifyDeletion(awaitility *wait.Awaitility, mur *toolchainv1alpha1.MasterUserRecord) {
+	hostAwait := wait.NewHostAwaitility(awaitility)
+	memberAwait := wait.NewMemberAwaitility(awaitility)
+
+	err := hostAwait.WaitForDeletedMasterUserRecord(mur.Name)
+	assert.NoError(awaitility.T, err, "MasterUserRecord is not deleted")
+
+	err = memberAwait.WaitForDeletedUserAccount(mur.Name)
+	assert.NoError(awaitility.T, err, "UserAccount is not deleted")
+
+	err = memberAwait.WaitForDeletedUser(mur.Name)
+	assert.NoError(awaitility.T, err)
+
+	err = memberAwait.WaitForDeletedIdentity(mur.Name)
+	assert.NoError(awaitility.T, err)
 }

--- a/wait/host.go
+++ b/wait/host.go
@@ -141,6 +141,22 @@ func (a *HostAwaitility) WaitForUserSignup(name string) error {
 	})
 }
 
+// WaitForDeletedMasterUserRecord waits until MUR with the given name is not present
+func (a *HostAwaitility) WaitForDeletedMasterUserRecord(name string) error {
+	return wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		mur := &toolchainv1alpha1.MasterUserRecord{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, mur); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("MasterUserAccount is checked as deleted '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until MasterUserAccount is deleted '%s'", name)
+		return false, nil
+	})
+}
+
 func getUaSpecSyncIndex(mur *toolchainv1alpha1.MasterUserRecord, targetCluster string) string {
 	for _, ua := range mur.Spec.UserAccounts {
 		if ua.TargetCluster == targetCluster {

--- a/wait/member.go
+++ b/wait/member.go
@@ -92,3 +92,51 @@ func (a *MemberAwaitility) WaitForIdentity(name string) error {
 		return false, nil
 	})
 }
+
+// WaitForDeletedUserAccount waits until the UserAccount with the given name is not found
+func (a *MemberAwaitility) WaitForDeletedUserAccount(name string) error {
+	return wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		ua := &toolchainv1alpha1.UserAccount{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, ua); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("UserAccount is checked as deleted '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until UserAccount is deleted '%s'", name)
+		return false, nil
+	})
+}
+
+// WaitForDeletedUser waits until the User with the given name is not found
+func (a *MemberAwaitility) WaitForDeletedUser(name string) error {
+	return wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		user := &userv1.User{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, user); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("deleted user '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until User is deleted '%s'", name)
+		return false, nil
+	})
+}
+
+// WaitForDeletedIdentity waits until the Identity with the given name is not found
+func (a *MemberAwaitility) WaitForDeletedIdentity(name string) error {
+	return wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		identity := &userv1.Identity{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, identity); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("deleted identity '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until Identity is deleted '%s'", name)
+		return false, nil
+	})
+}


### PR DESCRIPTION
somehow, while moving the e2e tests, I missed the deletion test case. This PR merges:
https://github.com/codeready-toolchain/host-operator/blob/08e3262b122db594b4e06f93f077112d1e265cec/test/e2e/masteruserrecord_test.go#L79-L96
and 
https://github.com/codeready-toolchain/member-operator/blob/0fce69b64078055ef51c2ca33e793bc7c86ac33f/test/e2e/useraccount_test.go#L115-L131 