### PR TITLE
WIP - fix: user account deleted but not recreated

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -197,4 +197,17 @@ func TestE2EFlow(t *testing.T) {
 		// Now when the main flow has been tested we can verify the signups we created in the very beginning
 		VerifyMultipleSignups(t, awaitility, signups)
 	})
+
+	t.Run("delete useraccount and expect recreation", func(t *testing.T) {
+		// given
+		memberAwait := wait.NewMemberAwaitility(awaitility)
+
+		// when deleting the user account
+		err := memberAwait.DeleteUserAccount(johnSignup.Status.CompliantUsername)
+
+		// then the user account should be recreated
+		require.NoError(t, err)
+		_, err = memberAwait.WaitForUserAccount(johnSignup.Status.CompliantUsername)
+		require.NoError(t, err)
+	})
 }

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -54,7 +54,7 @@ func CreateAndApproveSignup(t *testing.T, awaitility *wait.Awaitility, username 
 	err = awaitility.Host().Client.Update(context.TODO(), userSignup)
 	require.NoError(t, err)
 	// Check the updated conditions
-	_, err = awaitility.Host().WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
+	userSignup, err = awaitility.Host().WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
 	require.NoError(t, err)
 
 	return *userSignup

--- a/wait/member.go
+++ b/wait/member.go
@@ -598,3 +598,17 @@ func (a *MemberAwaitility) WaitForMetricsService() (corev1.Service, error) {
 	})
 	return *metricsSvc, err
 }
+
+// DeleteUserAccount deletes the user account resource with the given name and
+// waits until it was actually deleted
+func (a *MemberAwaitility) DeleteUserAccount(name string) error {
+	ua, err := a.WaitForUserAccount(name)
+	if err != nil {
+		return err
+	}
+	if err = a.Client.Delete(context.TODO(), ua); err != nil {
+		return err
+	}
+	return a.WaitUntilUserAccountDeleted(name)
+
+}


### PR DESCRIPTION
Note: may need some rework: the test verifies that the UserAccount was deleted and then waits for the UserAccount to exist again. However, there may be some race conditions (if the UserAccount is recreated too quickly, the test will fail while waiting for its deletion). Instead, we may want to check that the resource's UID changed.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
