### PR TITLE
fix(flaky test): test should use latest MUR when comparing with UA

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/api v0.0.0-20200623145816-ddd6c21322c5 h1:KhDJhOgoFEbXB5jlwmMos29Okoj+A+R5VCiYHZLKaZA=
-github.com/codeready-toolchain/api v0.0.0-20200623145816-ddd6c21322c5/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
+github.com/codeready-toolchain/api v0.0.0-20200702155133-4e0f9a1d7b18 h1:IE6CHyBlDWkcjnYOKmvVTCytzEuVOD1QCIx3mI4oBUc=
+github.com/codeready-toolchain/api v0.0.0-20200702155133-4e0f9a1d7b18/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf h1:co7HGUfH6yAWLf1dNkukg5M7+Z49wfW+emRRdcxZoyc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf/go.mod h1:NEidpsizFce1C6fknsCawASPpdpLViyauZBB5GdxJk4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -305,7 +305,7 @@ func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitili
 	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
 		wait.UntilUserAccountHasConditions(provisioned()),
 		wait.UntilUserAccountHasSpec(expectedUserAccount(userSignup.Name, tier, templateRefs)),
-		wait.UntilUserAccountMatchesMur(mur.Spec, mur.Spec.UserAccounts[0].Spec))
+		wait.UntilUserAccountMatchesMur(hostAwait))
 	require.NoError(t, err)
 	require.NotNil(t, userAccount)
 

--- a/wait/member.go
+++ b/wait/member.go
@@ -52,8 +52,8 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 	}
 }
 
-// UntilUserAccountMatchesMur returns a `UserAccountWaitCriterion` which checks that the given
-// MasterUserRecordSpec and UserAccountSpecEmbedded are the expected specs
+// UntilUserAccountMatchesMur returns a `UserAccountWaitCriterion` which loads the existing MUR
+// and compares the first UserAccountSpecEmbedded in the MUR with the actual UserAccount spec
 func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitCriterion {
 	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
 		mur, err := hostAwaitility.GetMasterUserRecord(WithMurName(ua.Name))

--- a/wait/member.go
+++ b/wait/member.go
@@ -54,18 +54,24 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 
 // UntilUserAccountMatchesMur returns a `UserAccountWaitCriterion` which checks that the given
 // MasterUserRecordSpec and UserAccountSpecEmbedded are the expected specs
-func UntilUserAccountMatchesMur(expectedMurSpec toolchainv1alpha1.MasterUserRecordSpec, expected toolchainv1alpha1.UserAccountSpecEmbedded) UserAccountWaitCriterion {
+func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitCriterion {
 	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
-		a.T.Logf("waiting for UserAccountSpecBase specs: Actual: '%+v'; Expected: '%+v', MasterUserRecordSpecs.UserID: Actual: '%+v'; Expected: '%+v' and MasterUserRecordSpecs.Disabled: Actual: '%+v'; Expected: '%+v'", ua.Spec.UserAccountSpecBase, expected.UserAccountSpecBase, ua.Spec.UserID, expectedMurSpec.UserID, ua.Spec.Disabled, expectedMurSpec.Disabled)
-		if ua.Spec.UserID != expectedMurSpec.UserID {
+		mur, err := hostAwaitility.GetMasterUserRecord(WithMurName(ua.Name))
+		if err != nil {
+			a.T.Logf("error while getting MUR: %s", err)
+			return false
+		}
+		expAccountSpecBase := mur.Spec.UserAccounts[0].Spec.UserAccountSpecBase
+		a.T.Logf("waiting for UserAccountSpecBase specs: Actual: '%+v'; Expected: '%+v', MasterUserRecordSpecs.UserID: Actual: '%+v'; Expected: '%+v' and MasterUserRecordSpecs.Disabled: Actual: '%+v'; Expected: '%+v'", ua.Spec.UserAccountSpecBase, expAccountSpecBase, ua.Spec.UserID, mur.Spec.UserID, ua.Spec.Disabled, mur.Spec.Disabled)
+		if ua.Spec.UserID != mur.Spec.UserID {
 			return false
 		}
 
-		if ua.Spec.Disabled != expectedMurSpec.Disabled {
+		if ua.Spec.Disabled != mur.Spec.Disabled {
 			return false
 		}
 
-		return reflect.DeepEqual(ua.Spec.UserAccountSpecBase, expected.UserAccountSpecBase)
+		return reflect.DeepEqual(ua.Spec.UserAccountSpecBase, expAccountSpecBase)
 	}
 }
 


### PR DESCRIPTION
When we compare UserAccount with MUR we need to use the latest version of MUR, otherwise, the test of NSTempalteTier updates can fail: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/codeready-toolchain_host-operator/239/pull-ci-codeready-toolchain-host-operator-master-e2e/1278939436381376512/build-log.txt
What happened?
1. User `cheesecakelover01` was provisioned and promoted to `cheesecake` tier containing basic templates
2. Test updated `cheesecake` Tier to use advanced template
3. There was synchronization between UserAccount and MUR of the `cheesecakelover01` user that changed the `SyncIndex`
4. Test loaded MUR with changed `SyncIndex` and in `Provisioned` state and saved the MUR (still with basic templates) in a var
5. Test started waiting for UserAccount having advanced templates but expecting that the NSTemplateSet will contain the same data as is in MUR - containing basic tempalte.
6. Test fails because the condition won't be ever met 