### PR TITLE
Switch to go 1.13 in builder image

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.10.0
+    OPERATOR_SDK_VERSION=v0.11.0
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/toolchain-e2e
 
@@ -18,7 +18,6 @@ RUN yum install epel-release -y \
     && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
     git2u-all \
-    golang \
     make \
     procps-ng \
     tar \
@@ -31,8 +30,19 @@ RUN yum install epel-release -y \
     jq \
     && yum clean all
 
-# download, verify and install openshift client tools (oc and kubectl)
 WORKDIR /tmp
+
+# download, verify and install golang
+ENV PATH=$PATH:/usr/local/go/bin
+RUN curl -Lo go1.13.4.linux-amd64.tar.gz https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz \
+    && echo "692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c go1.13.4.linux-amd64.tar.gz" > go1.13.4.linux-amd64.sha256 \
+    && sha256sum -c go1.13.4.linux-amd64.sha256 \
+    && tar xzf go1.13.4.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.13.4.linux-amd64.tar.gz \
+    && rm -f go1.13.4.linux-amd64.tar.gz \
+    && go version
+
+# download, verify and install openshift client tools (oc and kubectl)
 RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -o openshift-origin-client-tools.tar.gz \
     && echo "4b0f07428ba854174c58d2e38287e5402964c9a9355f6c359d1242efd0990da3 openshift-origin-client-tools.tar.gz" > openshift-origin-client-tools.sha256 \
     && sha256sum -c openshift-origin-client-tools.sha256 \
@@ -45,7 +55,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-key 90D2B445 \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 78086003 \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \


### PR DESCRIPTION
There is checksum mismatch for operator-sdk binary between go 1.12 and go 1.13. To fix this issue we need to switch our builder image to go 1.13.

Required for https://github.com/codeready-toolchain/toolchain-e2e/pull/32