### PR TITLE
feat: verify that ToolchainStatus collects resource usages

### DIFF
--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -17,7 +17,7 @@ func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility) {
 }
 
 func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility) {
-	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
+	_, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()), wait.UntilAllMembersHaveUsageSet())
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }
 


### PR DESCRIPTION
verify that ToolchainStatus collects resource usages

paired with: https://github.com/codeready-toolchain/host-operator/pull/285