### PR TITLE
chore: use operator-sdk 0.17.1

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,7 +9,7 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.16.0
+    OPERATOR_SDK_VERSION=v0.17.1
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/toolchain-e2e
 
@@ -60,7 +60,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # download, verify and install operator-sdk
 RUN curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk \
     && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-    && gpg --keyserver keyserver.ubuntu.com --recv-key 09FCE996 \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 9AF46519 \
     && gpg --verify operator-sdk.asc \
     && chmod +x operator-sdk \
     && cp operator-sdk /usr/bin/operator-sdk \


### PR DESCRIPTION
Changes the version of operator-sdk from 0.16.0 to 0.17.1