### PR TITLE
chore: use ${QUAY_NAMESPACE} prefix/suffix for namespaces and subscriptions

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,5 +1,5 @@
-DEV_MEMBER_NS := toolchain-member-operator
-DEV_HOST_NS := toolchain-host-operator
+DEV_MEMBER_NS := ${QUAY_NAMESPACE}-toolchain-member-operator
+DEV_HOST_NS := ${QUAY_NAMESPACE}-toolchain-host-operator
 DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,5 +1,5 @@
-DEV_MEMBER_NS := ${QUAY_NAMESPACE}-toolchain-member-operator
-DEV_HOST_NS := ${QUAY_NAMESPACE}-toolchain-host-operator
+DEV_MEMBER_NS := ${QUAY_NAMESPACE}-member-operator
+DEV_HOST_NS := ${QUAY_NAMESPACE}-host-operator
 DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -5,9 +5,9 @@
 ###########################################################
 
 QUAY_NAMESPACE ?= codeready-toolchain
-DATE_SUFFIX := $(shell date +'%s')
-MEMBER_NS := ${QUAY_NAMESPACE}-member-operator-${DATE_SUFFIX}
-HOST_NS := ${QUAY_NAMESPACE}-host-operator-${DATE_SUFFIX}
+DATE_SUFFIX := $(shell date +'%m%H%M%S')
+MEMBER_NS := ${QUAY_NAMESPACE}-member-${DATE_SUFFIX}
+HOST_NS := ${QUAY_NAMESPACE}-host-${DATE_SUFFIX}
 REGISTRATION_SERVICE_NS := $(HOST_NS)
 TEST_NS := ${QUAY_NAMESPACE}-toolchain-e2e-${DATE_SUFFIX}
 AUTHOR_LINK := $(shell jq -r '.refs[0].pulls[0].author_link' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]')


### PR DESCRIPTION
use `${QUAY_NAMESPACE}` as a prefix for namespaces and as a suffix for subscriptions

* this will allow us running (and cleaning) e2e tests in parallel in one cluster 
* will avoid any conflicts with namespaces created in other clusters (eg. if we are accidentally logged to crt dev clusters :-))