### PR TITLE
Allow tests to still pass when phone verification enabled

### DIFF
--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -114,7 +114,7 @@ func (s *registrationServiceTestSuite) TestAuthConfig() {
 }
 func (s *registrationServiceTestSuite) TestSignupFails() {
 	identity0 := authsupport.NewIdentity()
-	emailClaim0 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	emailClaim0 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@acme.com")
 
 	s.Run("post signup error no token 401 Unauthorized", func() {
 		// Call signup endpoint without a token.
@@ -292,7 +292,7 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 		// Get valid generated token for e2e tests. IAT claim is overriden
 		// to avoid token used before issued error.
 		identity1 := authsupport.NewIdentity()
-		emailClaim1 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+		emailClaim1 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@acme.com")
 		iatClaim1 := authsupport.WithIATClaim(time.Now().Add(-60 * time.Second))
 
 		// Not identical to the token used in POST signup - should return resource not found.
@@ -321,7 +321,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 	// Get valid generated token for e2e tests. IAT claim is overriden
 	// to avoid token used before issued error.
 	identity0 := authsupport.NewIdentity()
-	emailValue := uuid.NewV4().String() + "@email.tld"
+	emailValue := uuid.NewV4().String() + "@acme.com"
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
 	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0)
 	require.NoError(s.T(), err)

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -124,7 +124,7 @@ var HttpClient = &http.Client{
 func postSignup(t *testing.T, route string, identity authsupport.Identity) {
 	require.NotEmpty(t, route)
 	// Call signup endpoint with a valid token.
-	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@email.tld")
+	emailClaim := authsupport.WithEmailClaim(uuid.NewV4().String() + "@acme.com")
 	givenNameClaim := authsupport.WithGivenNameClaim(identity.Username + "-First-Name")
 	familyNameClaim := authsupport.WithFamilyNameClaim(identity.Username + "-Last-Name")
 	companyClaim := authsupport.WithCompanyClaim(identity.Username + "-Company-Name")


### PR DESCRIPTION
This PR accompanies https://github.com/codeready-toolchain/host-operator/pull/293 and contains fixes to the e2e tests to allow them to continue to pass when phone verification is enabled.