### PR TITLE
chore: remove ClusterResources constant

### DIFF
--- a/tiers/revisions.go
+++ b/tiers/revisions.go
@@ -11,11 +11,6 @@ type Revisions struct {
 	ClusterResources *string
 }
 
-const (
-	// ClusterResources the key to retrieve the cluster resources template
-	ClusterResources string = "clusterResources"
-)
-
 // GetRevisions returns the expected revisions for all the namespace templates and the optional cluster resources template for the given tier
 func GetRevisions(hostAwait *wait.HostAwaitility, tier string) Revisions {
 	templateTier, err := hostAwait.WaitForNSTemplateTier(tier, wait.UntilNSTemplateTierSpec(wait.Not(wait.HasNamespaceRevisions("000000a"))))


### PR DESCRIPTION
This PR removes the `ClusterResources` constant because:
* it wasn't used anywhere
* it contained capital "R" but the type name should contain only lower case letters
* to avoid any confusions with the correct name