### PR TITLE
addressing pr comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d
+	github.com/codeready-toolchain/api v0.0.0-20200619175042-339fd47c60d5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
@@ -24,7 +24,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.17.4 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d => github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d => github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,9 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
+github.com/codeready-toolchain/api v0.0.0-20200619175042-339fd47c60d5 h1:qMny3jYdNKgDz+gpCoLIN/hsiTS95XKoJdPnqoefE+Q=
+github.com/codeready-toolchain/api v0.0.0-20200619175042-339fd47c60d5/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf h1:co7HGUfH6yAWLf1dNkukg5M7+Z49wfW+emRRdcxZoyc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf/go.mod h1:NEidpsizFce1C6fknsCawASPpdpLViyauZBB5GdxJk4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -834,8 +837,6 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8 h1:JxJxPQZhj3PxJJw+Yl4QKQbfqgAdorl6cK5+FGPTzYw=
-github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d h1:jkvsDVtSKCQO/LJZyAdzgEyffE2YwEOIFLAwEFKpZ6s=
-github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf h1:co7HGUfH6yAWLf1dNkukg5M7+Z49wfW+emRRdcxZoyc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf/go.mod h1:NEidpsizFce1C6fknsCawASPpdpLViyauZBB5GdxJk4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -836,6 +834,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8 h1:JxJxPQZhj3PxJJw+Yl4QKQbfqgAdorl6cK5+FGPTzYw=
+github.com/tinakurian/api v0.0.0-20200619132801-686ad642e7e8/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -97,3 +97,11 @@ func provisionedNotificationCRCreated() toolchainv1alpha1.Condition {
 		Reason: "NotificationCRCreated",
 	}
 }
+
+func sent() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.NotificationSent,
+		Status: corev1.ConditionTrue,
+		Reason: "Sent",
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
-	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 
 	userv1 "github.com/openshift/api/user/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -25,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 )
 
 func TestE2EFlow(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -325,14 +325,6 @@ func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitili
 		wait.UntilMasterUserRecordHasConditions(provisioned(), provisionedNotificationCRCreated()),
 		wait.UntilMasterUserRecordHasUserAccountStatuses(expectedEmbeddedUaStatus))
 	assert.NoError(t, err)
-
-	notification, err := hostAwait.WaitForNotification(userAccount.Name + "-provisioned")
-	require.NoError(t, err)
-	require.NotNil(t, notification)
-	assert.Equal(t, userAccount.Name+"-provisioned", notification.Name)
-	assert.Equal(t, mur.Namespace, notification.Namespace)
-	assert.Equal(t, "userprovisioned", notification.Spec.Template)
-	assert.Equal(t, userAccount.Spec.UserID, notification.Spec.UserID)
 }
 
 func toIdentityName(userID string) string {

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -3,13 +3,14 @@ package e2e
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/stretchr/testify/require"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -18,7 +19,11 @@ func TestNotifications(t *testing.T) {
 }
 
 type notificationTestSuite struct {
-	baseUserIntegrationTest
+	suite.Suite
+	namespace   string
+	ctx         *framework.Context
+	awaitility  *wait.Awaitility
+	hostAwait   *wait.HostAwaitility
 	memberAwait *wait.MemberAwaitility
 }
 

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -3,12 +3,11 @@ package e2e
 import (
 	"testing"
 
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestNotifications(t *testing.T) {
+	suite.Run(t, &notificationTestSuite{})
+}
+
+type notificationTestSuite struct {
+	baseUserIntegrationTest
+	memberAwait *wait.MemberAwaitility
+}
+
+func (s *notificationTestSuite) SetupSuite() {
+	notificationList := &v1alpha1.NotificationList{}
+	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), notificationList)
+	s.hostAwait = s.awaitility.Host()
+	s.memberAwait = s.awaitility.Member()
+	s.namespace = s.awaitility.HostNs
+}
+
+func (s *notificationTestSuite) TearDownTest() {
+	s.ctx.Cleanup()
+}
+
+func (s *notificationTestSuite) TestNotificationCleanup() {
+
+	// Create and approve "janedoe"
+	janedoeName := "janedoe"
+	janeSignup := createAndApproveSignup(s.T(), s.awaitility, janedoeName)
+
+	s.T().Run("notification created and deleted", func(t *testing.T) {
+
+		hostAwait := wait.NewHostAwaitility(s.awaitility)
+		memberAwait := wait.NewMemberAwaitility(s.awaitility)
+
+		// Get the latest signup version
+		userSignup, err := s.awaitility.Host().WaitForUserSignup(janeSignup.Name)
+		require.NoError(t, err)
+
+		// First, wait for the MasterUserRecord to exist, no matter what status
+		mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
+		require.NoError(t, err)
+
+		// Then wait for the associated UserAccount to be provisioned
+		userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
+			wait.UntilUserAccountHasConditions(provisioned()))
+
+		_, err = hostAwait.WaitForMasterUserRecord(mur.Name,
+			wait.UntilMasterUserRecordHasConditions(provisioned(), provisionedNotificationCRCreated()))
+
+		notification, err := hostAwait.WaitForNotification(userAccount.Name + "-provisioned")
+		require.NoError(t, err)
+		require.NotNil(t, notification)
+		assert.Equal(t, userAccount.Name+"-provisioned", notification.Name)
+		assert.Equal(t, mur.Namespace, notification.Namespace)
+		assert.Equal(t, "userprovisioned", notification.Spec.Template)
+		assert.Equal(t, userAccount.Spec.UserID, notification.Spec.UserID)
+
+		hostAwait.WaitUntilNotificationDeleted(userAccount.Name + "-provisioned")
+	})
+}

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -26,7 +26,7 @@ import (
 const (
 	DefaultOperatorRetryInterval   = time.Millisecond * 500
 	DefaultOperatorTimeout         = time.Second * 120
-	DefaultRetryInterval           = time.Millisecond * 500
+	DefaultRetryInterval           = time.Millisecond * 100
 	DefaultTimeout                 = time.Second * 60
 	MemberNsVar                    = "MEMBER_NS"
 	HostNsVar                      = "HOST_NS"

--- a/wait/host.go
+++ b/wait/host.go
@@ -412,7 +412,6 @@ func (a *HostAwaitility) WaitForNotification(name string, criteria ...Notificati
 			}
 			return false, err
 		}
-
 		for _, match := range criteria {
 			if !match(a, obj) {
 				return false, nil
@@ -421,7 +420,6 @@ func (a *HostAwaitility) WaitForNotification(name string, criteria ...Notificati
 		a.T.Logf("found notification '%s'", name)
 		notification = obj
 		return true, nil
-
 	})
 	return notification, err
 }

--- a/wait/host.go
+++ b/wait/host.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type HostAwaitility struct {

--- a/wait/host.go
+++ b/wait/host.go
@@ -90,7 +90,7 @@ func (a *HostAwaitility) UpdateMasterUserRecord(murName string, modifyMur func(m
 	})
 }
 
-// MasterUserRecordWaitCriterion represents a function checking if MasterUserRecord meets the given condition
+// MasterUserRecordWaitCriterion checks if a MasterUserRecord meets the given condition
 type MasterUserRecordWaitCriterion func(a *HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord) bool
 
 // UntilMasterUserRecordHasConditions checks if MasterUserRecord status has the given set of conditions
@@ -397,13 +397,12 @@ func (a *HostAwaitility) WaitUntilChangeTierRequestDeleted(name string) error {
 	})
 }
 
-// NotificationWaitCriterion represents a function checking if Notification meets the given condition
+// NotificationWaitCriterion checks if a Notification meets the given condition
 type NotificationWaitCriterion func(a *HostAwaitility, mur *toolchainv1alpha1.Notification) bool
 
 // WaitForNotification waits until there is a Notification available with the given name and the optional conditions
 func (a *HostAwaitility) WaitForNotification(name string, criteria ...NotificationWaitCriterion) (*toolchainv1alpha1.Notification, error) {
 	var notification *toolchainv1alpha1.Notification
-	//notification := &toolchainv1alpha1.Notification{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Notification{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, obj); err != nil {

--- a/wait/host.go
+++ b/wait/host.go
@@ -401,18 +401,34 @@ func (a *HostAwaitility) WaitForChangeTierRequest(name string, condition toolcha
 	return changeTierRequest, err
 }
 
-// WaitUntilChangeTierRequestDeleted waits until ChangeTierRequest with the given name is deleted (ie, not found)
+// WaitUntilChangeTierRequestDeleted waits until the ChangeTierRequest with the given name is deleted (ie, not found)
 func (a *HostAwaitility) WaitUntilChangeTierRequestDeleted(name string) error {
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		changeTierRequest := &toolchainv1alpha1.ChangeTierRequest{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, changeTierRequest); err != nil {
 			if errors.IsNotFound(err) {
-				a.T.Logf("ChangeTierRequest is checked as deleted '%s'", name)
+				a.T.Logf("ChangeTierRequest has been deleted '%s'", name)
 				return true, nil
 			}
 			return false, err
 		}
 		a.T.Logf("waiting until ChangeTierRequest is deleted '%s'", name)
+		return false, nil
+	})
+}
+
+// WaitUntilNotificationDeleted waits until the Notification with the given name is deleted (ie, not found)
+func (a *HostAwaitility) WaitUntilNotificationDeleted(name string) error {
+	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+		notification := &toolchainv1alpha1.Notification{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, notification); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("Notification has been deleted '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until Notification is deleted '%s'", name)
 		return false, nil
 	})
 }

--- a/wait/host.go
+++ b/wait/host.go
@@ -31,7 +31,7 @@ func (a *HostAwaitility) WithRetryOptions(options ...interface{}) *HostAwaitilit
 	}
 }
 
-// WaitForMasterUserRecord waits until there is MasterUserRecord with the given name and the optional conditions is available
+// WaitForMasterUserRecord waits until there is a MasterUserRecord available with the given name and the optional conditions
 func (a *HostAwaitility) WaitForMasterUserRecord(name string, criteria ...MasterUserRecordWaitCriterion) (*toolchainv1alpha1.MasterUserRecord, error) {
 	var mur *toolchainv1alpha1.MasterUserRecord
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
@@ -400,7 +400,7 @@ func (a *HostAwaitility) WaitUntilChangeTierRequestDeleted(name string) error {
 // NotificationWaitCriterion represents a function checking if Notification meets the given condition
 type NotificationWaitCriterion func(a *HostAwaitility, mur *toolchainv1alpha1.Notification) bool
 
-// WaitForNotification waits until there is the notification with the given name available
+// WaitForNotification waits until there is a Notification available with the given name and the optional conditions
 func (a *HostAwaitility) WaitForNotification(name string, criteria ...NotificationWaitCriterion) (*toolchainv1alpha1.Notification, error) {
 	var notification *toolchainv1alpha1.Notification
 	//notification := &toolchainv1alpha1.Notification{}


### PR DESCRIPTION
E2E tests for notification. 

Due to the notification being cleaned up now in the notfication controller, we can no longer verify the notification as part of `verifyResourcesProvisionedForSignup.` This is because we call `createMultipleSignups` and `createAndApproveSignup` at the start of the test. when the notifications are created `verifyResourcesProvisionedForSignup` will pass for the first notification. However, for the subsequent notifications this would fail because the notification controller would have already deleted the other notifications since the deletion time would have passed. This would cause us to be stuck attempting to retrieve notifications. 

In order to work around this issue, i've moved the notification tests into a new file called `notification_test.` If there is a more preferred way of testing notifications, please do let me know - i'm open to ideas!

Related PRs: 
https://github.com/codeready-toolchain/host-operator/pull/228
https://github.com/codeready-toolchain/api/pull/157