### PR TITLE
fix: use new instance when getting resources in wait functions

### DIFF
--- a/wait/host.go
+++ b/wait/host.go
@@ -28,6 +28,7 @@ func NewHostAwaitility(a *Awaitility) *HostAwaitility {
 func (a *HostAwaitility) WaitForMasterUserRecord(name string, criteria ...MasterUserRecordWaitCriterion) (*toolchainv1alpha1.MasterUserRecord, error) {
 	mur := &toolchainv1alpha1.MasterUserRecord{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		mur = &toolchainv1alpha1.MasterUserRecord{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, mur); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of MasterUserRecord '%s'", name)
@@ -101,6 +102,7 @@ func UntilUserSignupHasConditions(conditions ...toolchainv1alpha1.Condition) Use
 func (a *HostAwaitility) WaitForUserSignup(name string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
 	userSignup := &toolchainv1alpha1.UserSignup{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		userSignup = &toolchainv1alpha1.UserSignup{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, userSignup); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of UserSignup '%s'", name)
@@ -159,6 +161,7 @@ func containsUserAccountStatus(uaStatuses []toolchainv1alpha1.UserAccountStatusE
 func (a *HostAwaitility) WaitForNSTemplateTier(name string, criteria ...NSTemplateTierWaitCriterion) (*toolchainv1alpha1.NSTemplateTier, error) {
 	tier := &toolchainv1alpha1.NSTemplateTier{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		tier = &toolchainv1alpha1.NSTemplateTier{}
 		a.T.Logf("waiting until NSTemplateTier '%s' is created or updated in namespace '%s'...", name, a.Ns)
 		err = a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, tier)
 		if err != nil && !errors.IsNotFound(err) {

--- a/wait/member.go
+++ b/wait/member.go
@@ -57,6 +57,7 @@ func UntilUserAccountHasConditions(conditions ...toolchainv1alpha1.Condition) Us
 func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccountWaitCriterion) (*toolchainv1alpha1.UserAccount, error) {
 	userAccount := &toolchainv1alpha1.UserAccount{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		userAccount = &toolchainv1alpha1.UserAccount{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, userAccount); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of useraccount '%s'", name)
@@ -95,6 +96,7 @@ func UntilNSTemplateSetHasConditions(conditions ...toolchainv1alpha1.Condition) 
 func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateSetWaitCriterion) (*toolchainv1alpha1.NSTemplateSet, error) {
 	nsTmplSet := &toolchainv1alpha1.NSTemplateSet{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		nsTmplSet = &toolchainv1alpha1.NSTemplateSet{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Ns}, nsTmplSet); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of NSTemplateSet '%s'", name)
@@ -133,6 +135,7 @@ func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(name string) error {
 func (a *MemberAwaitility) WaitForNamespace(username, typeName, revision string) (*v1.Namespace, error) {
 	namespaceList := &v1.NamespaceList{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		namespaceList = &v1.NamespaceList{}
 		labels := map[string]string{"owner": username, "type": typeName, "revision": revision}
 		opts := client.MatchingLabels(labels)
 		if err := a.Client.List(context.TODO(), namespaceList, opts); err != nil {
@@ -177,6 +180,7 @@ func (a *MemberAwaitility) WaitUntilNamespaceDeleted(username, typeName string) 
 func (a *MemberAwaitility) WaitForUser(name string) (*userv1.User, error) {
 	user := &userv1.User{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		user = &userv1.User{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, user); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of user '%s'", name)
@@ -197,6 +201,7 @@ func (a *MemberAwaitility) WaitForUser(name string) (*userv1.User, error) {
 func (a *MemberAwaitility) WaitForIdentity(name string) (*userv1.Identity, error) {
 	identity := &userv1.Identity{}
 	err := wait.Poll(RetryInterval, Timeout, func() (done bool, err error) {
+		identity = &userv1.Identity{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, identity); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of identity '%s'", name)


### PR DESCRIPTION
the wait functions re-used the same instance of the resource for all `Get` calls, which means that when it got it, then it rewrote the existing values in the instance... But when there was a new version of the `Status.Condition` that didn't contain `Message`, but the previous one did contain, then there was nothing that would be used for rewriting the old message, so it kept the old one.

The flow looked like:
at one time the wait function got :
```
Status:{Conditions:[{Type:Ready Status:False LastTransitionTime:2019-11-12 14:08:49 +0100 CET Reason:UnableToProvisionNamespace Message:Operation cannot be fulfilled on namespaces "extrajohn-3-stage": the object has been modified; please apply your changes to the latest version and try again}]}
```
Then the status was updated to
```
Status:{Conditions:[{Type:Ready Status:True LastTransitionTime:2019-11-12 13:08:51 +0000 UTC Reason:Provisioned Message:}]}
```
which is what the wait function got, but it rewrote the original instance where the message was set, so the result was:
```
Status:{Conditions:[{Type:Ready Status:True LastTransitionTime:2019-11-12 14:08:51 +0100 CET Reason:Provisioned Message:Operation cannot be fulfilled on namespaces "extrajohn-3-stage": the object has been modified; please apply your changes to the latest version and try again}]}
```