### PR TITLE
Properly pass variables when running dev-deploy targets

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -4,34 +4,18 @@ DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 
 .PHONY: dev-deploy-e2e
-## Deploy the e2e resources to dev environment with the operators and reg-service from master
-dev-deploy-e2e: MEMBER_NS=${DEV_MEMBER_NS}
-dev-deploy-e2e: HOST_NS=${DEV_HOST_NS}
-dev-deploy-e2e: REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS}
-dev-deploy-e2e: ENVIRONMENT=${DEV_ENVIRONMENT}
-dev-deploy-e2e: deploy-e2e print-reg-service-link
+dev-deploy-e2e: deploy-e2e-to-dev-namespaces print-reg-service-link
+
+.PHONY: deploy-e2e-to-dev-namespaces
+deploy-e2e-to-dev-namespaces:
+	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT}
 
 .PHONY: dev-deploy-e2e-local
-## Deploy the e2e resources to dev environment with the local operators and reg-service
-dev-deploy-e2e-local: MEMBER_REPO_PATH=${PWD}/../member-operator
-dev-deploy-e2e-local: HOST_REPO_PATH=${PWD}/../host-operator
-dev-deploy-e2e-local: REG_REPO_PATH=${PWD}/../registration-service
-dev-deploy-e2e-local: dev-deploy-e2e
+dev-deploy-e2e-local: deploy-e2e-local-to-dev-namespaces print-reg-service-link
 
-.PHONY: dev-deploy-e2e-member-local
-## Deploy the e2e resources to dev environment with the local 'member-operator' repository only
-dev-deploy-e2e-member-local: MEMBER_REPO_PATH=${PWD}/../member-operator
-dev-deploy-e2e-member-local: dev-deploy-e2e
-
-.PHONY: dev-deploy-e2e-host-local
-## Deploy the e2e resource to dev environment with the local 'host-operator' repository only
-dev-deploy-e2e-host-local: HOST_REPO_PATH=${PWD}/../host-operator
-dev-deploy-e2e-host-local: dev-deploy-e2e
-
-.PHONY: dev-deploy-e2e-registration-local
-## Deploy the e2e resources to dev environment with the local 'registration-service' repository only
-dev-deploy-e2e-registration-local: REG_REPO_PATH=${PWD}/../registration-service
-dev-deploy-e2e-registration-local: dev-deploy-e2e
+.PHONY: deploy-e2e-local-to-dev-namespaces
+deploy-e2e-local-to-dev-namespaces:
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT}
 
 .PHONY: print-reg-service-link
 print-reg-service-link:
@@ -41,3 +25,18 @@ print-reg-service-link:
 	@echo Access the Landing Page here: https://${ROUTE}
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 	@echo ""
+
+.PHONY: dev-deploy-e2e-member-local
+## Deploy the e2e resources with the local 'member-operator' repository only
+dev-deploy-e2e-member-local:
+	$(MAKE) dev-deploy-e2e MEMBER_REPO_PATH=${PWD}/../member-operator ENVIRONMENT=${DEV_ENVIRONMENT}
+
+.PHONY: dev-deploy-e2e-host-local
+## Deploy the e2e resource with the local 'host-operator' repository only
+dev-deploy-e2e-host-local:
+	$(MAKE) dev-deploy-e2e HOST_REPO_PATH=${PWD}/../host-operator ENVIRONMENT=${DEV_ENVIRONMENT}
+
+.PHONY: dev-deploy-e2e-registration-local
+## Deploy the e2e resources with the local 'registration-service' repository only
+dev-deploy-e2e-registration-local:
+	$(MAKE) dev-deploy-e2e REG_REPO_PATH=${PWD}/../registration-service ENVIRONMENT=${DEV_ENVIRONMENT}

--- a/make/test.mk
+++ b/make/test.mk
@@ -115,12 +115,8 @@ build-with-operators: build get-member-operator-repo get-host-operator-repo get-
 
 .PHONY: get-member-operator-repo
 get-member-operator-repo:
-	echo "1 MEMBER_REPO_PATH=$(MEMBER_REPO_PATH)"
-	echo "2 MEMBER_REPO_PATH=${MEMBER_REPO_PATH}"
 ifeq ($(MEMBER_REPO_PATH),)
 	$(eval MEMBER_REPO_PATH = /tmp/codeready-toolchain/member-operator)
-	echo "3 MEMBER_REPO_PATH=$(MEMBER_REPO_PATH)"
-	echo "4 MEMBER_REPO_PATH=${MEMBER_REPO_PATH}"
 	rm -rf ${MEMBER_REPO_PATH}
 	# clone
 	git clone https://github.com/codeready-toolchain/member-operator.git ${MEMBER_REPO_PATH}

--- a/make/test.mk
+++ b/make/test.mk
@@ -115,8 +115,12 @@ build-with-operators: build get-member-operator-repo get-host-operator-repo get-
 
 .PHONY: get-member-operator-repo
 get-member-operator-repo:
+	echo "1 MEMBER_REPO_PATH=$(MEMBER_REPO_PATH)"
+	echo "2 MEMBER_REPO_PATH=${MEMBER_REPO_PATH}"
 ifeq ($(MEMBER_REPO_PATH),)
 	$(eval MEMBER_REPO_PATH = /tmp/codeready-toolchain/member-operator)
+	echo "3 MEMBER_REPO_PATH=$(MEMBER_REPO_PATH)"
+	echo "4 MEMBER_REPO_PATH=${MEMBER_REPO_PATH}"
 	rm -rf ${MEMBER_REPO_PATH}
 	# clone
 	git clone https://github.com/codeready-toolchain/member-operator.git ${MEMBER_REPO_PATH}


### PR DESCRIPTION
Because of specifics of how makefile handles conditions (it evaluates them when it reads a makefile, not during execution) we can't use what was suggested in https://github.com/codeready-toolchain/toolchain-e2e/pull/44#discussion_r345638185

We have to use `$(MAKE) <some-target> VAR=${value}` constructions instead.

As side affect of this issue currently `make dev-deploy-e2-local` target deletes the local host/member/reg-service repos and re-clones them from github!