### PR TITLE
verify that 'member-operator-metrics' exists

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,6 +39,10 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("verify host metrics server", func(t *testing.T) {
 			VerifyHostMetricsService(t, awaitility.Host())
 		})
+
+		t.Run("verify member metrics server", func(t *testing.T) {
+			VerifyMemberMetricsService(t, awaitility.Member())
+		})
 	})
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -13,3 +13,10 @@ func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
 	_, err := hostAwait.WaitForMetricsService()
 	require.NoError(t, err, "failed while waiting for 'host-operator-metrics' service")
 }
+
+// VerifyMemberMetricsService verifies that there is a service called `member-operator-metrics`
+// in the host namespace.
+func VerifyMemberMetricsService(t *testing.T, memberAwait *wait.MemberAwaitility) {
+	_, err := memberAwait.WaitForMetricsService()
+	require.NoError(t, err, "failed while waiting for 'host-operator-metrics' service")
+}

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -18,5 +18,5 @@ func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
 // in the member namespace.
 func VerifyMemberMetricsService(t *testing.T, memberAwait *wait.MemberAwaitility) {
 	_, err := memberAwait.WaitForMetricsService()
-	require.NoError(t, err, "failed while waiting for 'host-operator-metrics' service")
+	require.NoError(t, err, "failed while waiting for 'member-operator-metrics' service")
 }

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -15,7 +15,7 @@ func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
 }
 
 // VerifyMemberMetricsService verifies that there is a service called `member-operator-metrics`
-// in the host namespace.
+// in the member namespace.
 func VerifyMemberMetricsService(t *testing.T, memberAwait *wait.MemberAwaitility) {
 	_, err := memberAwait.WaitForMetricsService()
 	require.NoError(t, err, "failed while waiting for 'host-operator-metrics' service")

--- a/wait/member.go
+++ b/wait/member.go
@@ -572,7 +572,7 @@ func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCrite
 	return memberStatus, err
 }
 
-// WaitForMetricsService waits until there's a service called `host-operator-metrics` in the host
+// WaitForMetricsService waits until there's a service called `member-operator-metrics` in the host
 // operator namespace
 func (a *MemberAwaitility) WaitForMetricsService() (corev1.Service, error) {
 	name := "member-operator-metrics"

--- a/wait/member.go
+++ b/wait/member.go
@@ -572,7 +572,7 @@ func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCrite
 	return memberStatus, err
 }
 
-// WaitForMetricsService waits until there's a service called `member-operator-metrics` in the host
+// WaitForMetricsService waits until there's a service called `member-operator-metrics` in the member
 // operator namespace
 func (a *MemberAwaitility) WaitForMetricsService() (corev1.Service, error) {
 	name := "member-operator-metrics"


### PR DESCRIPTION
E2E tests for https://github.com/codeready-toolchain/member-operator/pull/188

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
