### PR TITLE
Fix CRC admin check

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -89,9 +89,9 @@ ifeq ($(OPENSHIFT_BUILD_NAMESPACE),)
 			oc login -u system:admin 1>/dev/null
         endif
     else
-        ifneq ($(IS_KUBE_ADMIN),)
-			$(info logging as kube:admin")
-			oc login -u=kubeadmin -p=`cat ~/.crc/cache/crc_libvirt_*/kubeadmin-password` 1>/dev/null
+        # Running on CRC
+        ifeq ($(IS_KUBE_ADMIN),)
+            $(error You must be logged in as kube:admin")
         endif
     endif
 endif


### PR DESCRIPTION
1. The test makefile has
`IS_KUBE_ADMIN := $(shell oc whoami | grep "kube:admin")`

`$(IS_KUBE_ADMIN)` is not empty if you are logged in as the `kube:admin` user so I think the check in the `login-as-admin` target should be `ifeq ($(IS_KUBE_ADMIN),)`

2. The previous code attempted to log in using `oc login -u=kubeadmin -p=`cat ~/.crc/cache/crc_libvirt_*/kubeadmin-password` 1>/dev/null` however, I have CRC 1.10.0 and that file does not exist so the login doesn't work. 

```
crc version: 1.10.0+9025021
OpenShift version: 4.4.3 (embedded in binary)
```
