### PR TITLE
chore: replace 'framework.TestCtx' with 'framework.Context'

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -23,6 +23,7 @@ IMAGE_NAMES_DIR := /tmp/crt-e2e-image-names
 WAS_ALREADY_PAIRED_FILE := /tmp/${GO_PACKAGE_ORG_NAME}_${GO_PACKAGE_REPO_NAME}_already_paired
 
 .PHONY: test-e2e
+## Run the e2e tests
 test-e2e: deploy-e2e e2e-run
 	@echo "The tests successfully finished"
 	@echo "To clean the cluster run 'make clean-e2e-resources'"

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -21,7 +21,7 @@ import (
 type baseUserIntegrationTest struct {
 	suite.Suite
 	namespace  string
-	testCtx    *framework.TestCtx
+	ctx        *framework.Context
 	awaitility *wait.Awaitility
 	hostAwait  *wait.HostAwaitility
 }
@@ -86,7 +86,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 	// Create a new UserSignup with the given approved flag
 	userSignup := newUserSignup(s.T(), s.awaitility.Host(), username, email)
 	userSignup.Spec.Approved = specApproved
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.testCtx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -100,7 +100,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *v1alpha1.BannedUser {
 	// Create the BannedUser
 	bannedUser := newBannedUser(s.awaitility.Host(), email)
-	err := s.awaitility.Client.Create(context.TODO(), bannedUser, testsupport.CleanupOptions(s.testCtx))
+	err := s.awaitility.Client.Create(context.TODO(), bannedUser, testsupport.CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 
 	s.T().Logf("BannedUser '%s' created", bannedUser.Spec.Email)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -250,7 +250,7 @@ func expectedUserAccount(userID string, revisions tiers.Revisions, tier string) 
 	}
 }
 
-func createMultipleSignups(t *testing.T, ctx *framework.TestCtx, awaitility *wait.Awaitility, capacity int) []toolchainv1alpha1.UserSignup {
+func createMultipleSignups(t *testing.T, ctx *framework.Context, awaitility *wait.Awaitility, capacity int) []toolchainv1alpha1.UserSignup {
 	signups := make([]toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
 		// Create an approved UserSignup resource

--- a/test/e2e/kubefed_test.go
+++ b/test/e2e/kubefed_test.go
@@ -2,6 +2,8 @@ package e2e
 
 import (
 	"context"
+	"testing"
+
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
@@ -10,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
-	"testing"
 )
 
 func TestKubeFedE2E(t *testing.T) {
@@ -24,7 +25,7 @@ func TestKubeFedE2E(t *testing.T) {
 
 // verifyKubeFedCluster verifies existence and correct conditions of KubeFedCluster CRD
 // in the target cluster type operator
-func verifyKubeFedCluster(ctx *test.TestCtx, awaitility *wait.Awaitility, kubeFedClusterType cluster.Type, singleAwait wait.SingleAwaitility) {
+func verifyKubeFedCluster(ctx *test.Context, awaitility *wait.Awaitility, kubeFedClusterType cluster.Type, singleAwait wait.SingleAwaitility) {
 	// given
 	current, ok, err := singleAwait.GetKubeFedCluster(kubeFedClusterType, nil)
 	require.NoError(awaitility.T, err)

--- a/test/e2e/nstemplateset_test.go
+++ b/test/e2e/nstemplateset_test.go
@@ -17,7 +17,7 @@ import (
 type nsTemplateSetTest struct {
 	suite.Suite
 	namespace   string
-	testCtx     *framework.TestCtx
+	ctx         *framework.Context
 	awaitility  *wait.Awaitility
 	memberAwait *wait.MemberAwaitility
 	basicTier   *toolchainv1alpha1.NSTemplateTier
@@ -29,15 +29,15 @@ func TestNSTemplateSet(t *testing.T) {
 
 func (s *nsTemplateSetTest) SetupTest() {
 	nsTmplSetList := &toolchainv1alpha1.NSTemplateSetList{}
-	s.testCtx, s.awaitility = testsupport.WaitForDeployments(s.T(), nsTmplSetList)
+	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), nsTmplSetList)
 	s.memberAwait = s.awaitility.Member()
 	s.namespace = s.awaitility.MemberNs
 	s.basicTier = getBasicTier(s.T(), s.awaitility.Client, s.awaitility.HostNs)
 }
 
 func (s *nsTemplateSetTest) TearDownTest() {
-	if s.testCtx != nil {
-		s.testCtx.Cleanup()
+	if s.ctx != nil {
+		s.ctx.Cleanup()
 	}
 }
 
@@ -78,7 +78,7 @@ func (s *nsTemplateSetTest) createAndVerifyNSTmplSet(username string) *toolchain
 	t.Logf("Creating NSTmplSet with username:%s", username)
 	nsTmplSet := s.newNSTmplSet(username)
 	t.Logf("Creating NSTmplSet:%v", nsTmplSet)
-	err := s.awaitility.Client.Create(context.TODO(), nsTmplSet, testsupport.CleanupOptions(s.testCtx))
+	err := s.awaitility.Client.Create(context.TODO(), nsTmplSet, testsupport.CleanupOptions(s.ctx))
 	require.NoError(t, err)
 
 	// wait for NSTmplSet

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -15,9 +15,8 @@ import (
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
-
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -40,13 +39,13 @@ type registrationServiceTestSuite struct {
 	suite.Suite
 	namespace  string
 	route      string
-	testCtx    *framework.TestCtx
+	ctx        *framework.Context
 	awaitility *wait.Awaitility
 }
 
 func (s *registrationServiceTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.testCtx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
 	s.namespace = s.awaitility.RegistrationServiceNs
 	s.route = s.awaitility.RegistrationServiceURL
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -35,14 +35,14 @@ type userManagementTestSuite struct {
 
 func (s *userManagementTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.testCtx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
 	s.hostAwait = s.awaitility.Host()
 	s.memberAwait = s.awaitility.Member()
 	s.namespace = s.awaitility.HostNs
 }
 
 func (s *userManagementTestSuite) TearDownTest() {
-	s.testCtx.Cleanup()
+	s.ctx.Cleanup()
 }
 
 func (s *userManagementTestSuite) TestUserDeactivation() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,13 +28,13 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 
 func (s *userSignupIntegrationTest) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.testCtx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
 	s.hostAwait = s.awaitility.Host()
 	s.namespace = s.awaitility.HostNs
 }
 
 func (s *userSignupIntegrationTest) TearDownTest() {
-	s.testCtx.Cleanup()
+	s.ctx.Cleanup()
 }
 
 func (s *userSignupIntegrationTest) TestUserSignupApproval() {
@@ -78,7 +78,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 
 	// Remove the specified target cluster
 	userSignup.Spec.TargetCluster = ""
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.testCtx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -115,7 +115,7 @@ func (s *userSignupIntegrationTest) createUserSignupAndAssertPendingApproval() *
 	email := username + "@test.com"
 	userSignup := newUserSignup(s.T(), s.awaitility.Host(), username, email)
 
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.testCtx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 

--- a/testsupport/cleanup_options.go
+++ b/testsupport/cleanup_options.go
@@ -12,6 +12,6 @@ const (
 )
 
 // CleanupOptions returns a CleanupOptions for the given test context and set with CleanupTimeout and CleanupRetryInterval
-func CleanupOptions(ctx *framework.TestCtx) *framework.CleanupOptions {
+func CleanupOptions(ctx *framework.Context) *framework.CleanupOptions {
 	return &framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval}
 }

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -26,7 +26,7 @@ import (
 // that represents the current operator that is the target of the e2e test it retrieves namespace names.
 // Also waits for the registration service to be deployed (with 3 replica)
 // Returns the test context and an instance of Awaitility that contains all necessary information
-func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.TestCtx, *wait.Awaitility) {
+func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *wait.Awaitility) {
 	schemeBuilder := newSchemeBuilder()
 	err := framework.AddToFrameworkScheme(schemeBuilder.AddToScheme, obj)
 	require.NoError(t, err, "failed to add custom resource scheme to framework")


### PR DESCRIPTION
framework.TestCtx has been deprecated in Operator SDK 0.16.0.
See https://github.com/operator-framework/operator-sdk/blob/master/doc/migration/version-upgrade-guide.md#breaking-changes-2

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>