### PR TITLE
refactor: move setup and assertions in 'testsupport'

### DIFF
--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
@@ -72,7 +72,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 
 	// Confirm the MUR was created and ready
 
-	testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 
@@ -83,9 +83,9 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 	conditions ...v1alpha1.Condition) *v1alpha1.UserSignup {
 
 	// Create a new UserSignup with the given approved flag
-	userSignup := testsupport.NewUserSignup(s.T(), s.awaitility.Host(), username, email)
+	userSignup := NewUserSignup(s.T(), s.awaitility.Host(), username, email)
 	userSignup.Spec.Approved = specApproved
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -99,7 +99,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *v1alpha1.BannedUser {
 	// Create the BannedUser
 	bannedUser := newBannedUser(s.awaitility.Host(), email)
-	err := s.awaitility.Client.Create(context.TODO(), bannedUser, testsupport.CleanupOptions(s.ctx))
+	err := s.awaitility.Client.Create(context.TODO(), bannedUser, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 
 	s.T().Logf("BannedUser '%s' created", bannedUser.Spec.Email)

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -72,7 +72,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 
 	// Confirm the MUR was created and ready
 
-	verifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
+	testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 
@@ -83,7 +83,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 	conditions ...v1alpha1.Condition) *v1alpha1.UserSignup {
 
 	// Create a new UserSignup with the given approved flag
-	userSignup := newUserSignup(s.T(), s.awaitility.Host(), username, email)
+	userSignup := testsupport.NewUserSignup(s.T(), s.awaitility.Host(), username, email)
 	userSignup.Spec.Approved = specApproved
 	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
@@ -19,32 +19,32 @@ import (
 func TestE2EFlow(t *testing.T) {
 	// given
 	// full flow from usersignup with approval down to namespaces creation
-	ctx, awaitility := testsupport.WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
+	ctx, awaitility := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
 	defer ctx.Cleanup()
 
 	// host and member cluster statuses should be available at this point
 	t.Run("verify cluster statuses are valid", func(t *testing.T) {
 		t.Run("verify member cluster status", func(t *testing.T) {
-			testsupport.VerifyMemberStatus(t, awaitility.Member())
+			VerifyMemberStatus(t, awaitility.Member())
 		})
 
 		t.Run("verify overall toolchain status", func(t *testing.T) {
-			testsupport.VerifyToolchainStatus(t, awaitility.Host())
+			VerifyToolchainStatus(t, awaitility.Host())
 		})
 	})
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
-	signups := testsupport.CreateMultipleSignups(t, ctx, awaitility, 5)
+	signups := CreateMultipleSignups(t, ctx, awaitility, 5)
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup := testsupport.CreateAndApproveSignup(t, awaitility, johnsmithName)
+	johnSignup := CreateAndApproveSignup(t, awaitility, johnsmithName)
 	extrajohnName := "extrajohn"
-	johnExtraSignup := testsupport.CreateAndApproveSignup(t, awaitility, extrajohnName)
+	johnExtraSignup := CreateAndApproveSignup(t, awaitility, extrajohnName)
 
-	testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-	testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+	VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+	VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 
 	t.Run("try to break UserAccount", func(t *testing.T) {
 
@@ -59,14 +59,14 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
 			// given
 			identity := &userv1.Identity{}
-			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(johnSignup.Name)}, identity)
+			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(johnSignup.Name)}, identity)
 			require.NoError(t, err)
 
 			// when
@@ -74,8 +74,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -90,14 +90,14 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
 			// given
 			identity := &userv1.Identity{}
-			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(johnSignup.Name)}, identity)
+			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(johnSignup.Name)}, identity)
 			require.NoError(t, err)
 			identity.User = corev1.ObjectReference{Name: "", UID: ""}
 
@@ -106,8 +106,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
@@ -131,8 +131,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := awaitility.Member().WaitForNamespace(johnSignup.Spec.Username, ref)
 				require.NoError(t, err)
 			}
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 	})
 
@@ -178,11 +178,11 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+		VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 	})
 
 	t.Run("multiple MasterUserRecord resources provisioned", func(t *testing.T) {
 		// Now when the main flow has been tested we can verify the signups we created in the very beginning
-		testsupport.VerifyMultipleSignups(t, awaitility, signups)
+		VerifyMultipleSignups(t, awaitility, signups)
 	})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2,24 +2,14 @@ package e2e
 
 import (
 	"context"
-	"crypto/tls"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"testing"
-	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
 	userv1 "github.com/openshift/api/user/v1"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -35,26 +25,26 @@ func TestE2EFlow(t *testing.T) {
 	// host and member cluster statuses should be available at this point
 	t.Run("verify cluster statuses are valid", func(t *testing.T) {
 		t.Run("verify member cluster status", func(t *testing.T) {
-			verifyMemberStatus(t, awaitility.Member())
+			testsupport.VerifyMemberStatus(t, awaitility.Member())
 		})
 
 		t.Run("verify overall toolchain status", func(t *testing.T) {
-			verifyToolchainStatus(t, awaitility.Host())
+			testsupport.VerifyToolchainStatus(t, awaitility.Host())
 		})
 	})
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
-	signups := createMultipleSignups(t, ctx, awaitility, 5)
+	signups := testsupport.CreateMultipleSignups(t, ctx, awaitility, 5)
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup := createAndApproveSignup(t, awaitility, johnsmithName)
+	johnSignup := testsupport.CreateAndApproveSignup(t, awaitility, johnsmithName)
 	extrajohnName := "extrajohn"
-	johnExtraSignup := createAndApproveSignup(t, awaitility, extrajohnName)
+	johnExtraSignup := testsupport.CreateAndApproveSignup(t, awaitility, extrajohnName)
 
-	verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-	verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+	testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+	testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 
 	t.Run("try to break UserAccount", func(t *testing.T) {
 
@@ -69,14 +59,14 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
 			// given
 			identity := &userv1.Identity{}
-			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: toIdentityName(johnSignup.Name)}, identity)
+			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(johnSignup.Name)}, identity)
 			require.NoError(t, err)
 
 			// when
@@ -84,8 +74,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -100,14 +90,14 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
 			// given
 			identity := &userv1.Identity{}
-			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: toIdentityName(johnSignup.Name)}, identity)
+			err := awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(johnSignup.Name)}, identity)
 			require.NoError(t, err)
 			identity.User = corev1.ObjectReference{Name: "", UID: ""}
 
@@ -116,8 +106,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
@@ -141,8 +131,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := awaitility.Member().WaitForNamespace(johnSignup.Spec.Username, ref)
 				require.NoError(t, err)
 			}
-			verifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
-			verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnSignup, "basic")
+			testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 		})
 	})
 
@@ -188,206 +178,11 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		verifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
+		testsupport.VerifyResourcesProvisionedForSignup(t, awaitility, johnExtraSignup, "basic")
 	})
 
 	t.Run("multiple MasterUserRecord resources provisioned", func(t *testing.T) {
 		// Now when the main flow has been tested we can verify the signups we created in the very beginning
-		verifyMultipleSignups(t, awaitility, signups)
+		testsupport.VerifyMultipleSignups(t, awaitility, signups)
 	})
-}
-
-func createAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username string) toolchainv1alpha1.UserSignup {
-	// 1. Create a UserSignup resource via calling registration service
-	identity := &authsupport.Identity{
-		ID:       uuid.NewV4(),
-		Username: username,
-	}
-	postSignup(t, awaitility.RegistrationServiceURL, *identity)
-
-	// at this stage, the usersignup should not be approved nor completed
-	userSignup, err := awaitility.Host().WaitForUserSignup(identity.ID.String(), wait.UntilUserSignupHasConditions(pendingApproval()...))
-	require.NoError(t, err)
-	require.Equal(t, userSignup.Spec.GivenName, identity.Username+"-First-Name")
-	require.Equal(t, userSignup.Spec.FamilyName, identity.Username+"-Last-Name")
-	require.Equal(t, userSignup.Spec.Company, identity.Username+"-Company-Name")
-
-	// 2. approve the UserSignup
-	userSignup.Spec.Approved = true
-	err = awaitility.Host().Client.Update(context.TODO(), userSignup)
-	require.NoError(t, err)
-	// Check the updated conditions
-	_, err = awaitility.Host().WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(approvedByAdmin()...))
-	require.NoError(t, err)
-
-	return *userSignup
-}
-
-func postSignup(t *testing.T, route string, identity authsupport.Identity) {
-	// Call signup endpoint with a valid token.
-	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
-	givenNameClaim := authsupport.WithGivenNameClaim(identity.Username + "-First-Name")
-	familyNameClaim := authsupport.WithFamilyNameClaim(identity.Username + "-Last-Name")
-	companyClaim := authsupport.WithCompanyClaim(identity.Username + "-Company-Name")
-	iatClaim := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
-	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, companyClaim, givenNameClaim, familyNameClaim, iatClaim)
-	require.NoError(t, err)
-
-	req, err := http.NewRequest("POST", route+"/api/v1/signup", nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("content-type", "application/json")
-	client := httpClient
-
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-}
-
-func expectedUserAccount(userID string, tier string, templateRefs tiers.TemplateRefs) v1alpha1.UserAccountSpec {
-	namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, 0, len(templateRefs.Namespaces))
-	for _, ref := range templateRefs.Namespaces {
-		namespaces = append(namespaces, toolchainv1alpha1.NSTemplateSetNamespace{
-			Template:    "", // must be empty
-			TemplateRef: ref,
-		})
-	}
-	var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
-	if templateRefs.ClusterResources != nil {
-		clusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
-			TemplateRef: tier + "-" + "clusterresources" + "-" + *templateRefs.ClusterResources,
-		}
-	}
-	return v1alpha1.UserAccountSpec{
-		UserID:   userID,
-		Disabled: false,
-		UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
-			NSLimit: "default",
-			NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
-				TierName:         tier,
-				Namespaces:       namespaces,
-				ClusterResources: clusterResources,
-			},
-		},
-	}
-}
-
-func createMultipleSignups(t *testing.T, ctx *framework.Context, awaitility *wait.Awaitility, capacity int) []toolchainv1alpha1.UserSignup {
-	signups := make([]toolchainv1alpha1.UserSignup, capacity)
-	for i := 0; i < capacity; i++ {
-		// Create an approved UserSignup resource
-		userSignup := newUserSignup(t, awaitility.Host(), fmt.Sprintf("multiple-signup-testuser-%d", i), fmt.Sprintf("multiple-signup-testuser-%d@test.com", i))
-		userSignup.Spec.Approved = true
-		err := awaitility.Host().Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(ctx))
-		awaitility.T.Logf("created usersignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)
-		require.NoError(t, err)
-		signups[i] = *userSignup
-	}
-	return signups
-}
-
-func verifyMultipleSignups(t *testing.T, awaitility *wait.Awaitility, signups []toolchainv1alpha1.UserSignup) {
-	for _, signup := range signups {
-		verifyResourcesProvisionedForSignup(t, awaitility, signup, "basic")
-	}
-}
-
-func verifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitility, signup toolchainv1alpha1.UserSignup, tier string) {
-	hostAwait := wait.NewHostAwaitility(awaitility)
-	memberAwait := wait.NewMemberAwaitility(awaitility)
-	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
-	// Get the latest signup version
-	userSignup, err := awaitility.Host().WaitForUserSignup(signup.Name)
-	require.NoError(t, err)
-
-	// First, wait for the MasterUserRecord to exist, no matter what status
-	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
-	require.NoError(t, err)
-
-	// Then wait for the associated UserAccount to be provisioned
-	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
-		wait.UntilUserAccountHasConditions(provisioned()),
-		wait.UntilUserAccountHasSpec(expectedUserAccount(userSignup.Name, tier, templateRefs)),
-		wait.UntilUserAccountMatchesMur(hostAwait))
-	require.NoError(t, err)
-	require.NotNil(t, userAccount)
-
-	// Verify provisioned User
-	_, err = memberAwait.WaitForUser(userAccount.Name)
-	assert.NoError(t, err)
-
-	// Verify provisioned Identity
-	_, err = memberAwait.WaitForIdentity(toIdentityName(userAccount.Spec.UserID))
-	assert.NoError(t, err)
-
-	tiers.VerifyNsTemplateSet(t, awaitility, userAccount, tier)
-
-	// Get member cluster to verify that it was used to provision user accounts
-	memberCluster, ok, err := hostAwait.GetToolchainCluster(cluster.Member, nil)
-	require.NoError(t, err)
-	require.True(t, ok)
-
-	// Then finally check again the MasterUserRecord with the expected (embedded) UserAccount status, on top of the other criteria
-	expectedEmbeddedUaStatus := toolchainv1alpha1.UserAccountStatusEmbedded{
-		Cluster: toolchainv1alpha1.Cluster{
-			Name:        mur.Spec.UserAccounts[0].TargetCluster,
-			APIEndpoint: memberCluster.Spec.APIEndpoint,
-			ConsoleURL:  expectedConsoleURL(t, memberAwait, memberCluster),
-		},
-		UserAccountStatus: userAccount.Status,
-	}
-	_, err = hostAwait.WaitForMasterUserRecord(mur.Name,
-		wait.UntilMasterUserRecordHasConditions(provisioned(), provisionedNotificationCRCreated()),
-		wait.UntilMasterUserRecordHasUserAccountStatuses(expectedEmbeddedUaStatus))
-	assert.NoError(t, err)
-}
-
-func verifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(toolchainStatusReady()))
-	require.NoError(t, err, "failed while waiting for MemberStatus")
-}
-
-func verifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
-	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(toolchainStatusReady()))
-	require.NoError(t, err, "failed while waiting for ToolchainStatus")
-}
-
-func toIdentityName(userID string) string {
-	return fmt.Sprintf("%s:%s", "rhd", userID)
-}
-
-func expectedConsoleURL(t *testing.T, memberAwait *wait.MemberAwaitility, cluster toolchainv1alpha1.ToolchainCluster) string {
-	// If OpenShift 3.x console available then we expect its URL in the status
-	consoleURL := openShift3XConsoleURL(cluster.Spec.APIEndpoint)
-	if consoleURL == "" {
-		// Expect OpenShift 4.x console URL
-		route, err := memberAwait.GetConsoleRoute()
-		require.NoError(t, err)
-		consoleURL = fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
-	}
-	return consoleURL
-}
-
-// openShift3XConsoleURL checks if <apiEndpoint>/console URL is reachable.
-// This URL is used by web console in OpenShift 3.x
-func openShift3XConsoleURL(apiEndpoint string) string {
-	client := http.Client{
-		Timeout: time.Duration(1 * time.Second),
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-	url := fmt.Sprintf("%s/console", apiEndpoint)
-	resp, err := client.Get(url)
-	if err != nil {
-		return ""
-	}
-	defer func() {
-		_, _ = ioutil.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode != http.StatusOK {
-		return ""
-	}
-	return url
 }

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -42,16 +42,16 @@ func (s *notificationTestSuite) TestNotificationCleanup() {
 
 	// Create and approve "janedoe"
 	janedoeName := "janedoe"
-	createAndApproveSignup(s.T(), s.awaitility, janedoeName)
+	testsupport.CreateAndApproveSignup(s.T(), s.awaitility, janedoeName)
 
 	s.T().Run("notification created and deleted", func(t *testing.T) {
 		hostAwait := wait.NewHostAwaitility(s.awaitility)
 
 		mur, err := hostAwait.WaitForMasterUserRecord(janedoeName,
-			wait.UntilMasterUserRecordHasConditions(provisioned(), provisionedNotificationCRCreated()))
+			wait.UntilMasterUserRecordHasConditions(testsupport.Provisioned(), testsupport.ProvisionedNotificationCRCreated()))
 		require.NoError(t, err)
 
-		notification, err := hostAwait.WaitForNotification(mur.Name+"-provisioned", wait.UntilNotificationHasConditions(sent()))
+		notification, err := hostAwait.WaitForNotification(mur.Name+"-provisioned", wait.UntilNotificationHasConditions(testsupport.Sent()))
 		require.NoError(t, err)
 		require.NotNil(t, notification)
 		assert.Equal(t, mur.Name+"-provisioned", notification.Name)

--- a/test/e2e/notification_test.go
+++ b/test/e2e/notification_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
@@ -28,7 +28,7 @@ type notificationTestSuite struct {
 
 func (s *notificationTestSuite) SetupSuite() {
 	notificationList := &v1alpha1.NotificationList{}
-	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), notificationList)
+	s.ctx, s.awaitility = WaitForDeployments(s.T(), notificationList)
 	s.hostAwait = s.awaitility.Host()
 	s.memberAwait = s.awaitility.Member()
 	s.namespace = s.awaitility.HostNs
@@ -42,16 +42,16 @@ func (s *notificationTestSuite) TestNotificationCleanup() {
 
 	// Create and approve "janedoe"
 	janedoeName := "janedoe"
-	testsupport.CreateAndApproveSignup(s.T(), s.awaitility, janedoeName)
+	CreateAndApproveSignup(s.T(), s.awaitility, janedoeName)
 
 	s.T().Run("notification created and deleted", func(t *testing.T) {
 		hostAwait := wait.NewHostAwaitility(s.awaitility)
 
 		mur, err := hostAwait.WaitForMasterUserRecord(janedoeName,
-			wait.UntilMasterUserRecordHasConditions(testsupport.Provisioned(), testsupport.ProvisionedNotificationCRCreated()))
+			wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 		require.NoError(t, err)
 
-		notification, err := hostAwait.WaitForNotification(mur.Name+"-provisioned", wait.UntilNotificationHasConditions(testsupport.Sent()))
+		notification, err := hostAwait.WaitForNotification(mur.Name+"-provisioned", wait.UntilNotificationHasConditions(Sent()))
 		require.NoError(t, err)
 		require.NotNil(t, notification)
 		assert.Equal(t, mur.Name+"-provisioned", notification.Name)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	uuid "github.com/satori/go.uuid"
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var httpClient = testsupport.HttpClient
+var httpClient = HttpClient
 
 func TestRegistrationService(t *testing.T) {
 	suite.Run(t, &registrationServiceTestSuite{})
@@ -37,7 +37,7 @@ type registrationServiceTestSuite struct {
 
 func (s *registrationServiceTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = WaitForDeployments(s.T(), userSignupList)
 	s.namespace = s.awaitility.RegistrationServiceNs
 	s.route = s.awaitility.RegistrationServiceURL
 }
@@ -358,7 +358,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
 
 	// Wait for the UserSignup to be created
-	userSignup, err := s.awaitility.Host().WaitForUserSignup(identity0.ID.String(), wait.UntilUserSignupHasConditions(testsupport.PendingApproval()...))
+	userSignup, err := s.awaitility.Host().WaitForUserSignup(identity0.ID.String(), wait.UntilUserSignupHasConditions(PendingApproval()...))
 	require.NoError(s.T(), err)
 	emailAnnotation := userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
 	assert.Equal(s.T(), emailValue, emailAnnotation)
@@ -396,7 +396,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	require.NoError(s.T(), err)
 
 	// Wait the Master User Record to be provisioned
-	_, err = s.awaitility.Host().WaitForMasterUserRecord(identity0.Username, wait.UntilMasterUserRecordHasConditions(testsupport.Provisioned(), testsupport.ProvisionedNotificationCRCreated()))
+	_, err = s.awaitility.Host().WaitForMasterUserRecord(identity0.Username, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 	require.NoError(s.T(), err)
 
 	// Call signup endpoint with same valid token to check if status changed to Provisioned now
@@ -425,7 +425,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	memberCluster, ok, err := s.awaitility.Host().GetToolchainCluster(cluster.Member, nil)
 	require.NoError(s.T(), err)
 	require.True(s.T(), ok)
-	assert.Equal(s.T(), testsupport.ExpectedConsoleURL(s.T(), s.awaitility.Member(), memberCluster), mp["consoleURL"])
+	assert.Equal(s.T(), ExpectedConsoleURL(s.T(), s.awaitility.Member(), memberCluster), mp["consoleURL"])
 }
 
 func close(t *testing.T, resp *http.Response) {

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
@@ -15,7 +15,7 @@ import (
 
 func TestToolchainClusterE2E(t *testing.T) {
 	toolchainClusterList := &v1alpha1.ToolchainClusterList{}
-	ctx, awaitility := testsupport.WaitForDeployments(t, toolchainClusterList)
+	ctx, awaitility := WaitForDeployments(t, toolchainClusterList)
 	defer ctx.Cleanup()
 
 	verifyToolchainCluster(ctx, awaitility, cluster.Host, awaitility.Member().SingleAwaitility)
@@ -44,7 +44,7 @@ func verifyToolchainCluster(ctx *test.Context, awaitility *wait.Awaitility, tool
 		)
 
 		// when
-		err := awaitility.Client.Create(context.TODO(), toolchainCluster, testsupport.CleanupOptions(ctx))
+		err := awaitility.Client.Create(context.TODO(), toolchainCluster, CleanupOptions(ctx))
 
 		// then the ToolchainCluster should be ready
 		require.NoError(t, err)
@@ -68,7 +68,7 @@ func verifyToolchainCluster(ctx *test.Context, awaitility *wait.Awaitility, tool
 			wait.CapacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
 		// when
-		err := awaitility.Client.Create(context.TODO(), toolchainCluster, testsupport.CleanupOptions(ctx))
+		err := awaitility.Client.Create(context.TODO(), toolchainCluster, CleanupOptions(ctx))
 
 		// then the ToolchainCluster should be offline
 		require.NoError(t, err)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -46,7 +46,7 @@ func (s *userManagementTestSuite) TearDownTest() {
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.setApprovalPolicyConfig("automatic")
-	userSignup, mur := s.createAndCheckUserSignup(true, "iris", "iris@redhat.com", approvedByAdmin()...)
+	userSignup, mur := s.createAndCheckUserSignup(true, "iris", "iris@redhat.com", testsupport.ApprovedByAdmin()...)
 
 	s.T().Run("deactivate a user", func(t *testing.T) {
 		userSignup.Spec.Deactivated = true
@@ -87,7 +87,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(approvedAutomaticallyAndBanned()...))
+			wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomaticallyAndBanned()...))
 		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
@@ -103,7 +103,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.createAndCheckBannedUser(email)
 
 		// Check that no MUR created
-		_ = s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, banned()...)
+		_ = s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, testsupport.Banned()...)
 		mur, err := s.awaitility.Host().GetMasterUserRecord(wait.WithMurName("testuser" + id))
 		require.NoError(s.T(), err)
 		assert.Nil(s.T(), mur)
@@ -158,7 +158,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(approvedAutomaticallyAndBanned()...))
+			wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomaticallyAndBanned()...))
 		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
@@ -176,7 +176,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 			// Confirm the user is provisioned
 			_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-				wait.UntilUserSignupHasConditions(approvedAutomatically()...))
+				wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomatically()...))
 			require.NoError(s.T(), err)
 
 			// Confirm the MUR is created
@@ -190,9 +190,9 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	s.setApprovalPolicyConfig("manual")
 
 	// Create UserSignup
-	userSignup := createAndApproveSignup(s.T(), s.awaitility, "janedoe")
+	userSignup := testsupport.CreateAndApproveSignup(s.T(), s.awaitility, "janedoe")
 
-	verifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
+	testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
 
 	// Get MasterUserRecord
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username)
@@ -206,12 +206,12 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	// Wait until the UserAccount status is disabled
 	userAccount, err := s.memberAwait.WaitForUserAccount(mur.Name,
-		wait.UntilUserAccountHasConditions(disabled()))
+		wait.UntilUserAccountHasConditions(testsupport.Disabled()))
 	require.NoError(s.T(), err)
 
 	// Wait until the MUR status is disabled
 	mur, err = s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username,
-		wait.UntilMasterUserRecordHasConditions(disabled(), provisionedNotificationCRCreated()))
+		wait.UntilMasterUserRecordHasConditions(testsupport.Disabled(), testsupport.ProvisionedNotificationCRCreated()))
 	require.NoError(s.T(), err)
 
 	// Check that the UserAccount is now set to disabled
@@ -225,7 +225,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	// Check the Identity is deleted
 	identity := &userv1.Identity{}
-	err = s.awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: toIdentityName(userAccount.Spec.UserID)}, identity)
+	err = s.awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(userAccount.Spec.UserID)}, identity)
 	require.Error(s.T(), err)
 	assert.True(s.T(), apierros.IsNotFound(err))
 
@@ -236,11 +236,11 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		verifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
+		testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
 	})
 }
 
 func (s *userManagementTestSuite) createUserSignupAndAssertAutoApproval(specApproved bool) (*v1alpha1.UserSignup, *v1alpha1.MasterUserRecord) {
 	id := uuid.NewV4().String()
-	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", approvedAutomatically()...)
+	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", testsupport.ApprovedAutomatically()...)
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -3,17 +3,16 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"testing"
-
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
-	"github.com/codeready-toolchain/toolchain-e2e/wait"
-
 	"io/ioutil"
 	"net/http"
+	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
 	userv1 "github.com/openshift/api/user/v1"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +33,7 @@ type userManagementTestSuite struct {
 
 func (s *userManagementTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = WaitForDeployments(s.T(), userSignupList)
 	s.hostAwait = s.awaitility.Host()
 	s.memberAwait = s.awaitility.Member()
 	s.namespace = s.awaitility.HostNs
@@ -46,7 +45,7 @@ func (s *userManagementTestSuite) TearDownTest() {
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.setApprovalPolicyConfig("automatic")
-	userSignup, mur := s.createAndCheckUserSignup(true, "iris", "iris@redhat.com", testsupport.ApprovedByAdmin()...)
+	userSignup, mur := s.createAndCheckUserSignup(true, "iris", "iris@redhat.com", ApprovedByAdmin()...)
 
 	s.T().Run("deactivate a user", func(t *testing.T) {
 		userSignup.Spec.Deactivated = true
@@ -87,7 +86,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomaticallyAndBanned()...))
+			wait.UntilUserSignupHasConditions(ApprovedAutomaticallyAndBanned()...))
 		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
@@ -103,7 +102,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.createAndCheckBannedUser(email)
 
 		// Check that no MUR created
-		_ = s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, testsupport.Banned()...)
+		_ = s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, Banned()...)
 		mur, err := s.awaitility.Host().GetMasterUserRecord(wait.WithMurName("testuser" + id))
 		require.NoError(s.T(), err)
 		assert.Nil(s.T(), mur)
@@ -158,7 +157,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomaticallyAndBanned()...))
+			wait.UntilUserSignupHasConditions(ApprovedAutomaticallyAndBanned()...))
 		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
@@ -176,7 +175,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 			// Confirm the user is provisioned
 			_, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
-				wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomatically()...))
+				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...))
 			require.NoError(s.T(), err)
 
 			// Confirm the MUR is created
@@ -190,9 +189,9 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	s.setApprovalPolicyConfig("manual")
 
 	// Create UserSignup
-	userSignup := testsupport.CreateAndApproveSignup(s.T(), s.awaitility, "janedoe")
+	userSignup := CreateAndApproveSignup(s.T(), s.awaitility, "janedoe")
 
-	testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
 
 	// Get MasterUserRecord
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username)
@@ -206,12 +205,12 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	// Wait until the UserAccount status is disabled
 	userAccount, err := s.memberAwait.WaitForUserAccount(mur.Name,
-		wait.UntilUserAccountHasConditions(testsupport.Disabled()))
+		wait.UntilUserAccountHasConditions(Disabled()))
 	require.NoError(s.T(), err)
 
 	// Wait until the MUR status is disabled
 	mur, err = s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username,
-		wait.UntilMasterUserRecordHasConditions(testsupport.Disabled(), testsupport.ProvisionedNotificationCRCreated()))
+		wait.UntilMasterUserRecordHasConditions(Disabled(), ProvisionedNotificationCRCreated()))
 	require.NoError(s.T(), err)
 
 	// Check that the UserAccount is now set to disabled
@@ -225,7 +224,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	// Check the Identity is deleted
 	identity := &userv1.Identity{}
-	err = s.awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: testsupport.ToIdentityName(userAccount.Spec.UserID)}, identity)
+	err = s.awaitility.Client.Get(context.TODO(), types.NamespacedName{Name: ToIdentityName(userAccount.Spec.UserID)}, identity)
 	require.Error(s.T(), err)
 	assert.True(s.T(), apierros.IsNotFound(err))
 
@@ -236,11 +235,11 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
+		VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, userSignup, "basic")
 	})
 }
 
 func (s *userManagementTestSuite) createUserSignupAndAssertAutoApproval(specApproved bool) (*v1alpha1.UserSignup, *v1alpha1.MasterUserRecord) {
 	id := uuid.NewV4().String()
-	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", testsupport.ApprovedAutomatically()...)
+	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", ApprovedAutomatically()...)
 }

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
 	uuid "github.com/satori/go.uuid"
@@ -24,7 +24,7 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 
 func (s *userSignupIntegrationTest) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.awaitility = testsupport.WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.awaitility = WaitForDeployments(s.T(), userSignupList)
 	s.hostAwait = s.awaitility.Host()
 	s.namespace = s.awaitility.HostNs
 }
@@ -70,37 +70,37 @@ func (s *userSignupIntegrationTest) TestUserSignupApproval() {
 func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	// Create user signup
 	s.setApprovalPolicyConfig("automatic")
-	userSignup := testsupport.NewUserSignup(s.T(), s.awaitility.Host(), "reginald@alpha.com", "reginald@alpha.com")
+	userSignup := NewUserSignup(s.T(), s.awaitility.Host(), "reginald@alpha.com", "reginald@alpha.com")
 
 	// Remove the specified target cluster
 	userSignup.Spec.TargetCluster = ""
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
 	// Check the UserSignup is approved now
-	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(testsupport.ApprovedAutomatically()...))
+	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ApprovedAutomatically()...))
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {
 	// Create UserSignup with a username that we don't need to transform
-	userSignup, _ := s.createAndCheckUserSignup(true, "paul-no-need-to-transform", "paulnoneedtotransform@hotel.com", testsupport.ApprovedByAdmin()...)
+	userSignup, _ := s.createAndCheckUserSignup(true, "paul-no-need-to-transform", "paulnoneedtotransform@hotel.com", ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-no-need-to-transform", userSignup.Status.CompliantUsername)
 
 	// Create UserSignup with a username to transform
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", testsupport.ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the original username matching the transformed username of the existing signup
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul", "paulathotel@hotel.com", testsupport.ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul", "paulathotel@hotel.com", ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-2", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the same original username but different user ID
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", testsupport.ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-3", userSignup.Status.CompliantUsername)
 }
 
@@ -108,14 +108,14 @@ func (s *userSignupIntegrationTest) createUserSignupAndAssertPendingApproval() *
 	// Create a new UserSignup with approved flag set to false
 	username := "testuser" + uuid.NewV4().String()
 	email := username + "@test.com"
-	userSignup := testsupport.NewUserSignup(s.T(), s.awaitility.Host(), username, email)
+	userSignup := NewUserSignup(s.T(), s.awaitility.Host(), username, email)
 
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, testsupport.CleanupOptions(s.ctx))
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
 	// Check the UserSignup is pending approval now
-	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(testsupport.PendingApproval()...))
+	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(PendingApproval()...))
 	require.NoError(s.T(), err)
 
 	// Confirm the CompliantUsername has NOT been set
@@ -129,12 +129,12 @@ func (s *userSignupIntegrationTest) createUserSignupAndAssertPendingApproval() *
 
 func (s *userSignupIntegrationTest) createUserSignupAndAssertManualApproval(specApproved bool) (*v1alpha1.UserSignup, *v1alpha1.MasterUserRecord) {
 	id := uuid.NewV4().String()
-	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", testsupport.ApprovedByAdmin()...)
+	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", ApprovedByAdmin()...)
 }
 
 func (s *userSignupIntegrationTest) createUserSignupAndAssertAutoApproval(specApproved bool) (*v1alpha1.UserSignup, *v1alpha1.MasterUserRecord) {
 	id := uuid.NewV4().String()
-	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", testsupport.ApprovedAutomatically()...)
+	return s.createAndCheckUserSignup(specApproved, "testuser"+id, "testuser"+id+"@test.com", ApprovedAutomatically()...)
 }
 
 func (s *userSignupIntegrationTest) checkUserSignupManualApproval() {
@@ -148,11 +148,11 @@ func (s *userSignupIntegrationTest) checkUserSignupManualApproval() {
 		require.NoError(s.T(), err)
 
 		// Check the UserSignup is approved now
-		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(testsupport.ApprovedByAdmin()...))
+		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
 		require.NoError(s.T(), err)
 
 		// Confirm the MUR was created
-		testsupport.VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
+		VerifyResourcesProvisionedForSignup(s.T(), s.awaitility, *userSignup, "basic")
 	})
 
 	s.T().Run("usersignup created with approved set to true", func(t *testing.T) {

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -1,4 +1,4 @@
-package e2e
+package testsupport
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func provisioned() toolchainv1alpha1.Condition {
+func Provisioned() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
 		Status: corev1.ConditionTrue,
@@ -14,7 +14,7 @@ func provisioned() toolchainv1alpha1.Condition {
 	}
 }
 
-func pendingApproval() []toolchainv1alpha1.Condition {
+func PendingApproval() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
@@ -29,7 +29,7 @@ func pendingApproval() []toolchainv1alpha1.Condition {
 	}
 }
 
-func approvedByAdmin() []toolchainv1alpha1.Condition {
+func ApprovedByAdmin() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
@@ -43,7 +43,7 @@ func approvedByAdmin() []toolchainv1alpha1.Condition {
 	}
 }
 
-func approvedAutomatically() []toolchainv1alpha1.Condition {
+func ApprovedAutomatically() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
@@ -57,7 +57,7 @@ func approvedAutomatically() []toolchainv1alpha1.Condition {
 	}
 }
 
-func approvedAutomaticallyAndBanned() []toolchainv1alpha1.Condition {
+func ApprovedAutomaticallyAndBanned() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
@@ -72,7 +72,7 @@ func approvedAutomaticallyAndBanned() []toolchainv1alpha1.Condition {
 	}
 }
 
-func banned() []toolchainv1alpha1.Condition {
+func Banned() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupComplete,
@@ -82,7 +82,7 @@ func banned() []toolchainv1alpha1.Condition {
 	}
 }
 
-func disabled() toolchainv1alpha1.Condition {
+func Disabled() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
 		Status: corev1.ConditionFalse,
@@ -90,7 +90,7 @@ func disabled() toolchainv1alpha1.Condition {
 	}
 }
 
-func provisionedNotificationCRCreated() toolchainv1alpha1.Condition {
+func ProvisionedNotificationCRCreated() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
 		Status: corev1.ConditionTrue,
@@ -98,7 +98,7 @@ func provisionedNotificationCRCreated() toolchainv1alpha1.Condition {
 	}
 }
 
-func sent() toolchainv1alpha1.Condition {
+func Sent() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.NotificationSent,
 		Status: corev1.ConditionTrue,
@@ -106,7 +106,7 @@ func sent() toolchainv1alpha1.Condition {
 	}
 }
 
-func toolchainStatusReady() toolchainv1alpha1.Condition {
+func ToolchainStatusReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
 		Status: corev1.ConditionTrue,

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -1,0 +1,19 @@
+package testsupport
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	"github.com/stretchr/testify/require"
+)
+
+func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
+	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(ToolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for MemberStatus")
+}
+
+func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
+	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for ToolchainStatus")
+}

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -1,0 +1,149 @@
+package testsupport
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-e2e/tiers"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func VerifyMultipleSignups(t *testing.T, awaitility *wait.Awaitility, signups []toolchainv1alpha1.UserSignup) {
+	for _, signup := range signups {
+		VerifyResourcesProvisionedForSignup(t, awaitility, signup, "basic")
+	}
+}
+
+func VerifyResourcesProvisionedForSignup(t *testing.T, awaitility *wait.Awaitility, signup toolchainv1alpha1.UserSignup, tier string) {
+	hostAwait := wait.NewHostAwaitility(awaitility)
+	memberAwait := wait.NewMemberAwaitility(awaitility)
+	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
+	// Get the latest signup version
+	userSignup, err := awaitility.Host().WaitForUserSignup(signup.Name)
+	require.NoError(t, err)
+
+	// First, wait for the MasterUserRecord to exist, no matter what status
+	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
+	require.NoError(t, err)
+
+	// Then wait for the associated UserAccount to be provisioned
+	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
+		wait.UntilUserAccountHasConditions(Provisioned()),
+		wait.UntilUserAccountHasSpec(ExpectedUserAccount(userSignup.Name, tier, templateRefs)),
+		wait.UntilUserAccountMatchesMur(hostAwait))
+	require.NoError(t, err)
+	require.NotNil(t, userAccount)
+
+	// Verify provisioned User
+	_, err = memberAwait.WaitForUser(userAccount.Name)
+	assert.NoError(t, err)
+
+	// Verify provisioned Identity
+	_, err = memberAwait.WaitForIdentity(ToIdentityName(userAccount.Spec.UserID))
+	assert.NoError(t, err)
+
+	tiers.VerifyNsTemplateSet(t, awaitility, userAccount, tier)
+
+	// Get member cluster to verify that it was used to provision user accounts
+	memberCluster, ok, err := hostAwait.GetToolchainCluster(cluster.Member, nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Then finally check again the MasterUserRecord with the expected (embedded) UserAccount status, on top of the other criteria
+	expectedEmbeddedUaStatus := toolchainv1alpha1.UserAccountStatusEmbedded{
+		Cluster: toolchainv1alpha1.Cluster{
+			Name:        mur.Spec.UserAccounts[0].TargetCluster,
+			APIEndpoint: memberCluster.Spec.APIEndpoint,
+			ConsoleURL:  ExpectedConsoleURL(t, memberAwait, memberCluster),
+		},
+		UserAccountStatus: userAccount.Status,
+	}
+	_, err = hostAwait.WaitForMasterUserRecord(mur.Name,
+		wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()),
+		wait.UntilMasterUserRecordHasUserAccountStatuses(expectedEmbeddedUaStatus))
+	assert.NoError(t, err)
+}
+
+func ExpectedUserAccount(userID string, tier string, templateRefs tiers.TemplateRefs) v1alpha1.UserAccountSpec {
+	namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, 0, len(templateRefs.Namespaces))
+	for _, ref := range templateRefs.Namespaces {
+		namespaces = append(namespaces, toolchainv1alpha1.NSTemplateSetNamespace{
+			Template:    "", // must be empty
+			TemplateRef: ref,
+		})
+	}
+	var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
+	if templateRefs.ClusterResources != nil {
+		clusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+			TemplateRef: tier + "-" + "clusterresources" + "-" + *templateRefs.ClusterResources,
+		}
+	}
+	return v1alpha1.UserAccountSpec{
+		UserID:   userID,
+		Disabled: false,
+		UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
+			NSLimit: "default",
+			NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
+				TierName:         tier,
+				Namespaces:       namespaces,
+				ClusterResources: clusterResources,
+			},
+		},
+	}
+}
+
+func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
+	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(ToolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for MemberStatus")
+}
+
+func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
+	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
+	require.NoError(t, err, "failed while waiting for ToolchainStatus")
+}
+
+func ExpectedConsoleURL(t *testing.T, memberAwait *wait.MemberAwaitility, cluster toolchainv1alpha1.ToolchainCluster) string {
+	// If OpenShift 3.x console available then we expect its URL in the status
+	consoleURL := openShift3XConsoleURL(cluster.Spec.APIEndpoint)
+	if consoleURL == "" {
+		// Expect OpenShift 4.x console URL
+		route, err := memberAwait.GetConsoleRoute()
+		require.NoError(t, err)
+		consoleURL = fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
+	}
+	return consoleURL
+}
+
+// openShift3XConsoleURL checks if <apiEndpoint>/console URL is reachable.
+// This URL is used by web console in OpenShift 3.x
+func openShift3XConsoleURL(apiEndpoint string) string {
+	client := http.Client{
+		Timeout: time.Duration(1 * time.Second),
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	url := fmt.Sprintf("%s/console", apiEndpoint)
+	resp, err := client.Get(url)
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		_, _ = ioutil.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	return url
+}

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -102,16 +102,6 @@ func ExpectedUserAccount(userID string, tier string, templateRefs tiers.Template
 	}
 }
 
-func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	_, err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(ToolchainStatusReady()))
-	require.NoError(t, err, "failed while waiting for MemberStatus")
-}
-
-func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
-	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
-	require.NoError(t, err, "failed while waiting for ToolchainStatus")
-}
-
 func ExpectedConsoleURL(t *testing.T, memberAwait *wait.MemberAwaitility, cluster toolchainv1alpha1.ToolchainCluster) string {
 	// If OpenShift 3.x console available then we expect its URL in the status
 	consoleURL := openShift3XConsoleURL(cluster.Spec.APIEndpoint)

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -1,0 +1,117 @@
+package testsupport
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateMultipleSignups(t *testing.T, ctx *framework.Context, awaitility *wait.Awaitility, capacity int) []toolchainv1alpha1.UserSignup {
+	signups := make([]toolchainv1alpha1.UserSignup, capacity)
+	for i := 0; i < capacity; i++ {
+		// Create an approved UserSignup resource
+		userSignup := NewUserSignup(t, awaitility.Host(), fmt.Sprintf("multiple-signup-testuser-%d", i), fmt.Sprintf("multiple-signup-testuser-%d@test.com", i))
+		userSignup.Spec.Approved = true
+		err := awaitility.Host().Client.Create(context.TODO(), userSignup, CleanupOptions(ctx))
+		awaitility.T.Logf("created usersignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)
+		require.NoError(t, err)
+		signups[i] = *userSignup
+	}
+	return signups
+}
+
+func CreateAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username string) toolchainv1alpha1.UserSignup {
+	// 1. Create a UserSignup resource via calling registration service
+	identity := &authsupport.Identity{
+		ID:       uuid.NewV4(),
+		Username: username,
+	}
+	postSignup(t, awaitility.RegistrationServiceURL, *identity)
+
+	// at this stage, the usersignup should not be approved nor completed
+	userSignup, err := awaitility.Host().WaitForUserSignup(identity.ID.String(), wait.UntilUserSignupHasConditions(PendingApproval()...))
+	require.NoError(t, err)
+	require.Equal(t, userSignup.Spec.GivenName, identity.Username+"-First-Name")
+	require.Equal(t, userSignup.Spec.FamilyName, identity.Username+"-Last-Name")
+	require.Equal(t, userSignup.Spec.Company, identity.Username+"-Company-Name")
+
+	// 2. approve the UserSignup
+	userSignup.Spec.Approved = true
+	err = awaitility.Host().Client.Update(context.TODO(), userSignup)
+	require.NoError(t, err)
+	// Check the updated conditions
+	_, err = awaitility.Host().WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
+	require.NoError(t, err)
+
+	return *userSignup
+}
+
+func NewUserSignup(t *testing.T, host *wait.HostAwaitility, username string, email string) *toolchainv1alpha1.UserSignup {
+	memberCluster, ok, err := host.GetToolchainCluster(cluster.Member, wait.ReadyToolchainCluster)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	return &toolchainv1alpha1.UserSignup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      uuid.NewV4().String(),
+			Namespace: host.Ns,
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: email,
+			},
+			Labels: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: md5.CalcMd5(email),
+			},
+		},
+		Spec: toolchainv1alpha1.UserSignupSpec{
+			Username:      username,
+			TargetCluster: memberCluster.Name,
+		},
+	}
+}
+
+var HttpClient = &http.Client{
+	Timeout: time.Second * 10,
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	},
+}
+
+func postSignup(t *testing.T, route string, identity authsupport.Identity) {
+	// Call signup endpoint with a valid token.
+	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	givenNameClaim := authsupport.WithGivenNameClaim(identity.Username + "-First-Name")
+	familyNameClaim := authsupport.WithFamilyNameClaim(identity.Username + "-Last-Name")
+	companyClaim := authsupport.WithCompanyClaim(identity.Username + "-Company-Name")
+	iatClaim := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
+	token, err := authsupport.GenerateSignedE2ETestToken(identity, emailClaim, companyClaim, givenNameClaim, familyNameClaim, iatClaim)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", route+"/api/v1/signup", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("content-type", "application/json")
+	client := HttpClient
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+}
+
+func ToIdentityName(userID string) string {
+	return fmt.Sprintf("%s:%s", "rhd", userID)
+}


### PR DESCRIPTION
Moved the setup and assertions funcs in `testsupport` so we can later introduce a `test/perf` package and reuse the funcs.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
