### PR TITLE
Extracting additional user information

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/codeready-toolchain/toolchain-e2e
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49
+	github.com/codeready-toolchain/api v0.0.0-20200417005724-848dc61f6f9d
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 h1:A1QJx5Z
 github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850 h1:HGx1GHJcVxH7aN05EX8Jml5xIj/TP30NHuaRCcgaolY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7 h1:bphxX95bBnF0fA2lAN7GzLH40ere8WCsq0JI4t6m5Pw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,6 @@ github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 h1:A1QJx5ZrTFnQVbBYuiS6bqnFcPy7xS3fIpzrmEvKbdQ=
 github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850 h1:HGx1GHJcVxH7aN05EX8Jml5xIj/TP30NHuaRCcgaolY=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200403074820-4461b6d5a850/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7 h1:bphxX95bBnF0fA2lAN7GzLH40ere8WCsq0JI4t6m5Pw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 h1:A1QJx5ZrTFnQVbBYuiS6bqnFcPy7xS3fIpzrmEvKbdQ=
-github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200417005724-848dc61f6f9d h1:KvVlYn+JLfEltxgtk3pL7+WSGXT8FRtH58LNrTKrxmw=
+github.com/codeready-toolchain/api v0.0.0-20200417005724-848dc61f6f9d/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7 h1:bphxX95bBnF0fA2lAN7GzLH40ere8WCsq0JI4t6m5Pw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200416163051-c331c7b2b2d7/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -207,8 +207,11 @@ func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 	// Call signup endpoint with a valid token.
 	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	companyClaim := authsupport.WithCompanyClaim("red hat")
+	givenNameClaim := authsupport.WithGivenNameClaim("jane")
+	familyNameClaim := authsupport.WithGivenNameClaim("doe")
 	iatClaim := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
-	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, iatClaim)
+	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, companyClaim, givenNameClaim, familyNameClaim, iatClaim)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest("POST", route+"/api/v1/signup", nil)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -193,9 +193,9 @@ func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 	// at this stage, the usersignup should not be approved nor completed
 	userSignup, err := awaitility.Host().WaitForUserSignup(identity.ID.String(), wait.UntilUserSignupHasConditions(pendingApproval()...))
 	require.NoError(t, err)
-	require.Equal(t, userSignup.Spec.GivenName, "jane")
-	require.Equal(t, userSignup.Spec.FamilyName, "doe")
-	require.Equal(t, userSignup.Spec.Company, "red hat")
+	require.Equal(t, userSignup.Spec.GivenName, identity.Username+"-First-Name")
+	require.Equal(t, userSignup.Spec.FamilyName, identity.Username+"-Last-Name")
+	require.Equal(t, userSignup.Spec.Company, identity.Username+"-Company-Name")
 
 	// 2. approve the UserSignup
 	userSignup.Spec.Approved = true
@@ -211,9 +211,9 @@ func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 	// Call signup endpoint with a valid token.
 	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
-	givenNameClaim := authsupport.WithGivenNameClaim("jane")
-	familyNameClaim := authsupport.WithFamilyNameClaim("doe")
-	companyClaim := authsupport.WithCompanyClaim("red hat")
+	givenNameClaim := authsupport.WithGivenNameClaim(identity.Username + "-First-Name")
+	familyNameClaim := authsupport.WithFamilyNameClaim(identity.Username + "-Last-Name")
+	companyClaim := authsupport.WithCompanyClaim(identity.Username + "-Company-Name")
 	iatClaim := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
 	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, companyClaim, givenNameClaim, familyNameClaim, iatClaim)
 	require.NoError(t, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -192,6 +192,9 @@ func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 	// at this stage, the usersignup should not be approved nor completed
 	userSignup, err := awaitility.Host().WaitForUserSignup(identity.ID.String(), wait.UntilUserSignupHasConditions(pendingApproval()...))
 	require.NoError(t, err)
+	require.Equal(t, userSignup.Spec.GivenName, "jane")
+	require.Equal(t, userSignup.Spec.FamilyName, "doe")
+	require.Equal(t, userSignup.Spec.Company, "red hat")
 
 	// 2. approve the UserSignup
 	userSignup.Spec.Approved = true
@@ -207,9 +210,9 @@ func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 	// Call signup endpoint with a valid token.
 	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
-	companyClaim := authsupport.WithCompanyClaim("red hat")
 	givenNameClaim := authsupport.WithGivenNameClaim("jane")
-	familyNameClaim := authsupport.WithGivenNameClaim("doe")
+	familyNameClaim := authsupport.WithFamilyNameClaim("doe")
+	companyClaim := authsupport.WithCompanyClaim("red hat")
 	iatClaim := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
 	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, companyClaim, givenNameClaim, familyNameClaim, iatClaim)
 	require.NoError(t, err)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -330,9 +330,6 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.NewV4().String() + "@email.tld"
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
-	companyClaim := authsupport.WithCompanyClaim("red hat")
-	givenNameClaim := authsupport.WithGivenNameClaim("jane")
-	familyNameClaim := authsupport.WithFamilyNameClaim("doe")
 	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, companyClaim, givenNameClaim, familyNameClaim)
 	require.NoError(s.T(), err)
 

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -330,7 +330,10 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.NewV4().String() + "@email.tld"
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
-	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0)
+	companyClaim := authsupport.WithCompanyClaim("red hat")
+	givenNameClaim := authsupport.WithGivenNameClaim("jane")
+	familyNameClaim := authsupport.WithFamilyNameClaim("doe")
+	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, companyClaim, givenNameClaim, familyNameClaim)
 	require.NoError(s.T(), err)
 
 	// Call signup endpoint with a valid token to initiate a signup process

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -330,7 +330,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.NewV4().String() + "@email.tld"
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
-	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, companyClaim, givenNameClaim, familyNameClaim)
+	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0)
 	require.NoError(s.T(), err)
 
 	// Call signup endpoint with a valid token to initiate a signup process


### PR DESCRIPTION
In order to customize notification messages to users, we require additional user information which we should store in the UserSignup CRD when the user first registers. The new fields being added for the notification service messages are givenName, familyName and company. This PR will test that the fields were set correctly in the usersignup CRD via invoking the http post in registration service.

related to: https://github.com/codeready-toolchain/registration-service/pull/102
jira: https://issues.redhat.com/browse/CRT-518