### PR TITLE
chore: clean resources using testing.T.Cleanup function

### DIFF
--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -44,9 +45,11 @@ func verifyToolchainCluster(t *testing.T, ctx *test.Context, await *wait.Awaitil
 			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
-		defer func() {
-			await.Client.Delete(context.TODO(), toolchainCluster)
-		}()
+		t.Cleanup(func() {
+			if err := await.Client.Delete(context.TODO(), toolchainCluster); err != nil && !errors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+		})
 
 		// when
 		err := await.Client.Create(context.TODO(), toolchainCluster)
@@ -74,9 +77,11 @@ func verifyToolchainCluster(t *testing.T, ctx *test.Context, await *wait.Awaitil
 			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
-		defer func() {
-			await.Client.Delete(context.TODO(), toolchainCluster)
-		}()
+		t.Cleanup(func() {
+			if err := await.Client.Delete(context.TODO(), toolchainCluster); err != nil && !errors.IsNotFound(err) {
+				require.NoError(t, err)
+			}
+		})
 
 		// when
 		err := await.Client.Create(context.TODO(), toolchainCluster)

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -19,6 +19,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -85,6 +86,13 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 
 	err = hostAwait.WaitUntilNotificationDeleted(mur.Name + "-provisioned")
 	require.NoError(t, err)
+
+	// delete the userSignup at the end of the test
+	t.Cleanup(func() {
+		if err := hostAwait.Client.Delete(context.TODO(), userSignup); err != nil && !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+	})
 
 	return *userSignup
 }


### PR DESCRIPTION
The main change is in the `user_setup.go` - it cleans the UserSignup that is created through the registration service - until now, the UserSingups weren't deleted and stayed in the cluster.
