### PR TITLE
feat(CRT-354): let host-operator deploy the registration service

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -20,7 +20,18 @@ deploy-e2e-local-to-dev-namespaces:
 .PHONY: print-reg-service-link
 print-reg-service-link:
 	@echo ""
-	@echo "Deployment complete!"
+	@echo "Deployment complete! Waiting for the registration-service route being available"
+	@echo -n "."
+	@while [[ -z `oc get routes registration-service -n ${DEV_REGISTRATION_SERVICE_NS} 2>/dev/null` ]]; do \
+		if [[ $${NEXT_WAIT_TIME} -eq 100 ]]; then \
+            echo ""; \
+            echo "The timeout of waiting for the registration-service route has been reached. Try to run 'make  print-reg-service-link' later or check the deployment logs"; \
+            exit 1; \
+		fi; \
+		echo -n "."; \
+		sleep 1; \
+	done
+	@echo ""
 	$(eval ROUTE = $(shell oc get routes registration-service -n ${DEV_REGISTRATION_SERVICE_NS} -o=jsonpath='{.spec.host}'))
 	@echo Access the Landing Page here: https://${ROUTE}
 	@echo "To clean the cluster run 'make clean-e2e-resources'"

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -53,7 +53,7 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.TestCtx, *
 	require.NoError(t, err, "failed while waiting for member operator deployment")
 
 	// wait for registration service to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 3, wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 1, wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for registration service deployment")
 
 	registrationServiceRoute, err := waitForRoute(t, f, registrationServiceNs, "registration-service", wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -53,7 +53,7 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.TestCtx, *
 	require.NoError(t, err, "failed while waiting for member operator deployment")
 
 	// wait for registration service to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 1, wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, registrationServiceNs, "registration-service", 2, wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)
 	require.NoError(t, err, "failed while waiting for registration service deployment")
 
 	registrationServiceRoute, err := waitForRoute(t, f, registrationServiceNs, "registration-service", wait.DefaultRetryInterval, wait.DefaultOperatorTimeout)


### PR DESCRIPTION
based on the changes proposed in this PR https://github.com/codeready-toolchain/host-operator/pull/117 it changes the way the registration-service is being deployed. As the deployment is moved to host-operator, the e2e setup only builds the image and sets the appropriate host deployment params