### PR TITLE
verify that 'host-operator-metrics' exists

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,6 +33,14 @@ func TestE2EFlow(t *testing.T) {
 		})
 	})
 
+	// host metrics should be available at this point
+	t.Run("verify metrics servers", func(t *testing.T) {
+
+		t.Run("verify host metrics server", func(t *testing.T) {
+			VerifyHostMetricsService(t, awaitility.Host())
+		})
+	})
+
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
 	signups := CreateMultipleSignups(t, ctx, awaitility, 5)

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -1,0 +1,15 @@
+package testsupport
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// VerifyHostMetricsService verifies that there is a service called `host-operator-metrics`
+// in the host namespace.
+func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
+	_, err := hostAwait.WaitForMetricsService()
+	require.NoError(t, err, "failed while waiting for 'host-operator-metrics' service")
+}

--- a/wait/host.go
+++ b/wait/host.go
@@ -554,7 +554,7 @@ func (a *HostAwaitility) WaitForMetricsService() (corev1.Service, error) {
 	var metricsSvc *corev1.Service
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		metricsSvc = &corev1.Service{}
-		// retrieve the toolchainstatus from the host namespace
+		// retrieve the metrics service from the namespace
 		err = a.Client.Get(context.TODO(),
 			types.NamespacedName{
 				Namespace: a.Ns,


### PR DESCRIPTION
check that there is a service called 'host-operator-metrics'
in the host operator namespace.

see https://github.com/codeready-toolchain/host-operator/pull/262

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>