### PR TITLE
chore: use digest instead of tags

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -302,8 +302,15 @@ else
 	# use the provided image name
 	$(eval IMAGE_NAME := ${SET_IMAGE_NAME})
 endif
-	mkdir ${IMAGE_NAMES_DIR} || true
+ifneq ($(IS_OS_3),)
+	# is running locally, then use the normal image def with tag
 	echo "${IMAGE_NAME}" > ${IMAGE_NAMES_DIR}/${REPO_NAME}
+else
+	# is using OS4, then use digest instead of tag for defining image
+	mkdir ${IMAGE_NAMES_DIR} || true
+	docker pull ${IMAGE_NAME}
+	echo `docker inspect --format='{{index .RepoDigests 0}}' ${IMAGE_NAME}` > ${IMAGE_NAMES_DIR}/${REPO_NAME}
+endif
 
 
 .PHONY: deploy-operator


### PR DESCRIPTION
To properly verify that the changes introduced here https://github.com/codeready-toolchain/api/commit/d37dc262950f4345055d85c3d7e2aa8ba88c819a are working properly (in other words, that CSV and OLM can use digests instead of tags) use digests instead of tags in e2e tests too