### PR TITLE
add smoke test for the registration service

### DIFF
--- a/doubles/init.go
+++ b/doubles/init.go
@@ -1,26 +1,33 @@
 package doubles
 
 import (
+	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
+	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-// InitializeOperators initializes test context, registers schemes and waits until both operators (host, member)
+// WaitForDeployments initializes test context, registers schemes and waits until both operators (host, member)
 // and corresponding KubeFedCluster CRDs are present, running and ready. Based on the given cluster type
 // that represents the current operator that is the target of the e2e test it retrieves namespace names.
+// Also waits for the registration service to be deployed (with 3 replica)
 // Returns the test context and an instance of Awaitility that contains all necessary information
-func InitializeOperators(t *testing.T, obj runtime.Object) (*framework.TestCtx, *wait.Awaitility) {
+func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.TestCtx, *wait.Awaitility) {
 	schemeBuilder := newSchemeBuilder()
 	err := framework.AddToFrameworkScheme(schemeBuilder.AddToScheme, obj)
 	require.NoError(t, err, "failed to add custom resource scheme to framework")
@@ -33,6 +40,7 @@ func InitializeOperators(t *testing.T, obj runtime.Object) (*framework.TestCtx, 
 
 	memberNs := os.Getenv(wait.MemberNsVar)
 	hostNs := os.Getenv(wait.HostNsVar)
+	registrationServiceNs := os.Getenv(wait.RegistrationServiceVar)
 
 	// get global framework variables
 	f := framework.Global
@@ -45,14 +53,27 @@ func InitializeOperators(t *testing.T, obj runtime.Object) (*framework.TestCtx, 
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, memberNs, "member-operator", 1, wait.OperatorRetryInterval, wait.OperatorTimeout)
 	require.NoError(t, err, "failed while waiting for member operator deployment")
 
+	// wait for registration service to be ready
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 3, wait.RetryInterval, wait.OperatorTimeout)
+	require.NoError(t, err, "failed while waiting for registration service deployment")
+
+	registrationServiceRoute, err := waitForRoute(t, f, registrationServiceNs, "registration-service", wait.RetryInterval, wait.OperatorTimeout)
+	require.NoError(t, err, "failed while waiting for registration service deployment")
+
+	registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host
+	if registrationServiceRoute.Spec.TLS != nil {
+		registrationServiceURL = "https://" + registrationServiceRoute.Spec.Host
+	}
 	awaitility := &wait.Awaitility{
-		T:                t,
-		Client:           f.Client,
-		KubeClient:       f.KubeClient,
-		ControllerClient: f.Client.Client,
-		Scheme:           f.Scheme,
-		HostNs:           hostNs,
-		MemberNs:         memberNs,
+		T:                      t,
+		Client:                 f.Client,
+		KubeClient:             f.KubeClient,
+		ControllerClient:       f.Client.Client,
+		Scheme:                 f.Scheme,
+		HostNs:                 hostNs,
+		MemberNs:               memberNs,
+		RegistrationServiceNs:  registrationServiceNs,
+		RegistrationServiceURL: registrationServiceURL,
 	}
 
 	err = awaitility.WaitForReadyKubeFedClusters()
@@ -62,9 +83,33 @@ func InitializeOperators(t *testing.T, obj runtime.Object) (*framework.TestCtx, 
 	return ctx, awaitility
 }
 
+// waitForRoute
+func waitForRoute(t *testing.T, f *framework.Framework, ns, name string, retryInterval time.Duration, timeout time.Duration) (routev1.Route, error) {
+	var route routev1.Route
+	// retrieve the route for the registration service
+	err := k8swait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		err = f.Client.Get(context.TODO(),
+			types.NamespacedName{
+				Namespace: ns,
+				Name:      name,
+			},
+			&route)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("Waiting for availability of route '%s' in namespace '%s'...\n", name, ns)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	return route, err
+}
+
 func newSchemeBuilder() runtime.SchemeBuilder {
 	addToSchemes := append(apis.AddToSchemes, userv1.AddToScheme)
 	addToSchemes = append(addToSchemes, templatev1.AddToScheme)
+	addToSchemes = append(addToSchemes, routev1.AddToScheme)
 	return addToSchemes
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible
+	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/operator-framework/operator-sdk v0.10.0
 	github.com/rogpeppe/go-internal v1.4.0 // indirect
 	github.com/satori/go.uuid v1.2.0
@@ -19,6 +20,7 @@ require (
 	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
 	golang.org/x/tools v0.0.0-20190927052746-69890759d905 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0-20190925180651-d58b53da08f5
 	k8s.io/apiextensions-apiserver v0.0.0-20190927042040-728319705b32 // indirect
 	k8s.io/apimachinery v0.0.0-20190927035529-0104e33c351d

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible h1:sMBjLRdoavwnc2khLpIOmBkMPDGRB4sIbhOb8Cx2Uh0=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/client-go v3.9.0+incompatible h1:13k3Ok0B7TA2hA3bQW2aFqn6y04JaJWdk7ITTyg+Ek0=
+github.com/openshift/client-go v3.9.0+incompatible/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
@@ -657,6 +659,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/make/test.mk
+++ b/make/test.mk
@@ -7,6 +7,7 @@
 DATE_SUFFIX := $(shell date +'%s')
 MEMBER_NS := member-operator-${DATE_SUFFIX}
 HOST_NS := host-operator-${DATE_SUFFIX}
+REGISTRATION_SERVICE_NS := $(HOST_NS)
 TEST_NS := toolchain-e2e-${DATE_SUFFIX}
 AUTHOR_LINK := $(shell jq -r '.refs[0].pulls[0].author_link' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]')
 PULL_SHA := $(shell jq -r '.refs[0].pulls[0].sha' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]')
@@ -50,13 +51,14 @@ e2e-run:
 	oc get kubefedcluster -n $(MEMBER_NS)
 	$(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS}
 	-oc new-project $(TEST_NS) --display-name e2e-tests 1>/dev/null
-	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=15m" || \
-	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} && exit 1)
+	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=15m" || \
+	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs
 print-logs:
 	$(MAKE) print-operator-logs REPO_NAME=host-operator NAMESPACE=${HOST_NS}
 	$(MAKE) print-operator-logs REPO_NAME=member-operator NAMESPACE=${MEMBER_NS}
+	$(MAKE) print-operator-logs REPO_NAME=registration-service NAMESPACE=${REGISTRATION_SERVICE_NS}
 
 .PHONY: print-operator-logs
 print-operator-logs:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,7 +23,7 @@ import (
 func TestE2EFlow(t *testing.T) {
 	// given
 	murList := &toolchainv1alpha1.MasterUserRecordList{}
-	ctx, awaitility := doubles.InitializeOperators(t, murList)
+	ctx, awaitility := doubles.WaitForDeployments(t, murList)
 	defer ctx.Cleanup()
 
 	extraMur := createMasterUserRecord(awaitility, ctx, "extrajohn")

--- a/test/e2e/kubefed_test.go
+++ b/test/e2e/kubefed_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestKubeFedE2E(t *testing.T) {
 	fedClusterList := &v1beta1.KubeFedClusterList{}
-	ctx, awaitility := doubles.InitializeOperators(t, fedClusterList)
+	ctx, awaitility := doubles.WaitForDeployments(t, fedClusterList)
 	defer ctx.Cleanup()
 
 	verifyKubeFedCluster(ctx, awaitility, cluster.Host, awaitility.Member())

--- a/test/e2e/nstemplateset_test.go
+++ b/test/e2e/nstemplateset_test.go
@@ -29,7 +29,7 @@ func TestNSTemplateSet(t *testing.T) {
 
 func (s *nsTemplateSetTest) SetupSuite() {
 	nsTmplSetList := &toolchainv1alpha1.NSTemplateSetList{}
-	s.testCtx, s.awaitility = doubles.InitializeOperators(s.T(), nsTmplSetList)
+	s.testCtx, s.awaitility = doubles.WaitForDeployments(s.T(), nsTmplSetList)
 	s.memberAwait = s.awaitility.Member()
 	s.namespace = s.awaitility.MemberNs
 	s.basicTier = getBasicTier(s.T(), s.awaitility.Client, s.awaitility.HostNs)

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -13,7 +13,7 @@ import (
 func TestCreateOrUpdateNSTemplateTierAtStartup(t *testing.T) {
 	// given
 	tierList := &toolchainv1alpha1.NSTemplateTierList{}
-	ctx, awaitility := doubles.InitializeOperators(t, tierList)
+	ctx, awaitility := doubles.WaitForDeployments(t, tierList)
 	defer ctx.Cleanup()
 	hostAwait := NewHostAwaitility(awaitility)
 

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -35,7 +35,7 @@ func (s *registrationServiceTestSuite) SetupSuite() {
 	s.route = s.awaitility.RegistrationServiceURL
 }
 
-func (s *registrationServiceTestSuite) TestSmokeTest() {
+func (s *registrationServiceTestSuite) TestLandingPageReachable() {
 	// just make sure that the landing page is reachable
 	req, err := http.NewRequest("GET", s.route, nil)
 	require.NoError(s.T(), err)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/doubles"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestRegistrationService(t *testing.T) {
+	suite.Run(t, &registrationServiceTestSuite{})
+}
+
+type registrationServiceTestSuite struct {
+	suite.Suite
+	namespace  string
+	route      string
+	testCtx    *framework.TestCtx
+	awaitility *wait.Awaitility
+}
+
+func (s *registrationServiceTestSuite) SetupSuite() {
+	userSignupList := &v1alpha1.UserSignupList{}
+	s.testCtx, s.awaitility = doubles.WaitForDeployments(s.T(), userSignupList)
+	s.namespace = s.awaitility.RegistrationServiceNs
+	s.route = s.awaitility.RegistrationServiceURL
+}
+
+func (s *registrationServiceTestSuite) TestSmokeTest() {
+	// just make sure that the landing page is reachable
+	req, err := http.NewRequest("GET", s.route, nil)
+	require.NoError(s.T(), err)
+	client := &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+}

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -33,7 +33,7 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 
 func (s *userSignupIntegrationTest) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.testCtx, s.awaitility = doubles.InitializeOperators(s.T(), userSignupList)
+	s.testCtx, s.awaitility = doubles.WaitForDeployments(s.T(), userSignupList)
 	s.hostAwait = s.awaitility.Host()
 	s.namespace = s.awaitility.HostNs
 }

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -21,24 +21,27 @@ import (
 )
 
 const (
-	OperatorRetryInterval          = time.Second * 5
+	OperatorRetryInterval          = time.Millisecond * 200
 	OperatorTimeout                = time.Second * 60
-	RetryInterval                  = time.Millisecond * 300
+	RetryInterval                  = time.Millisecond * 200
 	Timeout                        = time.Second * 9
 	MemberNsVar                    = "MEMBER_NS"
 	HostNsVar                      = "HOST_NS"
+	RegistrationServiceVar         = "REGISTRATION_SERVICE_NS"
 	KubeFedClusterConditionTimeout = (util.DefaultClusterHealthCheckPeriod + 5) * time.Second
 )
 
 // Awaitility contains information necessary for verifying availability of resources in both operators
 type Awaitility struct {
-	T                *testing.T
-	Client           framework.FrameworkClient
-	ControllerClient client.Client
-	KubeClient       kubernetes.Interface
-	Scheme           *runtime.Scheme
-	MemberNs         string
-	HostNs           string
+	T                      *testing.T
+	Client                 framework.FrameworkClient
+	ControllerClient       client.Client
+	KubeClient             kubernetes.Interface
+	Scheme                 *runtime.Scheme
+	MemberNs               string
+	HostNs                 string
+	RegistrationServiceNs  string
+	RegistrationServiceURL string
 }
 
 // SingleAwaitility contains information necessary for verifying availability of resources in a single operator


### PR DESCRIPTION
waits for the registration service deployment to be ready
and for the route to be available (as part of the setup),
then during the test, just make sure that the homepage is
available (returning a '200 OK' response)

Fixes CRT-322

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>