### PR TITLE
fix: use correct images when triggered from reg-service repo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,8 +45,9 @@ NOTE: This is not required for openshift-ci environment
 ===== OpenShift 4.2+
 
 * Make sure you have set the `QUAY_NAMESPACE` variable: `export QUAY_NAMESPACE=<quay-username>`
-* Log in to the target OpenShift cluster with cluster admin privileges
-* The visibility of both repositories `host-operator` and `member-operator` in quay is set to public (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings)
+* Log in to the quay.io using `docker login quay.io`
+* The visibility of all repositories `host-operator`, `member-operator` and `registration-service` in quay is set to public (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings https://quay.io/repository/<your-username>/registration-service?tab=settings)
+* Log in to the target OpenShift 4.2+ cluster with cluster admin privileges using `oc login`
 
 ==== Running End-to-End Tests
 

--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ NOTE: This is not required for openshift-ci environment
 
 * Make sure you have set the `QUAY_NAMESPACE` variable: `export QUAY_NAMESPACE=<quay-username>`
 * Log in to the quay.io using `docker login quay.io`
-* The visibility of all repositories `host-operator`, `member-operator` and `registration-service` in quay is set to public (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings https://quay.io/repository/<your-username>/registration-service?tab=settings)
+* Make sure that the visibility of all repositories `host-operator`, `member-operator` and `registration-service` in quay is set to `public` (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings https://quay.io/repository/<your-username>/registration-service?tab=settings)
 * Log in to the target OpenShift 4.2+ cluster with cluster admin privileges using `oc login`
 
 ==== Running End-to-End Tests


### PR DESCRIPTION
#### Changes provided in this pr:
* adds info to the README that the user needs to log in to quay.io when using OS 4.2
* removes unnecessary printing
* when the e2e tests are triggered from the `registration-service` repo, then it sets `IS_OTHER_IMAGE_SET` appropriately 
* adds printing info about the image and namespace that is used for the particular repository
* removes `build-and-deploy-service` target
* slightly modifies `build-and-deploy-operator` target so it can be used for `registration-service` too

paired with: https://github.com/codeready-toolchain/registration-service/pull/59