### PR TITLE
Add makefile targets to deploy e2e resources without running tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,3 +115,13 @@ ci-operator --config ../../openshift/release/ci-operator/config/codeready-toolch
 assuming that you have the https://github.com/openshift/release[OpenShift Release] repo in `$GOPATH`.
 
 NOTE: you can ignore the RBAC issues that are displayed in the console
+
+== Deploying e2e resources without running tests
+
+All e2e resources (host operator, member operator, registration-service, CRDs, etc) can be deployed without running tests:
+
+* `make dev-deploy-e2e-local` - deploys the same resources as `make test-e2e-local` but doesn't run tests.
+
+* `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.
+
+By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.

--- a/README.adoc
+++ b/README.adoc
@@ -62,6 +62,7 @@ There are multiple Makefile targets that will execute the e2e tests, they just d
 The e2e tests will take care of creating all needed namespaces with random names (or see below for enforcing some specific namespace names).
 It will also create all required CRDs, role and role bindings for the service accounts, build the Docker images for both operators and push them to the OpenShift container registry. Finally, it will deploy the operators and run the tests using the operator-sdk.
 
+
 NOTE: you can override the default namespace names where the end-to-end tests are going to be executed - eg.: `make test-e2e HOST_NS=my-host MEMBER_NS=my-member` file.
 
 ===== What to do
@@ -125,3 +126,7 @@ All e2e resources (host operator, member operator, registration-service, CRDs, e
 * `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.
 
 By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
+
+NOTE: you can override the default namespace names via `make dev-deploy-e2e DEV_HOST_NS=my-host DEV_MEMBER_NS=my-member`
+
+NOTE: if running in Minishift `eval $(minishift docker-env)` `eval $(minishift oc-env)` is required and if running in CodeReady Containers: `eval $(crc oc-env)`

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,6 @@ All e2e resources (host operator, member operator, registration-service, CRDs, e
 
 By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
 
-NOTE: you can override the default namespace names via `make dev-deploy-e2e DEV_HOST_NS=my-host DEV_MEMBER_NS=my-member`
+NOTE: You can override the default namespace names via `make dev-deploy-e2e DEV_HOST_NS=my-host DEV_MEMBER_NS=my-member`
 
 NOTE: If running in Minishift `eval $(minishift docker-env)` and `eval $(minishift oc-env)` are required. If running in CodeReady Containers `eval $(crc oc-env)` is required.

--- a/README.adoc
+++ b/README.adoc
@@ -129,4 +129,4 @@ By default these targets deploy resources to `toolchain-host-operator` and `tool
 
 NOTE: you can override the default namespace names via `make dev-deploy-e2e DEV_HOST_NS=my-host DEV_MEMBER_NS=my-member`
 
-NOTE: if running in Minishift `eval $(minishift docker-env)` `eval $(minishift oc-env)` is required and if running in CodeReady Containers: `eval $(crc oc-env)`
+NOTE: If running in Minishift `eval $(minishift docker-env)` and `eval $(minishift oc-env)` are required. If running in CodeReady Containers `eval $(crc oc-env)` is required.

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -3,7 +3,8 @@ DEV_HOST_NS := toolchain-host-operator
 DEV_REGISTRATION_SERVICE_NS := $(HOST_NS)
 
 .PHONY: dev-deploy-e2e
-dev-deploy-e2e: $(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
+dev-deploy-e2e:
+	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
 	@echo "Deployment complete!"
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
@@ -13,3 +14,18 @@ dev-deploy-e2e-local:
 	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
 	@echo "Deployment complete!"
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
+
+.PHONY: dev-deploy-e2e-member-local
+## Deploy the e2e resources with the local 'member-operator' repository only
+dev-deploy-e2e-member-local:
+	$(MAKE) dev-deploy-e2e MEMBER_REPO_PATH=${PWD}/../member-operator
+
+.PHONY: dev-deploy-e2e-host-local
+## Deploy the e2e resource with the local 'host-operator' repository only
+dev-deploy-e2e-host-local:
+	$(MAKE) dev-deploy-e2e HOST_REPO_PATH=${PWD}/../host-operator
+
+.PHONY: dev-deploy-e2e-registration-local
+## Deploy the e2e resources with the local 'registration-service' repository only
+dev-deploy-e2e-registration-local:
+	$(MAKE) dev-deploy-e2e REG_REPO_PATH=${PWD}/../registration-service

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,0 +1,15 @@
+DEV_MEMBER_NS := toolchain-member-operator
+DEV_HOST_NS := toolchain-host-operator
+DEV_REGISTRATION_SERVICE_NS := $(HOST_NS)
+
+.PHONY: dev-deploy-e2e
+dev-deploy-e2e: $(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
+	@echo "Deployment complete!"
+	@echo "To clean the cluster run 'make clean-e2e-resources'"
+
+.PHONY: dev-deploy-e2e-local
+## Deploy the e2e environment with the local 'host', 'member', and 'registration-service' repositories
+dev-deploy-e2e-local:
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
+	@echo "Deployment complete!"
+	@echo "To clean the cluster run 'make clean-e2e-resources'"


### PR DESCRIPTION
It will be useful when developing operators and/or registration service:

- `make dev-deploy-e2e-local` - deploys the same resources as `make test-e2e-local` but doesn't run tests.
- `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.

Be default instead of using generated NS names it uses `toolchain-host/member-operator` namespaces.

From reg-service/host/member repos these targets can be re-used to deploy everything using just one command.
For example from reg-service repo: `make deploy-e2e` will download everything but the reg-service itself and deploy it to OpenShift cluster - https://github.com/codeready-toolchain/registration-service/pull/70