### PR TITLE
fixing tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
+	github.com/codeready-toolchain/api v0.0.0-20200217143846-eaa75f9b390c
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
@@ -28,7 +28,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/multierr v1.2.0 // indirect
-	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190926180335-cea2066c6411 // indirect
 	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
 	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
@@ -36,7 +35,6 @@ require (
 	golang.org/x/tools v0.0.0-20190927052746-69890759d905 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/h2non/gock.v1 v1.0.14
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20200217143846-eaa75f9b390c h1:wScGz8CP42fAa3ZE9Q3v/UCzwSQyU+dkqM4rC1Bqu3w=
+github.com/codeready-toolchain/api v0.0.0-20200217143846-eaa75f9b390c/go.mod h1:zPbdWiEiv9SpZMvyRkY6E6n7Eynm5Y0uhJhBiGXjkg0=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7 h1:F8dyoI19Xp+eScSlmUYy2aLCe0dh2DTwk0FaAqFWpqE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191205223917-60807877b9e7/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -355,6 +355,7 @@ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible h1:sMBjLRdoavwnc2khLpIOmBkMPDGRB4sIbhOb8Cx2Uh0=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/library-go v0.0.0-20191121124438-7c776f7cc17a/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -225,26 +225,28 @@ func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 
 func expectedUserAccount(userID string, revisions map[string]string) v1alpha1.UserAccountSpec {
 	return v1alpha1.UserAccountSpec{
-		UserID:   userID,
-		Disabled: false,
-		NSLimit:  "default",
-		NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
-			TierName: "basic",
-			Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
-				{
-					Type:     "code",
-					Revision: revisions["code"],
-					Template: "", // must be empty
-				},
-				{
-					Type:     "dev",
-					Revision: revisions["dev"],
-					Template: "", // must be empty
-				},
-				{
-					Type:     "stage",
-					Revision: revisions["stage"],
-					Template: "", // must be empty
+		UserID:              userID,
+		Disabled:            false,
+		UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
+			NSLimit:       "default",
+			NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
+				TierName: "basic",
+				Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
+					{
+						Type:     "code",
+						Revision: revisions["code"],
+						Template: "", // must be empty
+					},
+					{
+						Type:     "dev",
+						Revision: revisions["dev"],
+						Template: "", // must be empty
+					},
+					{
+						Type:     "stage",
+						Revision: revisions["stage"],
+						Template: "", // must be empty
+					},
 				},
 			},
 		},
@@ -308,7 +310,7 @@ func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitili
 	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
 		wait.UntilUserAccountHasConditions(provisioned()),
 		wait.UntilUserAccountHasSpec(expectedUserAccount(signup.Name, expectedRevisions)),
-		wait.UntilUserAccountHasSpec(mur.Spec.UserAccounts[0].Spec))
+		wait.UntilUserAccountMatchesMur(mur.Spec, mur.Spec.UserAccounts[0].Spec))
 	require.NoError(t, err)
 	require.NotNil(t, userAccount)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -225,10 +225,10 @@ func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 
 func expectedUserAccount(userID string, revisions map[string]string) v1alpha1.UserAccountSpec {
 	return v1alpha1.UserAccountSpec{
-		UserID:              userID,
-		Disabled:            false,
+		UserID:   userID,
+		Disabled: false,
 		UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
-			NSLimit:       "default",
+			NSLimit: "default",
 			NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
 				TierName: "basic",
 				Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -195,7 +195,7 @@ func (s *userSignupIntegrationTest) assertCreatedMUR(userSignup *v1alpha1.UserSi
 
 	require.Len(s.T(), mur.Spec.UserAccounts, 1)
 	assert.Equal(s.T(), userSignup.Name, mur.Labels["toolchain.dev.openshift.com/user-id"])
-	assert.Equal(s.T(), userSignup.Name, mur.Spec.UserAccounts[0].Spec.UserID)
+	assert.Equal(s.T(), userSignup.Name, mur.Spec.UserID)
 	assert.Equal(s.T(), "default", mur.Spec.UserAccounts[0].Spec.NSLimit)
 	assert.NotNil(s.T(), mur.Spec.UserAccounts[0].Spec.NSTemplateSet)
 	if userSignup.Spec.TargetCluster != "" {

--- a/wait/member.go
+++ b/wait/member.go
@@ -51,7 +51,7 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 func UntilUserAccountMatchesMur(expectedMurSpec toolchainv1alpha1.MasterUserRecordSpec, expected toolchainv1alpha1.UserAccountSpecEmbedded) UserAccountWaitCriterion {
 	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
 		a.T.Logf("waiting for UserAccountSpecBase specs: Actual: '%+v'; Expected: '%+v', MasterUserRecordSpecs.UserID: Actual: '%+v'; Expected: '%+v' and MasterUserRecordSpecs.Disabled: Actual: '%+v'; Expected: '%+v'", ua.Spec.UserAccountSpecBase, expected.UserAccountSpecBase, ua.Spec.UserID, expectedMurSpec.UserID, ua.Spec.Disabled, expectedMurSpec.Disabled)
-		if  ua.Spec.UserID != expectedMurSpec.UserID {
+		if ua.Spec.UserID != expectedMurSpec.UserID {
 			return false
 		}
 

--- a/wait/member.go
+++ b/wait/member.go
@@ -46,6 +46,23 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 	}
 }
 
+// UntilUserAccountMatchesMur returns a `UserAccountWaitCriterion` which checks that the given
+// MasterUserRecordSpec and UserAccountSpecEmbedded are the expected specs
+func UntilUserAccountMatchesMur(expectedMurSpec toolchainv1alpha1.MasterUserRecordSpec, expected toolchainv1alpha1.UserAccountSpecEmbedded) UserAccountWaitCriterion {
+	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
+		a.T.Logf("waiting for UserAccountSpecBase specs: Actual: '%+v'; Expected: '%+v', MasterUserRecordSpecs.UserID: Actual: '%+v'; Expected: '%+v' and MasterUserRecordSpecs.Disabled: Actual: '%+v'; Expected: '%+v'", ua.Spec.UserAccountSpecBase, expected.UserAccountSpecBase, ua.Spec.UserID, expectedMurSpec.UserID, ua.Spec.Disabled, expectedMurSpec.Disabled)
+		if  ua.Spec.UserID != expectedMurSpec.UserID {
+			return false
+		}
+
+		if ua.Spec.Disabled != expectedMurSpec.Disabled {
+			return false
+		}
+
+		return reflect.DeepEqual(ua.Spec.UserAccountSpecBase, expected.UserAccountSpecBase)
+	}
+}
+
 // UntilUserAccountHasConditions returns a `UserAccountWaitCriterion` which checks that the given
 // USerAccount has exactly all the given status conditions
 func UntilUserAccountHasConditions(conditions ...toolchainv1alpha1.Condition) UserAccountWaitCriterion {


### PR DESCRIPTION
Tests related to: https://github.com/codeready-toolchain/host-operator/pull/146

Deprecating Embedded UserAccount ID and UserAccount Disabled fields.

Relates to Jira task: https://issues.redhat.com/browse/CRT-455
Relates to Jira story: https://issues.redhat.com/browse/CRT-456

This will be done in three stages:

Deprecate Embedded UA ID/Disabled
PRs:
codeready-toolchain/api#100
#143
Change the implementation and start using the new API. Roll out to prod.
Delete deprecated API.
This PR is part of stage 2.