### PR TITLE
Update for IdP configured for e2e environment

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -329,7 +329,7 @@ func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitili
 }
 
 func toIdentityName(userID string) string {
-	return fmt.Sprintf("%s:%s", "rhd", userID)
+	return fmt.Sprintf("%s:%s", "testIdP", userID)
 }
 
 func expectedConsoleURL(t *testing.T, memberAwait *wait.MemberAwaitility, cluster v1beta1.KubeFedCluster) string {


### PR DESCRIPTION
## Related Issue(s)
https://issues.redhat.com/browse/CRT-216

## What does this PR do?
Updates the e2e tests to look for the IdP `testIdP` that is configured in the env yaml file for the e2e-tests. See https://github.com/codeready-toolchain/member-operator/pull/150 for details.
