### PR TITLE
feat: select first member cluster ready and with capacity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/multierr v1.2.0 // indirect
+	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
@@ -35,6 +36,7 @@ require (
 	golang.org/x/tools v0.0.0-20190927052746-69890759d905 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/h2non/gock.v1 v1.0.14
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -4,6 +4,7 @@ DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 
 .PHONY: dev-deploy-e2e
+## deploys the resources
 dev-deploy-e2e: deploy-e2e-to-dev-namespaces print-reg-service-link
 
 .PHONY: deploy-e2e-to-dev-namespaces

--- a/test/e2e/kubefed_test.go
+++ b/test/e2e/kubefed_test.go
@@ -29,7 +29,6 @@ func verifyKubeFedCluster(ctx *test.TestCtx, awaitility *wait.Awaitility, kubeFe
 	current, ok, err := singleAwait.GetKubeFedCluster(kubeFedClusterType, nil)
 	require.NoError(awaitility.T, err)
 	require.True(awaitility.T, ok, "KubeFedCluster should exist")
-	// labels := testsupport.KubeFedLabels(kubeFedClusterType, current.Labels["namespace"], current.Labels["ownerClusterName"])
 
 	awaitility.T.Run("create new KubeFedCluster with correct data and expect to be ready for cluster type "+string(kubeFedClusterType), func(t *testing.T) {
 		// given

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -111,17 +110,4 @@ func newSchemeBuilder() runtime.SchemeBuilder {
 	addToSchemes = append(addToSchemes, templatev1.AddToScheme)
 	addToSchemes = append(addToSchemes, routev1.AddToScheme)
 	return addToSchemes
-}
-
-// KubeFedLabels takes the label values and returns a key-value map containing label names key and values
-func KubeFedLabels(clType cluster.Type, ns, ownerClusterName string) map[string]string {
-	labels := map[string]string{}
-	if clType != "" {
-		labels["type"] = string(clType)
-	}
-	if ns != "" {
-		labels["namespace"] = ns
-	}
-	labels["ownerClusterName"] = ownerClusterName
-	return labels
 }

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -55,7 +55,6 @@ type SingleAwaitility interface {
 	WaitForKubeFedCluster(clusterType cluster.Type, condition *v1beta1.ClusterCondition) error
 	WaitForKubeFedClusterConditionWithName(name string, condition *v1beta1.ClusterCondition) error
 	GetKubeFedCluster(clusterType cluster.Type, condition *v1beta1.ClusterCondition) (v1beta1.KubeFedCluster, bool, error)
-	// NewKubeFedCluster(name string, caBundle []byte, apiEndpoint, secretRef string, labels map[string]string) *v1beta1.KubeFedCluster
 	NewKubeFedCluster(name string, options ...ClusterOption) *v1beta1.KubeFedCluster
 }
 
@@ -235,7 +234,7 @@ func CABundle(bundle []byte) ClusterOption {
 	}
 }
 
-func (a *SingleAwaitilityImpl) NewKubeFedCluster(name string, options ...ClusterOption) *v1beta1.KubeFedCluster { //caBundle []byte, apiEndpoint, secretRef string, labels map[string]string) *v1beta1.KubeFedCluster {
+func (a *SingleAwaitilityImpl) NewKubeFedCluster(name string, options ...ClusterOption) *v1beta1.KubeFedCluster {
 	kubeFedCluster := &v1beta1.KubeFedCluster{
 		Spec: v1beta1.KubeFedClusterSpec{
 			SecretRef: v1beta1.LocalSecretReference{
@@ -258,24 +257,6 @@ func (a *SingleAwaitilityImpl) NewKubeFedCluster(name string, options ...Cluster
 	}
 	return kubeFedCluster
 }
-
-// // NewKubeFedCluster creates KubeFedCluster CR object with the given values
-// func (a *SingleAwaitilityImpl) NewKubeFedCluster(name string, caBundle []byte, apiEndpoint, secretRef string, labels map[string]string) *v1beta1.KubeFedCluster {
-// 	return &v1beta1.KubeFedCluster{
-// 		ObjectMeta: metav1.ObjectMeta{
-// 			Namespace: a.Ns,
-// 			Name:      name,
-// 			Labels:    labels,
-// 		},
-// 		Spec: v1beta1.KubeFedClusterSpec{
-// 			CABundle:    caBundle,
-// 			APIEndpoint: apiEndpoint,
-// 			SecretRef: v1beta1.LocalSecretReference{
-// 				Name: secretRef,
-// 			},
-// 		},
-// 	}
-// }
 
 func containsClusterCondition(conditions []v1beta1.ClusterCondition, contains *v1beta1.ClusterCondition) bool {
 	if contains == nil {

--- a/wait/member.go
+++ b/wait/member.go
@@ -10,7 +10,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/stretchr/testify/require"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -160,8 +160,11 @@ func (a *MemberAwaitility) WaitForNamespace(username, typeName, revision string)
 			if err := a.Client.List(context.TODO(), allNSs, client.MatchingLabels(ls)); err != nil {
 				return false, err
 			}
-
-			a.T.Logf("waiting for availability of namespace of type '%s' with revision '%s' and owned by '%s'. Currently available codeready-toolchain NSs: '%+v'", typeName, revision, username, allNSs)
+			allNSNames := make(map[string]map[string]string, len(allNSs.Items))
+			for _, ns := range allNSs.Items {
+				allNSNames[ns.Name] = ns.Labels
+			}
+			a.T.Logf("waiting for availability of namespace of type '%s' with revision '%s' and owned by '%s'. Currently available codeready-toolchain NSs: '%+v'", typeName, revision, username, allNSNames)
 			return false, nil
 		}
 		require.Len(a.T, namespaceList.Items, 1, "there should be only one Namespace found")


### PR DESCRIPTION
fixes #CRT-406

e2e tests for https://github.com/codeready-toolchain/host-operator/pull/139

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>