### PR TITLE
chore: verify resource usage in MemberStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386
+	github.com/codeready-toolchain/api v0.0.0-20200909214235-3b03e49dd74a
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a h1:bkbQYgp
 github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386 h1:VRSALNcztJg+/bBr4QTTCLMgwnpq+UPpa+QA5kk8jUw=
 github.com/codeready-toolchain/api v0.0.0-20200907133933-475266b2a386/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/codeready-toolchain/api v0.0.0-20200909214235-3b03e49dd74a h1:tm3fcwAjV8SaWpN4+Gw6Ac14mZ2XEqHIv7QafYYxSsU=
+github.com/codeready-toolchain/api v0.0.0-20200909214235-3b03e49dd74a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886 h1:q+oeKCBgOij4NeO12YizGPOU/PNXPWNP39T8qXzOXzM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -14,6 +14,6 @@ func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
 }
 
 func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
-	err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()), wait.UntilAllMembersHaveUsageSet())
+	err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -9,11 +9,11 @@ import (
 )
 
 func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(ToolchainStatusReady()))
+	err := memberAwait.WaitForMemberStatus(wait.UntilMemberStatusHasConditions(ToolchainStatusReady()), wait.UntilMemberStatusHasUsageSet())
 	require.NoError(t, err, "failed while waiting for MemberStatus")
 }
 
 func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
-	err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
+	err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()), wait.UntilAllMembersHaveUsageSet())
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }

--- a/wait/host.go
+++ b/wait/host.go
@@ -535,6 +535,19 @@ func UntilToolchainStatusHasConditions(conditions ...toolchainv1alpha1.Condition
 	}
 }
 
+// UntilAllMembersHaveUsageSet returns a `ToolchainStatusWaitCriterion` which checks that the given
+// ToolchainStatus has all members with some non-zero resource usage
+func UntilAllMembersHaveUsageSet() ToolchainStatusWaitCriterion {
+	return func(a *HostAwaitility, toolchainStatus *toolchainv1alpha1.ToolchainStatus) bool {
+		for _, member := range toolchainStatus.Status.Members {
+			if !hasMemberStatusUsageSet(a.T, member.ClusterName, member.MemberStatus) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // WaitForToolchainStatus waits until the ToolchainStatus is available with the provided criteria, if any
 func (a *HostAwaitility) WaitForToolchainStatus(criteria ...ToolchainStatusWaitCriterion) error {
 	// there should only be one toolchain status with the name toolchain-status


### PR DESCRIPTION
Verifies that resource usage is set in `MemberStatus` CR - the propagation to `ToolchainStatus` CR will be verified later when the necessary changes are applied to `ToolchainStatus` controller.

paired with https://github.com/codeready-toolchain/member-operator/pull/198