### PR TITLE
configure golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,21 @@
+service:
+  project-path: github.com/codeready-toolchain/toolchain-e2e
+
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
+linters:
+  enable:
+    - gofmt 
+    - unparam
+
+# all available settings of specific linters
+linters-settings:
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: true
+ 

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -14,4 +14,4 @@ endif
 ## Checks the code with golangci-lint
 lint-go-code:
 	$(Q)go get github.com/golangci/golangci-lint/cmd/golangci-lint
-	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run --deadline=10m
+	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run


### PR DESCRIPTION
add 'golangci.yml' file with a timeout to 10min
and the same linter config as in 'host-operator'
repo for now

Fixes CRT-299

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>