### PR TITLE
updating test to use rhd instead of testIdP

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -354,7 +354,7 @@ func verifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
 }
 
 func toIdentityName(userID string) string {
-	return fmt.Sprintf("%s:%s", "testIdP", userID)
+	return fmt.Sprintf("%s:%s", "rhd", userID)
 }
 
 func expectedConsoleURL(t *testing.T, memberAwait *wait.MemberAwaitility, cluster v1beta1.KubeFedCluster) string {


### PR DESCRIPTION
This PR replaces testIdP with rhd. The default idp is rhd. 

Related PR: https://github.com/codeready-toolchain/member-operator/pull/182
Jira: https://issues.redhat.com/browse/CRT-743