### PR TITLE
fix: when it is executed from remote repo, then don't pair

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -128,8 +128,10 @@ ifneq ($(CLONEREFS_OPTIONS),)
 		echo "branch ref of the user's fork: \"$${REMOTE_E2E_BRANCH}\" - if empty then not found"; \
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master \
 		if [[ -n "$${REMOTE_E2E_BRANCH}" ]]; then \
-			git config --global user.email "devtools@redhat.com"; \
-			git config --global user.name "Devtools"; \
+			if [[ -n "$(OPENSHIFT_BUILD_NAMESPACE)" ]]; then \
+				git config --global user.email "devtools@redhat.com"; \
+				git config --global user.name "Devtools"; \
+			fi; \
 			# retrieve the branch name \
 			BRANCH_NAME=`echo ${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
 			# add the user's fork as remote repo \

--- a/make/test.mk
+++ b/make/test.mk
@@ -122,21 +122,23 @@ ifneq ($(CLONEREFS_OPTIONS),)
 	# get branch ref of the fork the PR was created from
 	$(eval BRANCH_REF := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a ${PULL_SHA} | awk '{print $$2}'))
 	@echo "detected branch ref ${BRANCH_REF}"
-	# check if a branch with the same ref exists in the user's fork of ${REPO_NAME} repo
-	$(eval REMOTE_E2E_BRANCH := $(shell curl ${AUTHOR_LINK}/${REPO_NAME}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$$" | awk '{print $$2}'))
-	@echo "branch ref of the user's fork: \"${REMOTE_E2E_BRANCH}\" - if empty then not found"
-	# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master
-	if [[ -n "${REMOTE_E2E_BRANCH}" ]]; then \
-		git config --global user.email "devtools@redhat.com"; \
-		git config --global user.name "Devtools"; \
-		# retrieve the branch name \
-		BRANCH_NAME=`echo ${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
-		# add the user's fork as remote repo \
-		git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} remote add external ${AUTHOR_LINK}/${REPO_NAME}.git; \
-		# fetch the branch; \
-		git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
-		# merge the branch with master \
-		git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
+	if [[ -n "${BRANCH_REF}" ]]; then \
+		# check if a branch with the same ref exists in the user's fork of ${REPO_NAME} repo \
+		REMOTE_E2E_BRANCH=`curl ${AUTHOR_LINK}/${REPO_NAME}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$$" | awk '{print $$2}'`; \
+		echo "branch ref of the user's fork: \"$${REMOTE_E2E_BRANCH}\" - if empty then not found"; \
+		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master \
+		if [[ -n "$${REMOTE_E2E_BRANCH}" ]]; then \
+			git config --global user.email "devtools@redhat.com"; \
+			git config --global user.name "Devtools"; \
+			# retrieve the branch name \
+			BRANCH_NAME=`echo ${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
+			# add the user's fork as remote repo \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} remote add external ${AUTHOR_LINK}/${REPO_NAME}.git; \
+			# fetch the branch; \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
+			# merge the branch with master \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
+		fi; \
 	fi;
 	$(MAKE) -C ${E2E_REPO_PATH} build
 	# operators are built, now copy the operators' binaries to make them available for CI


### PR DESCRIPTION
when the e2e tests are cloned & triggered inside of a job running for different repository (host-operator or member-operator) then it should not try to pair, because the found sha commit won't match any branch name
The impact of the bug can be seen here https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_member-operator/72/pull-ci-codeready-toolchain-member-operator-master-e2e/306