### PR TITLE
Allow individual tests override wait timeouts and retry intervals 

### DIFF
--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -64,7 +65,7 @@ func (s *userSignupIntegrationTest) TestUserSignupCreated() {
 	require.NoError(s.T(), err)
 
 	// Confirm that a MasterUserRecord wasn't created
-	_, err = s.hostAwait.WaitForMasterUserRecord("foo-somewhere-com")
+	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord("foo-somewhere-com")
 	require.Error(s.T(), err)
 
 	// Delete the User Signup
@@ -422,11 +423,11 @@ func (s *userSignupIntegrationTest) TestDeletedUserSignupIsGarbageCollected() {
 	require.NoError(s.T(), err)
 
 	// Confirm the UserSignup was deleted
-	_, err = s.hostAwait.WaitForUserSignup(userSignup.Name)
+	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForUserSignup(userSignup.Name)
 	require.Error(s.T(), err)
 
 	// Confirm the MasterUserRecord was deleted
-	_, err = s.hostAwait.WaitForMasterUserRecord(userSignup.Name)
+	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(userSignup.Name)
 	require.Error(s.T(), err)
 }
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -67,10 +67,6 @@ func (s *userSignupIntegrationTest) TestUserSignupCreated() {
 	// Confirm that a MasterUserRecord wasn't created
 	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord("foo-somewhere-com")
 	require.Error(s.T(), err)
-
-	// Delete the User Signup
-	err = s.awaitility.Client.Delete(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
 }
 
 func (s *userSignupIntegrationTest) TestUserSignupWithNoApprovalConfig() {
@@ -390,45 +386,6 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 
 	// Confirm the target cluster was set
 	require.NotEmpty(s.T(), mur.Spec.UserAccounts[0].TargetCluster)
-}
-
-func (s *userSignupIntegrationTest) TestDeletedUserSignupIsGarbageCollected() {
-	// Set the user approval policy to automatic
-	s.setApprovalPolicyConfig("automatic")
-
-	// Create user signup - no approval set
-	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
-
-	userSignup, err := newUserSignup(s.awaitility.Host(), uuid.NewV4().String(), "oliver@bravo.com")
-	require.NoError(s.T(), err)
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.testCtx))
-
-	require.NoError(s.T(), err)
-	s.T().Logf("user signup '%s' created", userSignup.Name)
-
-	// Confirm the UserSignup was created
-	_, err = s.hostAwait.WaitForUserSignup(userSignup.Name)
-	require.NoError(s.T(), err)
-
-	// Get the newly created UserSignup resource
-	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name)
-	require.NoError(s.T(), err)
-
-	// Confirm the MasterUserRecord was created
-	_, err = s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
-	require.NoError(s.T(), err)
-
-	// Delete the UserSignup
-	err = s.awaitility.Client.Delete(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
-
-	// Confirm the UserSignup was deleted
-	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForUserSignup(userSignup.Name)
-	require.Error(s.T(), err)
-
-	// Confirm the MasterUserRecord was deleted
-	_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(userSignup.Name)
-	require.Error(s.T(), err)
 }
 
 func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalNoApprovalSet() {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -46,18 +46,18 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.TestCtx, *
 	f := framework.Global
 
 	// wait for host operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, hostNs, "host-operator", 1, wait.OperatorRetryInterval, wait.OperatorTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, hostNs, "host-operator", 1, wait.DefaultOperatorRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for host operator deployment")
 
 	// wait for member operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, memberNs, "member-operator", 1, wait.OperatorRetryInterval, wait.OperatorTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, memberNs, "member-operator", 1, wait.DefaultOperatorRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for member operator deployment")
 
 	// wait for registration service to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 3, wait.RetryInterval, wait.OperatorTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 3, wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for registration service deployment")
 
-	registrationServiceRoute, err := waitForRoute(t, f, registrationServiceNs, "registration-service", wait.RetryInterval, wait.OperatorTimeout)
+	registrationServiceRoute, err := waitForRoute(t, f, registrationServiceNs, "registration-service", wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for registration service deployment")
 
 	registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -33,8 +33,6 @@ const (
 	KubeFedClusterConditionTimeout = 10*defaults.DefaultClusterHealthCheckPeriod + 5*time.Second
 )
 
-type OperatorRetryIntervalOption time.Duration
-type OperatorTimeoutOption time.Duration
 type RetryIntervalOption time.Duration
 type TimeoutOption time.Duration
 
@@ -60,26 +58,22 @@ type SingleAwaitility interface {
 }
 
 type SingleAwaitilityImpl struct {
-	T                     *testing.T
-	Client                framework.FrameworkClient
-	Ns                    string
-	OtherOperatorNs       string
-	OperatorRetryInterval time.Duration
-	OperatorTimeout       time.Duration
-	RetryInterval         time.Duration
-	Timeout               time.Duration
+	T               *testing.T
+	Client          framework.FrameworkClient
+	Ns              string
+	OtherOperatorNs string
+	RetryInterval   time.Duration
+	Timeout         time.Duration
 }
 
 func NewSingleAwaitility(t *testing.T, client framework.FrameworkClient, operatorNS, otherOperatorNS string) *SingleAwaitilityImpl {
 	return &SingleAwaitilityImpl{
-		T:                     t,
-		Client:                client,
-		Ns:                    operatorNS,
-		OtherOperatorNs:       otherOperatorNS,
-		OperatorRetryInterval: DefaultOperatorRetryInterval,
-		OperatorTimeout:       DefaultOperatorTimeout,
-		RetryInterval:         DefaultRetryInterval,
-		Timeout:               DefaultTimeout,
+		T:               t,
+		Client:          client,
+		Ns:              operatorNS,
+		OtherOperatorNs: otherOperatorNS,
+		RetryInterval:   DefaultRetryInterval,
+		Timeout:         DefaultTimeout,
 	}
 }
 
@@ -114,10 +108,6 @@ func (a *SingleAwaitilityImpl) WithRetryOptions(options ...interface{}) *SingleA
 	newAwait := NewSingleAwaitility(a.T, a.Client, a.Ns, a.OtherOperatorNs)
 	for _, option := range options {
 		switch v := option.(type) {
-		case OperatorRetryIntervalOption:
-			newAwait.OperatorRetryInterval = time.Duration(v)
-		case OperatorTimeoutOption:
-			newAwait.OperatorTimeout = time.Duration(v)
 		case RetryIntervalOption:
 			newAwait.RetryInterval = time.Duration(v)
 		case TimeoutOption:

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,15 +23,20 @@ import (
 )
 
 const (
-	OperatorRetryInterval          = time.Millisecond * 500
-	OperatorTimeout                = time.Second * 120
-	RetryInterval                  = time.Millisecond * 500
-	Timeout                        = time.Second * 120
+	DefaultOperatorRetryInterval   = time.Millisecond * 500
+	DefaultOperatorTimeout         = time.Second * 120
+	DefaultRetryInterval           = time.Millisecond * 500
+	DefaultTimeout                 = time.Second * 120
 	MemberNsVar                    = "MEMBER_NS"
 	HostNsVar                      = "HOST_NS"
 	RegistrationServiceVar         = "REGISTRATION_SERVICE_NS"
 	KubeFedClusterConditionTimeout = 10*defaults.DefaultClusterHealthCheckPeriod + 5*time.Second
 )
+
+type OperatorRetryIntervalOption time.Duration
+type OperatorTimeoutOption time.Duration
+type RetryIntervalOption time.Duration
+type TimeoutOption time.Duration
 
 // Awaitility contains information necessary for verifying availability of resources in both operators
 type Awaitility struct {
@@ -54,10 +60,27 @@ type SingleAwaitility interface {
 }
 
 type SingleAwaitilityImpl struct {
-	T               *testing.T
-	Client          framework.FrameworkClient
-	Ns              string
-	OtherOperatorNs string
+	T                     *testing.T
+	Client                framework.FrameworkClient
+	Ns                    string
+	OtherOperatorNs       string
+	OperatorRetryInterval time.Duration
+	OperatorTimeout       time.Duration
+	RetryInterval         time.Duration
+	Timeout               time.Duration
+}
+
+func NewSingleAwaitility(t *testing.T, client framework.FrameworkClient, operatorNS, otherOperatorNS string) *SingleAwaitilityImpl {
+	return &SingleAwaitilityImpl{
+		T:                     t,
+		Client:                client,
+		Ns:                    operatorNS,
+		OtherOperatorNs:       otherOperatorNS,
+		OperatorRetryInterval: DefaultOperatorRetryInterval,
+		OperatorTimeout:       DefaultOperatorTimeout,
+		RetryInterval:         DefaultRetryInterval,
+		Timeout:               DefaultTimeout,
+	}
 }
 
 // Member creates SingleAwaitility for the member operator
@@ -87,15 +110,34 @@ func (a *Awaitility) WaitForReadyKubeFedClusters() error {
 	return nil
 }
 
+func (a *SingleAwaitilityImpl) WithRetryOptions(options ...interface{}) *SingleAwaitilityImpl {
+	newAwait := NewSingleAwaitility(a.T, a.Client, a.Ns, a.OtherOperatorNs)
+	for _, option := range options {
+		switch v := option.(type) {
+		case OperatorRetryIntervalOption:
+			newAwait.OperatorRetryInterval = time.Duration(v)
+		case OperatorTimeoutOption:
+			newAwait.OperatorTimeout = time.Duration(v)
+		case RetryIntervalOption:
+			newAwait.RetryInterval = time.Duration(v)
+		case TimeoutOption:
+			newAwait.Timeout = time.Duration(v)
+		default:
+			assert.Fail(a.T, "unsupported retry option type", "actual type: %T", v)
+		}
+	}
+	return newAwait
+}
+
 // WaitForKubeFedCluster waits until there is a KubeFedCluster representing a operator of the given type
 // and running in the given expected namespace. If the given condition is not nil, then it also checks
 // if the CR has the ClusterCondition
 func (a *SingleAwaitilityImpl) WaitForKubeFedCluster(clusterType cluster.Type, condition *v1beta1.ClusterCondition) error {
-	timeout := Timeout
+	timeout := a.Timeout
 	if condition != nil {
 		timeout = KubeFedClusterConditionTimeout
 	}
-	return wait.Poll(RetryInterval, timeout, func() (done bool, err error) {
+	return wait.Poll(a.RetryInterval, timeout, func() (done bool, err error) {
 		_, ok, err := a.GetKubeFedCluster(clusterType, condition)
 		if ok {
 			return true, nil
@@ -108,11 +150,11 @@ func (a *SingleAwaitilityImpl) WaitForKubeFedCluster(clusterType cluster.Type, c
 // WaitForKubeFedClusterConditionWithName waits until there is a KubeFedCluster with the given name
 // and with the given ClusterCondition (if it the condition is nil, then it skips this check)
 func (a *SingleAwaitilityImpl) WaitForKubeFedClusterConditionWithName(name string, condition *v1beta1.ClusterCondition) error {
-	timeout := Timeout
+	timeout := a.Timeout
 	if condition != nil {
 		timeout = KubeFedClusterConditionTimeout
 	}
-	return wait.Poll(RetryInterval, timeout, func() (done bool, err error) {
+	return wait.Poll(a.RetryInterval, timeout, func() (done bool, err error) {
 		cluster := &v1beta1.KubeFedCluster{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, cluster); err != nil {
 			return false, err


### PR DESCRIPTION
For example if we need to override the default timeout:
```
s.hostAwait.WithRetryOptions(TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(...)
```

It's useful in test which wait for some resource not to be created and we don't want to wait for the entire default 120 seconds in such tests.