### PR TITLE
makefile goal to display the latest e2e project names

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -208,7 +208,7 @@ ifeq ($(HOST_REPO_PATH),)
 endif
 	@echo "Deploying host operator to $(HOST_NS)..."
 	-oc new-project $(HOST_NS) 1>/dev/null
-	-oc label ns $(MEMBER_NS) app=host-operator
+	-oc label ns $(HOST_NS) app=host-operator
 	-oc project $(HOST_NS)
 ifneq ($(IS_OS_3),)
 	# is using OS 3, so we need to deploy the manifests manually

--- a/make/test.mk
+++ b/make/test.mk
@@ -310,8 +310,8 @@ endif
 
 .PHONY: display-eval
 display-eval:
-	@echo 'export HOST_NS=$(shell oc get projects -l app=host-operator --output=name --no-headers=true -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tail -n 1)'
-	@echo 'export MEMBER_NS=$(shell oc get projects -l app=member-operator --output=name --no-headers=true -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tail -n 1)'
+	@echo 'export HOST_NS=$(shell oc get projects -l app=host-operator --output=name -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tail -n 1)'
+	@echo 'export MEMBER_NS=$(shell oc get projects -l app=member-operator --output=name -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tail -n 1)'
 	@echo 'export REGISTRATION_SERVICE_NS=$$HOST_NS'
 	@echo '# Run this command to configure your shell:'
 	@echo '# eval $$(make display-eval)'


### PR DESCRIPTION
The goal of `display-eval` is to provide a convenient way to retrieve the latest host and member operator namespaces on a cluster, and optionally, to export them as env vars:
```
$ make display-eval
export HOST_NS=host-operator-1574156115
export MEMBER_NS=member-operator-1574156115
export REGISTRATION_SERVICE_NS=$HOST_NS
# Run this command to configure your shell:
# eval $(make display-eval)
```

The `host-operator-xxx` and `member-operator-xxx` projects are now labelled with `app=host-operator` and `app=member-operator` respectively the latest occurrence is retained. 
By querying the cluster, we can use this goal alone, without interfering with the `HOST_NS` and `MEMBER_NS` variables set in the `test.mk` file.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>