### PR TITLE
Revert "Update operator-sdk to 0.16.0"

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.16.0
+    OPERATOR_SDK_VERSION=v0.15.2
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/toolchain-e2e
 
@@ -60,7 +60,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-key 09FCE996 \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 9391EA2A \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \


### PR DESCRIPTION
Reverts codeready-toolchain/toolchain-e2e#89

`operator-sdk test local` (0.16.0) fails with:
```
flag provided but not defined: -skipCleanupOnError
```
I'm reverting the operator-sdk upgrade until this problem is investigated and fixed.