### PR TITLE
Add auto deactivation test

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -80,18 +80,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		mur := MoveUserToTier(t, hostAwait, userSignup.Spec.Username, *deactivationTier)
 
-		err := s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: mur.Namespace,
-			Name:      mur.Name,
-		}, mur)
-		require.NoError(s.T(), err)
-
 		// We cannot wait days for deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time to a time far enough
 		// in the past to trigger auto deactivation. Subtracting the tier deactivation period from the current time and setting this as the provisioned
 		// time should cause the deactivation controller to reconcile and see the mur is ready for deactivation.
 		tierDeactivationDuration := time.Duration(tierDeactivationPeriod*24) * time.Hour
 		mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-		err = s.hostAwait.Client.Status().Update(context.TODO(), mur)
+		err := s.hostAwait.Client.Status().Update(context.TODO(), mur)
 		require.NoError(s.T(), err)
 		s.T().Logf("masteruserrecord '%s' provisioned time adjusted", mur.Name)
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -52,6 +52,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		err = s.hostAwait.WaitUntilMasterUserRecordDeleted(mur.Name)
 		require.NoError(s.T(), err)
+
+		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasConditions(Deactivated()...))
+		require.NoError(s.T(), err)
+		require.True(t, userSignup.Spec.Deactivated, "usersignup should be deactivated")
 	})
 
 	s.T().Run("reactivate a deactivated user", func(t *testing.T) {
@@ -68,6 +73,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		_, err = s.hostAwait.WaitForMasterUserRecord(mur.Name)
 		require.NoError(s.T(), err)
+
+		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasConditions(ApprovedAutomatically()...))
+		require.NoError(s.T(), err)
+		require.False(t, userSignup.Spec.Deactivated, "usersignup should not be deactivated")
 	})
 
 	s.T().Run("check that auto deactivation deactivates a user", func(t *testing.T) {
@@ -91,6 +101,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		err = s.hostAwait.WaitUntilMasterUserRecordDeleted(mur.Name)
 		require.NoError(s.T(), err)
+
+		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasConditions(Deactivated()...))
+		require.NoError(s.T(), err)
+		require.True(t, userSignup.Spec.Deactivated, "usersignup should be deactivated")
 	})
 }
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -75,7 +75,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 
 		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(ApprovedAutomatically()...))
+			wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
 		require.NoError(s.T(), err)
 		require.False(t, userSignup.Spec.Deactivated, "usersignup should not be deactivated")
 	})

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -128,3 +128,18 @@ func ToolchainStatusReady() toolchainv1alpha1.Condition {
 		Reason: "AllComponentsReady",
 	}
 }
+
+func Deactivated() []toolchainv1alpha1.Condition {
+	return []toolchainv1alpha1.Condition{
+		{
+			Type:   toolchainv1alpha1.UserSignupApproved,
+			Status: corev1.ConditionTrue,
+			Reason: "ApprovedAutomatically",
+		},
+		{
+			Type:   toolchainv1alpha1.UserSignupComplete,
+			Status: corev1.ConditionTrue,
+			Reason: toolchainv1alpha1.UserSignupUserDeactivatedReason,
+		},
+	}
+}

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -134,7 +134,7 @@ func Deactivated() []toolchainv1alpha1.Condition {
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
 			Status: corev1.ConditionTrue,
-			Reason: "ApprovedAutomatically",
+			Reason: toolchainv1alpha1.UserSignupApprovedByAdminReason,
 		},
 		{
 			Type:   toolchainv1alpha1.UserSignupComplete,

--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -1,0 +1,99 @@
+package testsupport
+
+import (
+	"context"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	. "github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TierModifier func(tier *toolchainv1alpha1.NSTemplateTier) error
+
+var toBeComplete = toolchainv1alpha1.Condition{
+	Type:   toolchainv1alpha1.ChangeTierRequestComplete,
+	Status: corev1.ConditionTrue,
+	Reason: toolchainv1alpha1.ChangeTierRequestChangedReason,
+}
+
+func CreateNSTemplateTier(t *testing.T, ctx *test.Context, hostAwait *HostAwaitility, tierName string, modifiers ...TierModifier) *toolchainv1alpha1.NSTemplateTier {
+	// We'll use the `basic` tier as a source of inspiration.
+	_, err := hostAwait.WaitForNSTemplateTier("basic",
+		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-code-000000a"))),
+		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-dev-000000a"))),
+		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-stage-000000a"))),
+		UntilNSTemplateTierSpec(Not(HasClusterResourcesTemplateRef("basic-clusterresources-000000a"))),
+	)
+	require.NoError(t, err)
+	basicTier := &toolchainv1alpha1.NSTemplateTier{}
+	err = hostAwait.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: hostAwait.Namespace,
+		Name:      "basic",
+	}, basicTier)
+	require.NoError(t, err)
+
+	// now let's create the new NSTemplateTier with the same templates as the "basic" tier
+	tier := &toolchainv1alpha1.NSTemplateTier{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: basicTier.Namespace,
+			Name:      tierName,
+		},
+		Spec: basicTier.Spec,
+	}
+
+	err = Modify(tier, modifiers...)
+	require.NoError(t, err)
+
+	err = hostAwait.FrameworkClient.Create(context.TODO(), tier, CleanupOptions(ctx))
+	require.NoError(t, err)
+
+	return tier
+}
+
+func MoveUserToTier(t *testing.T, hostAwait *HostAwaitility, username string, tier toolchainv1alpha1.NSTemplateTier) *toolchainv1alpha1.MasterUserRecord {
+	changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, username, tier.Name)
+	err := hostAwait.FrameworkClient.Create(context.TODO(), changeTierRequest, &test.CleanupOptions{})
+	require.NoError(t, err)
+	_, err = hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
+	require.NoError(t, err)
+	mur, err := hostAwait.WaitForMasterUserRecord(username,
+		UntilMasterUserRecordHasCondition(Provisioned())) // ignore other conditions, such as notification sent, etc.
+	require.NoError(t, err)
+	return mur
+}
+
+func NewChangeTierRequest(namespace, murName, tier string) *toolchainv1alpha1.ChangeTierRequest {
+	return &toolchainv1alpha1.ChangeTierRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "changetierrequest-",
+		},
+		Spec: toolchainv1alpha1.ChangeTierRequestSpec{
+			MurName:  murName,
+			TierName: tier,
+		},
+	}
+}
+
+func Modify(tier *toolchainv1alpha1.NSTemplateTier, modifiers ...TierModifier) error {
+	for _, modify := range modifiers {
+		if err := modify(tier); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DeactivationTimeoutDays(timeoutDurationDays int) TierModifier {
+	return func(tier *toolchainv1alpha1.NSTemplateTier) error {
+		tier.Spec.DeactivationTimeoutDays = timeoutDurationDays
+		return nil
+	}
+}


### PR DESCRIPTION
e2e tests for the new auto deactivation controller.

Summary of the changes:
- Refactored some of the code to reuse functions related to creating and manipulating tiers
- Added a new test for verifying that auto deactivation triggers user deactivation

Paired with https://github.com/codeready-toolchain/host-operator/pull/281