### PR TITLE
chore: increase wait limit for resources after deployment

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -233,7 +233,7 @@ ifeq ($(IS_OS_3),)
 	$(eval CATALOGSOURCE_NAME := $(shell sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ${E2E_REPO_PATH}/hack/deploy_csv.yaml | oc apply -f - | grep catalogsource | awk '{print $$1;}'))
 	$(eval SUBSCRIPTION_NAME := $(shell sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g' ${E2E_REPO_PATH}/hack/install_operator.yaml | oc apply -f - | grep subscription | awk '{print $$1;}'))
 	while [[ -z `oc get sa ${REPO_NAME} -n ${NAMESPACE} 2>/dev/null` ]] || [[ -z `oc get crd kubefedclusters.core.kubefed.k8s.io 2>/dev/null` ]]; do \
-        if [[ $${NEXT_WAIT_TIME} -eq 60 ]]; then \
+        if [[ $${NEXT_WAIT_TIME} -eq 300 ]]; then \
            echo "reached timeout of waiting for ServiceAccount ${REPO_NAME} to be available in namespace ${NAMESPACE} and CRD kubefedclusters.core.kubefed.k8s.io to be available in the cluster - see following info for debugging:"; \
            echo "================================ CatalogSource =================================="; \
            oc get ${CATALOGSOURCE_NAME} -n openshift-marketplace -o yaml; \


### PR DESCRIPTION
...so the e2e tests don't fail when the deployment/installation takes a longer time