### PR TITLE
Add test for toolchainstatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200702155133-4e0f9a1d7b18
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf
+	github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d
 	github.com/gobuffalo/envy v1.7.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
@@ -28,7 +28,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.17.4 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -749,6 +749,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c h1:mXSRvpp/3HKbbaZ4UdS3nlL06ltsJsBOhyjjj4/4Uv4=
+github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -136,11 +136,10 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200608101253-f0555f65f63d/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/api v0.0.0-20200702155133-4e0f9a1d7b18 h1:IE6CHyBlDWkcjnYOKmvVTCytzEuVOD1QCIx3mI4oBUc=
-github.com/codeready-toolchain/api v0.0.0-20200702155133-4e0f9a1d7b18/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf h1:co7HGUfH6yAWLf1dNkukg5M7+Z49wfW+emRRdcxZoyc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200608102500-f81c6b7e77cf/go.mod h1:NEidpsizFce1C6fknsCawASPpdpLViyauZBB5GdxJk4=
+github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd h1:G54EWvJPeJer/p07NuKKMYmXKscSnQcRMTH63AzWN+w=
+github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d h1:N9CxG2CBZk4JQsFR5lI96Km0dNBNIgxBWlCRB/UooB0=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d/go.mod h1:IC9kx4UmJCII7dEmH2ChvgGYcmZ/o9P6F/b89UvEHOw=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -749,8 +748,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c h1:mXSRvpp/3HKbbaZ4UdS3nlL06ltsJsBOhyjjj4/4Uv4=
-github.com/rajivnathan/api v0.0.0-20200713212239-c401261cd16c/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/test/e2e/conditions.go
+++ b/test/e2e/conditions.go
@@ -106,7 +106,7 @@ func sent() toolchainv1alpha1.Condition {
 	}
 }
 
-func memberStatusReady() toolchainv1alpha1.Condition {
+func toolchainStatusReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
 		Status: corev1.ConditionTrue,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -38,6 +38,10 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("verify member cluster status", func(t *testing.T) {
 			verifyMemberStatus(t, awaitility.Member())
 		})
+
+		t.Run("verify overall toolchain status", func(t *testing.T) {
+			verifyToolchainStatus(t, awaitility.Host())
+		})
 	})
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
@@ -340,8 +344,13 @@ func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitili
 }
 
 func verifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(memberStatusReady()))
-	require.NoError(t, err, "failed while waiting for toolchain member status")
+	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(toolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for MemberStatus")
+}
+
+func verifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
+	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(toolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }
 
 func toIdentityName(userID string) string {

--- a/wait/member.go
+++ b/wait/member.go
@@ -496,17 +496,17 @@ func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(username string
 }
 
 // MemberStatusWaitCriterion a function to check that an MemberStatus has the expected condition
-type MemberStatusWaitCriterion func(a *MemberAwaitility, ua *toolchainv1alpha1.MemberStatus) bool
+type MemberStatusWaitCriterion func(*MemberAwaitility, *toolchainv1alpha1.MemberStatus) bool
 
 // UntilMemberStatusHasConditions returns a `MemberStatusWaitCriterion` which checks that the given
 // MemberStatus has exactly all the given status conditions
 func UntilMemberStatusHasConditions(conditions ...toolchainv1alpha1.Condition) MemberStatusWaitCriterion {
 	return func(a *MemberAwaitility, memberStatus *toolchainv1alpha1.MemberStatus) bool {
 		if test.ConditionsMatch(memberStatus.Status.Conditions, conditions...) {
-			a.T.Logf("status conditions match in NSTemplateSet '%s`", memberStatus.Name)
+			a.T.Logf("status conditions match in MemberStatus '%s`", memberStatus.Name)
 			return true
 		}
-		a.T.Logf("waiting for status condition of NSTemplateSet '%s'. Actual: '%+v'; Expected: '%+v'", memberStatus.Name, memberStatus.Status.Conditions, conditions)
+		a.T.Logf("waiting for status condition of MemberStatus '%s'. Actual: '%+v'; Expected: '%+v'", memberStatus.Name, memberStatus.Status.Conditions, conditions)
 		return false
 	}
 }


### PR DESCRIPTION
Updates the main e2e test to verify the overall toolchain status (ToolchainStatus resource)

The verification step verifies that the toolchain status exists and has the AllComponentsReady condition which means the member clusters, registration service and host operator are all ready.

Related PR: https://github.com/codeready-toolchain/host-operator/pull/241