### PR TITLE
perf: write results in a file in ARTIFCAT_DIR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200827095351-b2cb9e622a9a
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
+	github.com/go-logr/logr v0.1.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible

--- a/make/perf.mk
+++ b/make/perf.mk
@@ -15,5 +15,5 @@ perf-run:
 	oc get toolchaincluster -n $(HOST_NS)
 	oc get toolchaincluster -n $(MEMBER_NS)
 	-oc new-project $(TEST_NS) --display-name perf-tests 1>/dev/null
-	MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/perf --no-setup --operator-namespace $(TEST_NS) --verbose --go-test-flags "-timeout=60m -failfast" || \
+	ARTIFACT_DIR=${ARTIFACT_DIR} MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/perf --no-setup --operator-namespace $(TEST_NS) --verbose --go-test-flags "-timeout=60m -failfast" || \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -2,20 +2,29 @@ package perf
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	. "github.com/codeready-toolchain/toolchain-e2e/wait"
+	"github.com/go-logr/logr"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestPerformance(t *testing.T) {
 	// given
+	logger, out, err := initLogger()
+	require.NoError(t, err)
+	defer out.Close()
+
 	ctx, awaitility := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
 	defer ctx.Cleanup()
 
@@ -23,7 +32,7 @@ func TestPerformance(t *testing.T) {
 	metricsService, err := awaitility.Host().WaitForMetricsService("host-operator-metrics")
 	require.NoError(t, err, "failed while waiting for the 'host-operator-metrics' service")
 
-	count := 1000
+	count := 10
 	t.Run(fmt.Sprintf("%d users", count), func(t *testing.T) {
 		// given
 		users := CreateMultipleSignups(t, ctx, awaitility, count)
@@ -51,7 +60,38 @@ func TestPerformance(t *testing.T) {
 		err = host.WaitUntilMetricsCounterHasValue(metricsRoute.Status.Ingress[0].Host, "workqueue_depth", "name", "usersignup-controller", 0)
 		assert.NoError(t, err, "failed to reach the expected queue depth")
 		end := time.Now()
-		fmt.Printf("time to process the resource: %dms\n", end.Sub(start).Milliseconds())
+		logger.Info("done processing resources", "count", count, "duration (ms)", end.Sub(start).Milliseconds())
 	})
 
+}
+
+// initLogger initializes a logger which will write to `$(ARTIFACT_DIR)/perf-<YYYYMMDD-HHmmSS>.log` or `./tmp/perf-<YYYYMMDD-HHmmSS>.log` if no `ARTIFACT_DIR`
+// env var is defined.
+// Notes:
+// - the target directory will be created on-the-fly if needed
+// - it's up to the caller to close the returned file at the end of the tests
+func initLogger() (logr.Logger, *os.File, error) {
+	// log messages that need to be retained after the OpenShift CI job completion must be written in a file located in `${ARTIFACT_DIR}` to
+	var artifactDir string
+	if artifactDir = os.Getenv("ARTIFACT_DIR"); artifactDir == "" {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return nil, nil, err
+		}
+		artifactDir = filepath.Join(pwd, "tmp")
+	}
+	if _, err := os.Open(artifactDir); os.IsNotExist(err) {
+		// make sure that `./tmp` exists
+		if err = os.MkdirAll(artifactDir, os.ModeDir+os.ModePerm); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	out, err := os.Create(path.Join(artifactDir, fmt.Sprintf("perf-%s.log", time.Now().Format("20060102-030405"))))
+	if err != nil {
+		return nil, nil, err
+	}
+	logger := zap.New(zap.WriteTo(out))
+	fmt.Printf("configured logger to write messages in '%s'\n", out.Name())
+	return logger, out, nil
 }

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -32,7 +32,7 @@ func TestPerformance(t *testing.T) {
 	metricsService, err := awaitility.Host().WaitForMetricsService("host-operator-metrics")
 	require.NoError(t, err, "failed while waiting for the 'host-operator-metrics' service")
 
-	count := 10
+	count := 1000
 	t.Run(fmt.Sprintf("%d users", count), func(t *testing.T) {
 		// given
 		users := CreateMultipleSignups(t, ctx, awaitility, count)
@@ -71,7 +71,7 @@ func TestPerformance(t *testing.T) {
 // - the target directory will be created on-the-fly if needed
 // - it's up to the caller to close the returned file at the end of the tests
 func initLogger() (logr.Logger, *os.File, error) {
-	// log messages that need to be retained after the OpenShift CI job completion must be written in a file located in `${ARTIFACT_DIR}` to
+	// log messages that need to be retained after the OpenShift CI job completion must be written in a file located in `${ARTIFACT_DIR}`
 	var artifactDir string
 	if artifactDir = os.Getenv("ARTIFACT_DIR"); artifactDir == "" {
 		pwd, err := os.Getwd()


### PR DESCRIPTION
messages written in `stdout` are not retained after the job
completions on OpenShift CI, so we need to write the results
in a file in `$(ARTIFACT_DIR)`

Fixes https://issues.redhat.com/browse/CRT-799

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
