### PR TITLE
chore(CRT-226): deploy and install member-operator via CSV

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -232,9 +232,9 @@ ifeq ($(IS_OS_3),)
 	# it is not using OS 3 so we will install operator via CSV
 	$(eval CATALOGSOURCE_NAME := $(shell sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ${E2E_REPO_PATH}/hack/deploy_csv.yaml | oc apply -f - | grep catalogsource | awk '{print $$1;}'))
 	$(eval SUBSCRIPTION_NAME := $(shell sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g' ${E2E_REPO_PATH}/hack/install_operator.yaml | oc apply -f - | grep subscription | awk '{print $$1;}'))
-	while [[ -z `oc get sa ${REPO_NAME} -n ${NAMESPACE} 2>/dev/null` ]] || [[ -z `oc get crd kubefedclusters.core.kubefed.k8s.io 2>/dev/null` ]] || [[ -z `oc get crd nstemplatetiers.toolchain.dev.openshift.com 2>/dev/null` ]]; do \
+	while [[ -z `oc get sa ${REPO_NAME} -n ${NAMESPACE} 2>/dev/null` ]] || [[ -z `oc get crd kubefedclusters.core.kubefed.k8s.io 2>/dev/null` ]]; do \
         if [[ $${NEXT_WAIT_TIME} -eq 60 ]]; then \
-           echo "reached timeout of waiting for ServiceAccount ${REPO_NAME} to be available in namespace ${NAMESPACE} and both CRDs kubefedclusters.core.kubefed.k8s.io and nstemplatetiers.toolchain.dev.openshift.com to be available in the cluster - see following info for debugging:"; \
+           echo "reached timeout of waiting for ServiceAccount ${REPO_NAME} to be available in namespace ${NAMESPACE} and CRD kubefedclusters.core.kubefed.k8s.io to be available in the cluster - see following info for debugging:"; \
            echo "================================ CatalogSource =================================="; \
            oc get ${CATALOGSOURCE_NAME} -n openshift-marketplace -o yaml; \
            echo "================================ CatalogSource Pod Logs =================================="; \
@@ -244,7 +244,7 @@ ifeq ($(IS_OS_3),)
            oc get ${SUBSCRIPTION_NAME} -n ${NAMESPACE} -o yaml; \
            exit 1; \
         fi; \
-        echo "$$(( NEXT_WAIT_TIME++ )). attempt of waiting for ServiceAccount ${REPO_NAME} in namespace ${NAMESPACE}" and both CRDs kubefedclusters.core.kubefed.k8s.io and nstemplatetiers.toolchain.dev.openshift.com to be available in the cluster; \
+        echo "$$(( NEXT_WAIT_TIME++ )). attempt of waiting for ServiceAccount ${REPO_NAME} in namespace ${NAMESPACE}" and CRD kubefedclusters.core.kubefed.k8s.io to be available in the cluster; \
         sleep 1; \
     done
 else

--- a/make/test.mk
+++ b/make/test.mk
@@ -162,13 +162,15 @@ ifeq ($(MEMBER_REPO_PATH),)
 	$(eval MEMBER_REPO_PATH = /tmp/member-operator)
 endif
 	oc new-project $(MEMBER_NS) 1>/dev/null
+ifneq ($(IS_OS_3),)
 	oc apply -f ${MEMBER_REPO_PATH}/deploy/service_account.yaml
 	oc apply -f ${MEMBER_REPO_PATH}/deploy/role.yaml
 	oc apply -f ${MEMBER_REPO_PATH}/deploy/role_binding.yaml
 	oc apply -f ${MEMBER_REPO_PATH}/deploy/cluster_role.yaml
 	cat ${MEMBER_REPO_PATH}/deploy/cluster_role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(MEMBER_NS)/ | oc apply -f -
 	oc apply -f ${MEMBER_REPO_PATH}/deploy/crds
-	$(MAKE) build-and-deploy-operator E2E_REPO_PATH=${MEMBER_REPO_PATH} REPO_NAME=member-operator SET_IMAGE_NAME=${MEMBER_IMAGE_NAME} IS_OTHER_IMAGE_SET=${HOST_IMAGE_NAME}
+endif
+	$(MAKE) build-and-deploy-operator E2E_REPO_PATH=${MEMBER_REPO_PATH} REPO_NAME=member-operator SET_IMAGE_NAME=${MEMBER_IMAGE_NAME} IS_OTHER_IMAGE_SET=${HOST_IMAGE_NAME} NAMESPACE=$(MEMBER_NS)
 
 .PHONY: deploy-host
 deploy-host:
@@ -223,8 +225,8 @@ else
 	# use the provided image name
 	$(eval IMAGE_NAME := ${SET_IMAGE_NAME})
 endif
-ifeq ($(shell [[ "${REPO_NAME}" == "host-operator" && -z "${IS_OS_3}" ]] && echo true ),true)
-	# it is host-operator and is not using OS 3, so we will install operator via CSV
+ifeq ($(IS_OS_3),)
+	# it is not using OS 3 so we will install operator via CSV
 	$(eval CATALOGSOURCE_NAME := $(shell sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ${E2E_REPO_PATH}/hack/deploy_csv.yaml | oc apply -f - | grep catalogsource | awk '{print $$1;}'))
 	$(eval SUBSCRIPTION_NAME := $(shell sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g' ${E2E_REPO_PATH}/hack/install_operator.yaml | oc apply -f - | grep subscription | awk '{print $$1;}'))
 	while [[ -z `oc get sa ${REPO_NAME} -n ${NAMESPACE} 2>/dev/null` ]]; do \


### PR DESCRIPTION
Instead of directly deploying host operator it adds it to Catalog and then installs as a standard operator
Paired PR: codeready-toolchain/member-operator#77