### PR TITLE
Tests for Idler

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -8,7 +8,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/tiers"
-	"github.com/codeready-toolchain/toolchain-e2e/wait"
 	. "github.com/codeready-toolchain/toolchain-e2e/wait"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -137,7 +136,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 // 2. creating 10 users (signups, MURs, etc.)
 // 3. promoting the users to the `cheesecake` tier
 // returns the tier, users and their "syncIndexes"
-func setupAccounts(t *testing.T, ctx *test.Context, awaitility *wait.Awaitility, tierName, nameFmt string, count int) map[string]string {
+func setupAccounts(t *testing.T, ctx *test.Context, awaitility *Awaitility, tierName, nameFmt string, count int) map[string]string {
 	hostAwaitility := NewHostAwaitility(awaitility)
 	// first, let's create the `cheesecake` NSTemplateTier (to avoid messing with other tiers)
 	// We'll use the `basic` tier as a source of inspiration.
@@ -193,7 +192,7 @@ func setupAccounts(t *testing.T, ctx *test.Context, awaitility *wait.Awaitility,
 }
 
 // updateTemplateTier updates the given "tier" using the templateRefs of the "aliasTier" (basically, we reuse the templates of the "alias" tier)
-func updateTemplateTier(t *testing.T, awaitility *wait.Awaitility, tierName string, aliasTierName string) {
+func updateTemplateTier(t *testing.T, awaitility *Awaitility, tierName string, aliasTierName string) {
 	hostAwaitility := NewHostAwaitility(awaitility)
 
 	// let's retrieve the `aliasTierName` NSTemplateTier
@@ -218,7 +217,7 @@ func updateTemplateTier(t *testing.T, awaitility *wait.Awaitility, tierName stri
 	require.NoError(t, err)
 }
 
-func verifyStatus(t *testing.T, awaitility *wait.Awaitility, tierName string, expectedCount int) {
+func verifyStatus(t *testing.T, awaitility *Awaitility, tierName string, expectedCount int) {
 	var tier *toolchainv1alpha1.NSTemplateTier
 	tier, err := awaitility.Host().WaitForNSTemplateTier(tierName, UntilNSTemplateTierStatusUpdates(expectedCount))
 	require.NoError(t, err)
@@ -232,7 +231,7 @@ func verifyStatus(t *testing.T, awaitility *wait.Awaitility, tierName string, ex
 	}
 }
 
-func verifyResourceUpdates(t *testing.T, awaitility *wait.Awaitility, syncIndexes map[string]string, tierName, aliasTierName string) {
+func verifyResourceUpdates(t *testing.T, awaitility *Awaitility, syncIndexes map[string]string, tierName, aliasTierName string) {
 	hostAwaitility := NewHostAwaitility(awaitility)
 	//
 	aliasTier, err := hostAwaitility.WaitForNSTemplateTier(aliasTierName)
@@ -253,9 +252,9 @@ func verifyResourceUpdates(t *testing.T, awaitility *wait.Awaitility, syncIndexe
 		usersignup, err := hostAwaitility.WaitForUserSignup(userID)
 		require.NoError(t, err)
 		userAccount, err := memberAwaitility.WaitForUserAccount(usersignup.Status.CompliantUsername,
-			wait.UntilUserAccountHasConditions(provisioned()),
-			wait.UntilUserAccountHasSpec(expectedUserAccount(usersignup.Name, tier.Name, templateRefs)),
-			wait.UntilUserAccountMatchesMur(hostAwaitility))
+			UntilUserAccountHasConditions(provisioned()),
+			UntilUserAccountHasSpec(expectedUserAccount(usersignup.Name, tier.Name, templateRefs)),
+			UntilUserAccountMatchesMur(hostAwaitility))
 		require.NoError(t, err)
 		_, err = hostAwaitility.WaitForMasterUserRecord(usersignup.Status.CompliantUsername,
 			UntilMasterUserRecordHasCondition(provisioned()), // ignore other conditions, such as notification sent, etc.

--- a/tiers/checks.go
+++ b/tiers/checks.go
@@ -79,6 +79,7 @@ func (a *basicTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return []clusterObjectsCheck{
 		clusterResourceQuota("4000m", "1750m", "7Gi"),
 		numberOfClusterResourceQuotas(1),
+		idlers("code", "dev", "stage"),
 	}
 }
 
@@ -109,6 +110,7 @@ func (a *advancedTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return []clusterObjectsCheck{
 		clusterResourceQuota("4000m", "1750m", "7Gi"),
 		numberOfClusterResourceQuotas(1),
+		idlers("code", "dev", "stage"),
 	}
 }
 
@@ -152,6 +154,7 @@ func (a *teamTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return []clusterObjectsCheck{
 		clusterResourceQuota("4000m", "2000m", "15Gi"),
 		numberOfClusterResourceQuotas(1),
+		idlers("dev", "stage"),
 	}
 }
 
@@ -305,6 +308,17 @@ func networkPolicyIngress(name, group string) namespaceObjectsCheck {
 		}
 
 		assert.Equal(t, expected.Spec, np.Spec)
+	}
+}
+
+func idlers(namespaceTypes ...string) clusterObjectsCheck {
+	return func(t *testing.T, memberAwait *wait.MemberAwaitility, userName string) {
+		for _, nt := range namespaceTypes {
+			idler, err := memberAwait.WaitForIdler(fmt.Sprintf("%s-%s", userName, nt))
+			require.NoError(t, err)
+			assert.Equal(t, userName, idler.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
+			assert.Equal(t, int32(28800), idler.Spec.TimeoutSeconds)
+		}
 	}
 }
 

--- a/tiers/checks.go
+++ b/tiers/checks.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 	quotav1 "github.com/openshift/api/quota/v1"
 	"github.com/stretchr/testify/assert"
@@ -319,6 +321,16 @@ func idlers(namespaceTypes ...string) clusterObjectsCheck {
 			assert.Equal(t, userName, idler.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
 			assert.Equal(t, int32(28800), idler.Spec.TimeoutSeconds)
 		}
+
+		// Make sure there is no unexpected idlers
+		idlers := &v1alpha1.IdlerList{}
+		err := memberAwait.Client.List(context.TODO(), idlers,
+			client.MatchingLabels(map[string]string{
+				"toolchain.dev.openshift.com/provider": "codeready-toolchain",
+				"toolchain.dev.openshift.com/owner":    userName,
+			}))
+		require.NoError(t, err)
+		assert.Len(t, idlers.Items, len(namespaceTypes))
 	}
 }
 


### PR DESCRIPTION
Tests for https://github.com/codeready-toolchain/host-operator/pull/245

These tests only checks that Idler resources are created during user provisioning. The Idler controller tests are more tricky to implement.
First at all there is no easy way of configuring a shorter timeout for idling (vs. 8 hours which are specified in all tiers).
Also, the tests might take awhile to execute because we would want to create many pods (with different controllers like Deployment, ReplicaSet, etc). Wait for them to start. And then wait for them to be killed.
Idler controller is pretty well covered by unit tests. So, not sure if it's that critical for us to introduce complex and slow e2e tests for full e2e coverage right now.

Any thoughts?