### PR TITLE
add gcc to Dockerfile.tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -28,6 +28,7 @@ RUN yum install epel-release -y \
     yamllint \
     python36-virtualenv \
     jq \
+    gcc \
     && yum clean all
 
 WORKDIR /tmp


### PR DESCRIPTION
add 'gcc' to fix the errors that happened on e2e tests:
```
go: finding sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
go: finding k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab
exec: "gcc": executable file not found in $PATH
FAIL	github.com/codeready-toolchain/toolchain-e2e/test/e2e [build failed]
FAIL
```

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>