### PR TITLE
WIP adding usersignup email

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/codeready-toolchain/toolchain-e2e
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c
+	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/spec v0.19.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,12 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
+github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c h1:0ifmV7vF71GSlT3AribGdMKX91Zo5iTFGDrJt3iXTt8=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7 h1:F8dyoI19Xp+eScSlmUYy2aLCe0dh2DTwk0FaAqFWpqE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
 github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c h1:0ifmV7vF71GSlT3AribGdMKX91Zo5iTFGDrJt3iXTt8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7 h1:F8dyoI19Xp+eScSlmUYy2aLCe0dh2DTwk0FaAqFWpqE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -235,7 +235,7 @@ func createMultipleSignups(t *testing.T, ctx *framework.TestCtx, awaitility *wai
 	signups := make([]toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
 		// Create an approved UserSignup resource
-		userSignup := newUserSignup(t, awaitility.Host(), fmt.Sprintf("multiple-signup-testuser-%d", i))
+		userSignup := newUserSignup(t, awaitility.Host(), fmt.Sprintf("multiple-signup-testuser-%d", i), fmt.Sprintf("multiple-signup-testuser-%d@test.com", i))
 		userSignup.Spec.Approved = true
 		err := awaitility.Host().Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(ctx))
 		awaitility.T.Logf("created UserSignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -329,7 +329,8 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	// Get valid generated token for e2e tests. IAT claim is overriden
 	// to avoid token used before issued error.
 	identity0 := authsupport.NewIdentity()
-	emailClaim0 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	emailValue := uuid.NewV4().String() + "@email.tld"
+	emailClaim0 := authsupport.WithEmailClaim(emailValue)
 	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0)
 	require.NoError(s.T(), err)
 
@@ -368,6 +369,8 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	// Wait for the UserSignup to be created
 	userSignup, err := s.awaitility.Host().WaitForUserSignup(identity0.ID.String(), wait.UntilUserSignupHasConditions(pendingApproval()...))
 	require.NoError(s.T(), err)
+	emailAnnotation := userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
+	assert.Equal(s.T(), emailValue, emailAnnotation)
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
 	req, err = http.NewRequest("GET", s.route+"/api/v1/signup", nil)

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -218,7 +218,7 @@ func newUserSignup(t *testing.T, host *wait.HostAwaitility, username string, ema
 		ObjectMeta: v1.ObjectMeta{
 			Name:      uuid.NewV4().String(),
 			Namespace: host.Ns,
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				v1alpha1.UserSignupUserEmailAnnotationKey: email,
 			},
 		},

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -219,8 +219,8 @@ func newUserSignup(t *testing.T, host *wait.HostAwaitility, username string, ema
 			Name:      uuid.NewV4().String(),
 			Namespace: host.Ns,
 			Annotations: map[string]string{
-                "toolchain.dev.openshift.com/user-email": email,
-            },
+				"toolchain.dev.openshift.com/user-email": email,
+			},
 		},
 		Spec: v1alpha1.UserSignupSpec{
 			Username:      username,

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -110,7 +110,7 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 	require.Equal(s.T(), "paul-at-hotel-com-1", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the same original username but different user ID
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com","paul@hotel.com", approvedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", approvedByAdmin()...)
 	require.Equal(s.T(), "paul-at-hotel-com-2", userSignup.Status.CompliantUsername)
 }
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -219,7 +219,7 @@ func newUserSignup(t *testing.T, host *wait.HostAwaitility, username string, ema
 			Name:      uuid.NewV4().String(),
 			Namespace: host.Ns,
 			Annotations: map[string]string{
-				"toolchain.dev.openshift.com/user-email": email,
+				v1alpha1.UserSignupUserEmailLabelKey: email,
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -218,8 +218,8 @@ func newUserSignup(t *testing.T, host *wait.HostAwaitility, username string, ema
 		ObjectMeta: v1.ObjectMeta{
 			Name:      uuid.NewV4().String(),
 			Namespace: host.Ns,
-			Annotations: map[string]string{
-				v1alpha1.UserSignupUserEmailLabelKey: email,
+			Labels: map[string]string{
+				v1alpha1.UserSignupUserEmailAnnotationKey: email,
 			},
 		},
 		Spec: v1alpha1.UserSignupSpec{


### PR DESCRIPTION
As an admin, I want to see the user email when approving an account. This makes my work easier as I can see where the user is coming from (e.g. redhat.com).

Relates to:
jira - https://jira.coreos.com/browse/CRT-374
api - codeready-toolchain/api#69
host - https://github.com/codeready-toolchain/host-operator/pull/115
reg - https://github.com/codeready-toolchain/registration-service/pull/78

**NOTE:** still need to add an e2e test for email