### PR TITLE
feat(CRT-363): load config env files using enrich-by-envs-from-yaml.sh script

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -338,7 +338,9 @@ else
 			sleep 1; \
 		done
     else
-		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ${E2E_REPO_PATH}/deploy/operator.yaml | oc apply -f -
+		echo "before curl ${REPO_NAME}"
+		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/deploy/operator.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml
+		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml | oc apply -f -
     endif
 endif
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -62,9 +62,8 @@ e2e-run:
 	oc get kubefedcluster -n $(HOST_NS)
 	oc get kubefedcluster -n $(MEMBER_NS)
 	-oc new-project $(TEST_NS) --display-name e2e-tests 1>/dev/null
-	$(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1
-#	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=30m" || \
-#	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
+	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=30m" || \
+	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs
 print-logs:
@@ -315,7 +314,7 @@ else
 	$(eval REG_SERVICE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
     ifeq ($(IS_OS_3),)
 		# it is not using OS 3 so we will install operator via CSV
-		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
+		curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
 		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml | oc apply -f -
 		sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g;s|^  source: .*|&-${DATE_SUFFIX}|' ${E2E_REPO_PATH}/hack/install_operator.yaml > /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml
@@ -339,7 +338,7 @@ else
 		done
     else
 		echo "before curl ${REPO_NAME}"
-		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/deploy/operator.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml
+		curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/deploy/operator.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml
 		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml | oc apply -f -
     endif
 endif

--- a/make/test.mk
+++ b/make/test.mk
@@ -315,9 +315,8 @@ else
 	$(eval REG_SERVICE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
     ifeq ($(IS_OS_3),)
 		# it is not using OS 3 so we will install operator via CSV
-		$(eval CAPITALIZED_REPO_NAME := $(shell echo "${REPO_NAME}' | awk '{ print toupper($0) }' | tr '-' '_'))
-		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/e2e-tests.yaml ${CAPITALIZED_REPO_NAME}_DYNAMIC_KEYS > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
-		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
+		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/e2e-tests.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
+		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml | oc apply -f -
 		sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g;s|^  source: .*|&-${DATE_SUFFIX}|' ${E2E_REPO_PATH}/hack/install_operator.yaml > /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml | oc apply -f -

--- a/make/test.mk
+++ b/make/test.mk
@@ -17,11 +17,12 @@ IS_KUBE_ADMIN := $(shell oc whoami | grep "kube:admin")
 IS_OS_3 := $(shell curl -k -XGET -H "Authorization: Bearer $(shell oc whoami -t 2>/dev/null)" $(shell oc config view --minify -o jsonpath='{.clusters[0].cluster.server}')/version/openshift 2>/dev/null | grep paths)
 
 ENVIRONMENT := e2e-tests
+IMAGE_NAMES_DIR := /tmp/crt-e2e-image-names
 
 WAS_ALREADY_PAIRED_FILE := /tmp/${GO_PACKAGE_ORG_NAME}_${GO_PACKAGE_REPO_NAME}_already_paired
 
 .PHONY: deploy-ops
-deploy-ops: deploy-member deploy-host
+deploy-ops: deploy-host deploy-member
 
 .PHONY: test-e2e
 test-e2e: deploy-e2e e2e-run
@@ -61,8 +62,9 @@ e2e-run:
 	oc get kubefedcluster -n $(HOST_NS)
 	oc get kubefedcluster -n $(MEMBER_NS)
 	-oc new-project $(TEST_NS) --display-name e2e-tests 1>/dev/null
-	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=30m" || \
-	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
+	$(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1
+#	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(TEST_NS) --verbose --go-test-flags "-timeout=30m" || \
+#	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs
 print-logs:
@@ -297,6 +299,8 @@ else
 	# use the provided image name
 	$(eval IMAGE_NAME := ${SET_IMAGE_NAME})
 endif
+	mkdir ${IMAGE_NAMES_DIR} || true
+	echo "${IMAGE_NAME}" > ${IMAGE_NAMES_DIR}/${REPO_NAME}
 	@echo Using image ${IMAGE_NAME} and namespace ${NAMESPACE} for the repository ${REPO_NAME}
 ifeq ($(REPO_NAME),registration-service)
 	# registration service is not integrated with OLM yet, so deploy it directly
@@ -306,9 +310,14 @@ ifeq ($(REPO_NAME),registration-service)
 	    -p NAMESPACE=${NAMESPACE} \
         | oc apply -f -
 else
+	$(eval REGISTRATION_SERVICE_IMAGE_NAME := $(shell cat ${IMAGE_NAMES_DIR}/registration-service))
+	@echo Using image ${IMAGE_NAME} and namespace ${NAMESPACE} for the repository ${REPO_NAME}
+	$(eval REG_SERVICE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
     ifeq ($(IS_OS_3),)
 		# it is not using OS 3 so we will install operator via CSV
-		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|' ${E2E_REPO_PATH}/hack/deploy_csv.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
+		$(eval CAPITALIZED_REPO_NAME := $(shell echo "${REPO_NAME}' | awk '{ print toupper($0) }' | tr '-' '_'))
+		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/e2e-tests.yaml ${CAPITALIZED_REPO_NAME}_DYNAMIC_KEYS > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
+		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml | oc apply -f -
 		sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g;s|^  source: .*|&-${DATE_SUFFIX}|' ${E2E_REPO_PATH}/hack/install_operator.yaml > /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml | oc apply -f -

--- a/make/test.mk
+++ b/make/test.mk
@@ -30,7 +30,7 @@ test-e2e: deploy-e2e e2e-run
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
 .PHONY: deploy-e2e
-deploy-e2e: build-with-operators login-as-admin deploy-ops deploy-registration setup-kubefed
+deploy-e2e: build-with-operators login-as-admin deploy-registration deploy-ops setup-kubefed
 
 .PHONY: test-e2e-local
 ## Run the e2e tests with the local 'host', 'member', and 'registration-service' repositories

--- a/make/test.mk
+++ b/make/test.mk
@@ -315,7 +315,7 @@ else
 	$(eval REG_SERVICE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
     ifeq ($(IS_OS_3),)
 		# it is not using OS 3 so we will install operator via CSV
-		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/e2e-tests.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
+		curl -sSL https://raw.githubusercontent.com/MatousJobanek/api/enrich-by-envs-from-yaml/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
 		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${DATE_SUFFIX}|;s|^  configMap: .*|&-${DATE_SUFFIX}|${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml | oc apply -f -
 		sed -e 's|REPLACE_NAMESPACE|${NAMESPACE}|g;s|^  source: .*|&-${DATE_SUFFIX}|' ${E2E_REPO_PATH}/hack/install_operator.yaml > /tmp/${REPO_NAME}_install_operator_${DATE_SUFFIX}.yaml


### PR DESCRIPTION
This is a paired PR for https://github.com/codeready-toolchain/host-operator/pull/136 and also uses the functionality of the script introduced here: https://github.com/codeready-toolchain/api/pull/88.

The changes use the script and enriches either CSV or deployment YAML file by registation-service environment variables that are set in `deploy/env/<environment>.yaml` configuration files. 
In addition, it also stores the images in `/tmp/crt-e2e-image-names/` directory and then sets the registation-service image location to the host-operator YAML file as a variable ` REPLACE_REGISTRATION_SERVICE_IMAGE`

To verify that the variables are properly set please check the output of the build that intentionally failed: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/65/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/430/build-log.txt
```
{"level":"info","ts":1579172814.857339,"logger":"cmd","msg":"Registration Service configuration variables:"}
{"level":"info","ts":1579172814.8573575,"logger":"cmd","msg":"REGISTRATION_SERVICE_AUTH_CLIENT_CONFIG_RAW: {\"realm\": \"toolchain-public\", \"auth-server-url\": \"https://sso.prod-preview.openshift.io/auth\", \"ssl-required\": \"none\", \"resource\": \"crt\", \"clientId\": \"crt\", \"public-client\": true }"}
{"level":"info","ts":1579172814.857364,"logger":"cmd","msg":"REGISTRATION_SERVICE_AUTH_CLIENT_LIBRARY_URL: https://sso.prod-preview.openshift.io/auth/js/keycloak.js"}
{"level":"info","ts":1579172814.8573692,"logger":"cmd","msg":"REGISTRATION_SERVICE_REPLICAS: 1"}
{"level":"info","ts":1579172814.857374,"logger":"cmd","msg":"REGISTRATION_SERVICE_SERVICE_HOST: 172.30.55.45"}
{"level":"info","ts":1579172814.8573785,"logger":"cmd","msg":"REGISTRATION_SERVICE_PORT_80_TCP_PORT: 80"}
{"level":"info","ts":1579172814.8573823,"logger":"cmd","msg":"REGISTRATION_SERVICE_PORT_80_TCP_PROTO: tcp"}
{"level":"info","ts":1579172814.857387,"logger":"cmd","msg":"REGISTRATION_SERVICE_SERVICE_PORT_8080: 80"}
{"level":"info","ts":1579172814.8573916,"logger":"cmd","msg":"REGISTRATION_SERVICE_ENVIRONMENT: e2e-tests"}
{"level":"info","ts":1579172814.857396,"logger":"cmd","msg":"REGISTRATION_SERVICE_IMAGE: registry.svc.ci.openshift.org/ci-op-13107m1m/stable:registration-service"}
{"level":"info","ts":1579172814.8574004,"logger":"cmd","msg":"REGISTRATION_SERVICE_PORT_80_TCP: tcp://172.30.55.45:80"}
{"level":"info","ts":1579172814.8574047,"logger":"cmd","msg":"REGISTRATION_SERVICE_PORT: tcp://172.30.55.45:80"}
{"level":"info","ts":1579172814.8574088,"logger":"cmd","msg":"REGISTRATION_SERVICE_AUTH_CLIENT_PUBLIC_KEYS_URL: https://sso.prod-preview.openshift.io/auth/realms/toolchain-public/protocol/openid-connect/certs"}
{"level":"info","ts":1579172814.8574133,"logger":"cmd","msg":"REGISTRATION_SERVICE_PORT_80_TCP_ADDR: 172.30.55.45"}
{"level":"info","ts":1579172814.857417,"logger":"cmd","msg":"REGISTRATION_SERVICE_SERVICE_PORT: 80"}
```

The log contains more variables as they are all loaded by the prefix, but it at least makes debugging easier.

It will be then used for the creation of RegistrationService CR in the following PR - for now, host-operator only prints it into the log.