### PR TITLE
fix: fail if multiple branches are found

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -18,8 +18,6 @@ IS_OS_3 := $(shell curl -k -XGET -H "Authorization: Bearer $(shell oc whoami -t 
 
 ENVIRONMENT := e2e-tests
 
-WAS_ALREADY_PAIRED_FILE := /tmp/${GO_PACKAGE_ORG_NAME}_${GO_PACKAGE_REPO_NAME}_already_paired
-
 .PHONY: deploy-ops
 deploy-ops: deploy-member deploy-host
 
@@ -113,11 +111,7 @@ clean-e2e-resources:
 ###########################################################
 
 .PHONY: build-with-operators
-build-with-operators: build clean-before-e2e get-member-operator-repo get-host-operator-repo get-registration-service-repo
-
-.PHONY: clean-before-e2e
-clean-before-e2e:
-	rm -f ${WAS_ALREADY_PAIRED_FILE} 2>/dev/null || echo true
+build-with-operators: build get-member-operator-repo get-host-operator-repo get-registration-service-repo
 
 .PHONY: get-member-operator-repo
 get-member-operator-repo:
@@ -174,23 +168,12 @@ ifneq ($(CLONEREFS_OPTIONS),)
 		echo "branch ref of the user's fork: \"$${REMOTE_E2E_BRANCH}\" - if empty then not found"; \
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master \
 		if [[ -n "$${REMOTE_E2E_BRANCH}" ]]; then \
-			if [[ -f ${WAS_ALREADY_PAIRED_FILE} ]]; then \
-                echo "####################################  ERROR WHILE TRYING TO PAIR PRs  ####################################"; \
-				echo "There was an error while trying to pair this e2e PR with ${REPO_URL}@$${BRANCH_REF}"; \
-				echo "The reason is that there was alraedy detected a branch from another repo this PR could be paired with - see:"; \
-				echo ${WAS_ALREADY_PAIRED_FILE}; \
-				echo "It's not possible to pair a PR with multiple branches from other repositories."; \
-				echo "Please delete one of the braches from your fork and rerun the e2e tests"; \
-				echo "##########################################################################################################"; \
-				exit 1; \
-            fi; \
 			if [[ -n "$(OPENSHIFT_BUILD_NAMESPACE)" ]]; then \
 				git config --global user.email "devtools@redhat.com"; \
 				git config --global user.name "Devtools"; \
 			fi; \
 			# retrieve the branch name \
 			BRANCH_NAME=`echo $${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
-			echo "repository: ${AUTHOR_LINK}/${REPO_NAME} \nbranch: $${BRANCH_NAME}" > ${WAS_ALREADY_PAIRED_FILE}; \
 			# add the user's fork as remote repo \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} remote add external ${AUTHOR_LINK}/${REPO_NAME}.git; \
 			# fetch the branch; \

--- a/make/test.mk
+++ b/make/test.mk
@@ -18,6 +18,8 @@ IS_OS_3 := $(shell curl -k -XGET -H "Authorization: Bearer $(shell oc whoami -t 
 
 ENVIRONMENT := e2e-tests
 
+WAS_ALREADY_PAIRED_FILE := /tmp/${GO_PACKAGE_ORG_NAME}_${GO_PACKAGE_REPO_NAME}_already_paired
+
 .PHONY: deploy-ops
 deploy-ops: deploy-member deploy-host
 
@@ -111,7 +113,11 @@ clean-e2e-resources:
 ###########################################################
 
 .PHONY: build-with-operators
-build-with-operators: build get-member-operator-repo get-host-operator-repo get-registration-service-repo
+build-with-operators: build clean-before-e2e get-member-operator-repo get-host-operator-repo get-registration-service-repo
+
+.PHONY: clean-before-e2e
+clean-before-e2e:
+	rm -f ${WAS_ALREADY_PAIRED_FILE} 2>/dev/null || echo true
 
 .PHONY: get-member-operator-repo
 get-member-operator-repo:
@@ -149,24 +155,46 @@ ifneq ($(CLONEREFS_OPTIONS),)
 	@echo "using author link ${AUTHOR_LINK}"
 	@echo "using pull sha ${PULL_SHA}"
 	# get branch ref of the fork the PR was created from
-	$(eval BRANCH_REF := $(shell curl ${AUTHOR_LINK}/toolchain-e2e.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a ${PULL_SHA} | awk '{print $$2}'))
-	@echo "detected branch ref ${BRANCH_REF}"
-	if [[ -n "${BRANCH_REF}" ]]; then \
+	$(eval REPO_URL := ${AUTHOR_LINK}/toolchain-e2e)
+	$(eval GET_BRANCH_NAME := curl ${REPO_URL}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a ${PULL_SHA})
+	if [[ `${GET_BRANCH_NAME} | wc -l` > 1 ]]; then \
+		echo "###################################  ERROR DURING THE E2E TEST SETUP  ###################################"; \
+		echo "There were found more branches with the same latest commit '${PULL_SHA}' in the repo ${REPO_URL} - see:"; \
+		echo "`${GET_BRANCH_NAME}`"; \
+		echo "It's not possible to detect the correct branch this PR is made for."; \
+		echo "Please delete the unreleated brach from your fork and rerun the e2e tests"; \
+		echo "##########################################################################################################"; \
+		exit 1; \
+	fi; \
+	BRANCH_REF=`${GET_BRANCH_NAME} | awk '{print $$2}')`; \
+	echo "detected branch ref $${BRANCH_REF}"; \
+	if [[ -n "$${BRANCH_REF}" ]]; then \
 		# check if a branch with the same ref exists in the user's fork of ${REPO_NAME} repo \
-		REMOTE_E2E_BRANCH=`curl ${AUTHOR_LINK}/${REPO_NAME}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$$" | awk '{print $$2}'`; \
+		REMOTE_E2E_BRANCH=`curl ${AUTHOR_LINK}/${REPO_NAME}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "$${BRANCH_REF}$$" | awk '{print $$2}'`; \
 		echo "branch ref of the user's fork: \"$${REMOTE_E2E_BRANCH}\" - if empty then not found"; \
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master \
 		if [[ -n "$${REMOTE_E2E_BRANCH}" ]]; then \
+			if [[ -f ${WAS_ALREADY_PAIRED_FILE} ]]; then \
+                echo "####################################  ERROR WHILE TRYING TO PAIR PRs  ####################################"; \
+				echo "There was an error while trying to pair this e2e PR with ${REPO_URL}@$${BRANCH_REF}"; \
+				echo "The reason is that there was alraedy detected a branch from another repo this PR could be paired with - see:"; \
+				echo ${WAS_ALREADY_PAIRED_FILE}; \
+				echo "It's not possible to pair a PR with multiple branches from other repositories."; \
+				echo "Please delete one of the braches from your fork and rerun the e2e tests"; \
+				echo "##########################################################################################################"; \
+				exit 1; \
+            fi; \
 			if [[ -n "$(OPENSHIFT_BUILD_NAMESPACE)" ]]; then \
 				git config --global user.email "devtools@redhat.com"; \
 				git config --global user.name "Devtools"; \
 			fi; \
 			# retrieve the branch name \
-			BRANCH_NAME=`echo ${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
+			BRANCH_NAME=`echo $${BRANCH_REF} | awk -F'/' '{print $$3}'`; \
+			echo "repository: ${AUTHOR_LINK}/${REPO_NAME} \nbranch: $${BRANCH_NAME}" > ${WAS_ALREADY_PAIRED_FILE}; \
 			# add the user's fork as remote repo \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} remote add external ${AUTHOR_LINK}/${REPO_NAME}.git; \
 			# fetch the branch; \
-			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external ${BRANCH_REF}; \
+			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} fetch external $${BRANCH_REF}; \
 			# merge the branch with master \
 			git --git-dir=${E2E_REPO_PATH}/.git --work-tree=${E2E_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD; \
 		fi; \


### PR DESCRIPTION
adds a check that detects if there are multiple branches found while getting the branch name the PR is created for. If multiple branches are found, then it fails with:
```
###################################  ERROR DURING THE E2E TEST SETUP  ###################################
There were found more branches with the same latest commit 'd98a6058bef952cc2e88156f2d3105c9662a6964' in the repo https://github.com/MatousJobanek/toolchain-e2e - see:
0047d98a6058bef952cc2e88156f2d3105c9662a6964 refs/heads/another-branch
0053d98a6058bef952cc2e88156f2d3105c9662a6964 refs/heads/fail-for-multiple-branches
It's not possible to detect the correct branch this PR is made for.
Please delete the unreleated brach from your fork and rerun the e2e tests
##########################################################################################################
```

see https://storage.googleapis.com/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/60/pull-ci-codeready-toolchain-toolchain-e2e-master-images/313/build-log.txt  