### PR TITLE
Tests for idler which doesn't watch all namespaces

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1408,6 +1408,7 @@ k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCk
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
+k8s.io/apiserver v0.18.2 h1:fwKxdTWwwYhxvtjo0UUfX+/fsitsNtfErPNegH2x9ic=
 k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/autoscaler v0.0.0-20190607113959-1b4f1855cb8e/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=
 k8s.io/cli-runtime v0.18.0/go.mod h1:1eXfmBsIJosjn9LjEBUd2WVPoPAY9XGTqTFcPMIBsUQ=

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -116,6 +117,7 @@ func (s *registrationServiceTestSuite) TestAuthConfig() {
 		require.NotNil(s.T(), body)
 	})
 }
+
 func (s *registrationServiceTestSuite) TestSignupFails() {
 	identity0 := authsupport.NewIdentity()
 	emailClaim0 := authsupport.WithEmailClaim(uuid.NewV4().String() + "@acme.com")
@@ -442,7 +444,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Call the signup endpoint
-	invokeEndpoint(s.T(), "POST", s.route + "/api/v1/signup", token0, "", http.StatusAccepted)
+	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token0, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
 	userSignup, err := s.hostAwait.WaitForUserSignup(identity0.ID.String(), wait.UntilUserSignupHasConditions(PendingApproval()...))
@@ -451,7 +453,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	assert.Equal(s.T(), emailValue, emailAnnotation)
 
 	// Call get signup endpoint with a valid token and make sure verificationRequired is true
-	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route + "/api/v1/signup", token0, "", http.StatusOK))
+	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
 	assert.Equal(s.T(), "", mp["compliantUsername"])
 	assert.Equal(s.T(), identity0.Username, mp["username"])
 	require.IsType(s.T(), false, mpStatus["ready"])
@@ -469,7 +471,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.True(s.T(), errors.IsNotFound(err))
 
 	// Initiate the verification process
-	invokeEndpoint(s.T(), "PUT", s.route + "/api/v1/signup/verification", token0,
+	invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", token0,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup
@@ -497,7 +499,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.Equal(s.T(), verificationCode, userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Verify with the correct code
-	invokeEndpoint(s.T(), "GET", s.route + fmt.Sprintf("/api/v1/signup/verification/%s",
+	invokeEndpoint(s.T(), "GET", s.route+fmt.Sprintf("/api/v1/signup/verification/%s",
 		userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]), token0, "", http.StatusOK)
 
 	// Retrieve the updated UserSignup
@@ -513,7 +515,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
-	mp, mpStatus = parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route + "/api/v1/signup", token0, "", http.StatusOK))
+	mp, mpStatus = parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
 	assert.Equal(s.T(), "", mp["compliantUsername"])
 	assert.Equal(s.T(), identity0.Username, mp["username"])
 	require.IsType(s.T(), false, mpStatus["ready"])

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -58,8 +58,7 @@ func (s *userWorkloadsTestSuite) TestIdler() {
 	}
 
 	// Noise pods are still there
-	labels := make(map[string]string)
-	labels["app"] = "idler-hello-openshift"
+	labels := map[string]string{"app": "idler-hello-openshift"}
 	_, err = s.memberAwait.WaitForPods(idlerNoise.Name, labels, len(podsNoise), wait.UntilPodRunning())
 	require.NoError(s.T(), err)
 }

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/wait"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUserWorkloads(t *testing.T) {
+	suite.Run(t, &userWorkloadsTestSuite{})
+}
+
+type userWorkloadsTestSuite struct {
+	baseUserIntegrationTest
+}
+
+func (s *userWorkloadsTestSuite) SetupSuite() {
+	s.ctx, s.hostAwait, s.memberAwait = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
+	s.setApprovalPolicyConfig("automatic")
+}
+
+func (s *userWorkloadsTestSuite) TearDownTest() {
+	s.ctx.Cleanup()
+}
+
+func (s *userWorkloadsTestSuite) TestIdler() {
+	// Provision a user to idle with a short idling timeout
+	s.createAndCheckUserSignup(true, "test-idler", "test-idler@redhat.com", ApprovedByAdmin()...)
+	idler, err := s.memberAwait.WaitForIdler("test-idler-dev")
+	require.NoError(s.T(), err)
+	idler.Spec.TimeoutSeconds = 3
+	err = s.memberAwait.Client.Update(context.TODO(), idler)
+	require.NoError(s.T(), err)
+
+	// Noise
+	s.createAndCheckUserSignup(true, "test-idler-noise", "test-idler-noise@redhat.com", ApprovedByAdmin()...)
+	idlerNoise, err := s.memberAwait.WaitForIdler("test-idler-noise-dev")
+	require.NoError(s.T(), err)
+
+	// Create payloads for both users
+	podsToIdle := s.prepareWorkloads(idler)
+	podsNoise := s.prepareWorkloads(idlerNoise)
+
+	// Wait for the pods to be deleted
+	for _, p := range podsToIdle {
+		err := s.memberAwait.WaitUntilPodDeleted(p.Namespace, p.Name)
+		require.NoError(s.T(), err)
+	}
+
+	// Noise pods are still there
+	labels := make(map[string]string)
+	labels["app"] = "idler-hello-openshift"
+	_, err = s.memberAwait.WaitForPods(idlerNoise.Name, labels, len(podsNoise), wait.UntilPodRunning())
+	require.NoError(s.T(), err)
+}
+
+func (s *userWorkloadsTestSuite) prepareWorkloads(idler *v1alpha1.Idler) []*corev1.Pod {
+	// Create a Deployment with two pods
+	var err error
+	replicas := int32(2)
+	labels := make(map[string]string)
+	labels["app"] = "idler-hello-openshift"
+	require.NoError(s.T(), err)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-deployment", Namespace: idler.Name},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "hello-openshift",
+						Image: "openshift/hello-openshift",
+						Ports: []corev1.ContainerPort{{ContainerPort: 8080}},
+					}},
+				},
+			},
+		},
+	}
+	err = s.memberAwait.Client.Create(context.TODO(), deployment)
+	require.NoError(s.T(), err)
+
+	// Create a standalone Pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "idler-test-pod",
+			Namespace: idler.Name,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "hello-openshift",
+				Image: "openshift/hello-openshift",
+				Ports: []corev1.ContainerPort{{ContainerPort: 8080}},
+			}},
+		},
+	}
+	err = s.memberAwait.Client.Create(context.TODO(), pod)
+	require.NoError(s.T(), err)
+
+	pods, err := s.memberAwait.WaitForPods(idler.Name, labels, 3, wait.UntilPodRunning())
+	require.NoError(s.T(), err)
+
+	return pods
+}

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -67,8 +67,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(idler *v1alpha1.Idler) []*core
 	// Create a Deployment with two pods
 	var err error
 	replicas := int32(2)
-	labels := make(map[string]string)
-	labels["app"] = "idler-hello-openshift"
+	labels := map[string]string{"app": "idler-hello-openshift"}
 	require.NoError(s.T(), err)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-deployment", Namespace: idler.Name},

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -3,16 +3,21 @@ package e2e
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestUserWorkloads(t *testing.T) {
@@ -30,6 +35,27 @@ func (s *userWorkloadsTestSuite) SetupSuite() {
 
 func (s *userWorkloadsTestSuite) TearDownTest() {
 	s.ctx.Cleanup()
+}
+
+var labels = map[string]string{"app": "idler-sleep"}
+
+var podSpec = corev1.PodSpec{
+	Containers: []corev1.Container{{
+		Name:    "sleep",
+		Image:   "busybox",
+		Command: []string{"sleep", "36000"}, // 10 hours
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse("1m"),
+				"memory": resource.MustParse("8Mi"),
+			},
+		},
+	}},
+}
+
+var podTemplateSpec = corev1.PodTemplateSpec{
+	ObjectMeta: metav1.ObjectMeta{Labels: labels},
+	Spec:       podSpec,
 }
 
 func (s *userWorkloadsTestSuite) TestIdler() {
@@ -53,62 +79,167 @@ func (s *userWorkloadsTestSuite) TestIdler() {
 
 	// Wait for the pods to be deleted
 	for _, p := range podsToIdle {
-		err := s.memberAwait.WaitUntilPodDeleted(p.Namespace, p.Name)
+		err := s.memberAwait.WaitUntilPodsDeleted(p.Namespace, wait.PodName(p.Name))
 		require.NoError(s.T(), err)
 	}
 
 	// Noise pods are still there
-	labels := map[string]string{"app": "idler-hello-openshift"}
 	_, err = s.memberAwait.WaitForPods(idlerNoise.Name, labels, len(podsNoise), wait.UntilPodRunning())
+	require.NoError(s.T(), err)
+
+	// Create another pod and make sure it's deleted.
+	// In the tests above the Idler reconcile was triggered after we changed the Idler resource (to set a short timeout).
+	// Now we want to verify that the idler reconcile is triggered without modifying the Idler resource.
+	pod := s.createStandalonePod(idler) // create just one standalone pod. No need to create all possible pod controllers which may own pods.
+	// We can't really make sure that the pod was created first before the idler deletes it.
+	// So, let's just wait for three seconds assuming it will be enough for the API server to create a pod before start waiting for the Pod to be deleted.
+	time.Sleep(3 * time.Second)
+	err = s.memberAwait.WaitUntilPodDeleted(pod.Namespace, pod.Name)
+	require.NoError(s.T(), err)
+
+	// There should not be any pods left in the namespace
+	err = s.memberAwait.WaitUntilPodsDeleted(idler.Name, wait.PodLabels(labels))
 	require.NoError(s.T(), err)
 }
 
 func (s *userWorkloadsTestSuite) prepareWorkloads(idler *v1alpha1.Idler) []*corev1.Pod {
-	// Create a Deployment with two pods
-	var err error
-	replicas := int32(2)
-	labels := map[string]string{"app": "idler-hello-openshift"}
+	s.createStandalonePod(idler)
+	d := s.createDeployment(idler)
+	n := 1 + int(*d.Spec.Replicas) // total number of created pods
+
+	rs := s.createReplicaSet(idler)
+	n = n + int(*rs.Spec.Replicas)
+
+	s.createDaemonSet(idler)
+	nodes := &corev1.NodeList{}
+	err := s.memberAwait.Client.List(context.TODO(), nodes, client.MatchingLabels(map[string]string{"node-role.kubernetes.io/worker": ""}))
 	require.NoError(s.T(), err)
+	n = n + len(nodes.Items) // DeamonSet creates N pods where N is the number of worker nodes in the cluster
+
+	s.createJob(idler)
+	n++
+
+	dc := s.createDeploymentConfig(idler)
+	n = n + int(dc.Spec.Replicas)
+
+	rc := s.createReplicationController(idler)
+	n = n + int(*rc.Spec.Replicas)
+
+	pods, err := s.memberAwait.WaitForPods(idler.Name, labels, n, wait.UntilPodRunning())
+	require.NoError(s.T(), err)
+	return pods
+}
+
+func (s *userWorkloadsTestSuite) createDeployment(idler *v1alpha1.Idler) *appsv1.Deployment {
+	// Create a Deployment with two pods
+	replicas := int32(2)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-deployment", Namespace: idler.Name},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Replicas: &replicas,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "hello-openshift",
-						Image: "openshift/hello-openshift",
-						Ports: []corev1.ContainerPort{{ContainerPort: 8080}},
-					}},
-				},
-			},
+			Template: podTemplateSpec,
 		},
 	}
-	err = s.memberAwait.Client.Create(context.TODO(), deployment)
+	err := s.memberAwait.Client.Create(context.TODO(), deployment)
 	require.NoError(s.T(), err)
 
-	// Create a standalone Pod
+	return deployment
+}
+
+func (s *userWorkloadsTestSuite) createReplicaSet(idler *v1alpha1.Idler) *appsv1.ReplicaSet {
+	// Standalone ReplicaSet
+	replicas := int32(2)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-replicaset", Namespace: idler.Name},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Replicas: &replicas,
+			Template: podTemplateSpec,
+		},
+	}
+	err := s.memberAwait.Client.Create(context.TODO(), rs)
+	require.NoError(s.T(), err)
+
+	return rs
+}
+
+func (s *userWorkloadsTestSuite) createDaemonSet(idler *v1alpha1.Idler) *appsv1.DaemonSet {
+	// Standalone ReplicaSet
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-daemonset", Namespace: idler.Name},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: podTemplateSpec,
+		},
+	}
+	err := s.memberAwait.Client.Create(context.TODO(), ds)
+	require.NoError(s.T(), err)
+
+	return ds
+}
+
+func (s *userWorkloadsTestSuite) createJob(idler *v1alpha1.Idler) *batchv1.Job {
+	// Job
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-job", Namespace: idler.Name},
+		Spec: batchv1.JobSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: podTemplateSpec,
+		},
+	}
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	err := s.memberAwait.Client.Create(context.TODO(), job)
+	require.NoError(s.T(), err)
+
+	return job
+}
+
+func (s *userWorkloadsTestSuite) createDeploymentConfig(idler *v1alpha1.Idler) *openshiftappsv1.DeploymentConfig {
+	// Create a Deployment with two pods
+	replicas := int32(2)
+	dc := &openshiftappsv1.DeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-dc", Namespace: idler.Name},
+		Spec: openshiftappsv1.DeploymentConfigSpec{
+			Selector: labels,
+			Replicas: replicas,
+			Template: &podTemplateSpec,
+		},
+	}
+	err := s.memberAwait.Client.Create(context.TODO(), dc)
+	require.NoError(s.T(), err)
+
+	return dc
+}
+
+func (s *userWorkloadsTestSuite) createReplicationController(idler *v1alpha1.Idler) *corev1.ReplicationController {
+	// Standalone ReplicationController
+	replicas := int32(2)
+	rc := &corev1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-rc", Namespace: idler.Name},
+		Spec: corev1.ReplicationControllerSpec{
+			Selector: labels,
+			Replicas: &replicas,
+			Template: &podTemplateSpec,
+		},
+	}
+	err := s.memberAwait.Client.Create(context.TODO(), rc)
+	require.NoError(s.T(), err)
+
+	return rc
+}
+
+func (s *userWorkloadsTestSuite) createStandalonePod(idler *v1alpha1.Idler) *corev1.Pod {
+	// Create a Deployment with two pods
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "idler-test-pod",
 			Namespace: idler.Name,
 			Labels:    labels,
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "hello-openshift",
-				Image: "openshift/hello-openshift",
-				Ports: []corev1.ContainerPort{{ContainerPort: 8080}},
-			}},
-		},
+		Spec: podSpec,
 	}
-	err = s.memberAwait.Client.Create(context.TODO(), pod)
+	err := s.memberAwait.Client.Create(context.TODO(), pod)
 	require.NoError(s.T(), err)
-
-	pods, err := s.memberAwait.WaitForPods(idler.Name, labels, 3, wait.UntilPodRunning())
-	require.NoError(s.T(), err)
-
-	return pods
+	return pod
 }

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -37,18 +37,19 @@ func (s *userWorkloadsTestSuite) TestIdler() {
 	s.createAndCheckUserSignup(true, "test-idler", "test-idler@redhat.com", ApprovedByAdmin()...)
 	idler, err := s.memberAwait.WaitForIdler("test-idler-dev")
 	require.NoError(s.T(), err)
-	idler.Spec.TimeoutSeconds = 3
-	err = s.memberAwait.Client.Update(context.TODO(), idler)
-	require.NoError(s.T(), err)
 
 	// Noise
-	s.createAndCheckUserSignup(true, "test-idler-noise", "test-idler-noise@redhat.com", ApprovedByAdmin()...)
-	idlerNoise, err := s.memberAwait.WaitForIdler("test-idler-noise-dev")
+	idlerNoise, err := s.memberAwait.WaitForIdler("test-idler-stage")
 	require.NoError(s.T(), err)
 
 	// Create payloads for both users
 	podsToIdle := s.prepareWorkloads(idler)
 	podsNoise := s.prepareWorkloads(idlerNoise)
+
+	// Set a short timeout for one of the idler to trigger pod idling
+	idler.Spec.TimeoutSeconds = 3
+	err = s.memberAwait.Client.Update(context.TODO(), idler)
+	require.NoError(s.T(), err)
 
 	// Wait for the pods to be deleted
 	for _, p := range podsToIdle {

--- a/wait/member.go
+++ b/wait/member.go
@@ -404,17 +404,18 @@ func (a *MemberAwaitility) WaitForPods(namespace string, labels map[string]strin
 			if err := a.Client.List(context.TODO(), foundPods, &client.ListOptions{Namespace: namespace}); err != nil {
 				return false, err
 			}
-			a.T.Logf("waiting for pods with labels '%v' in namespace '%s'. Currently available pods: '%v'", labels, namespace, foundPods)
+			a.T.Logf("waiting for %d pods with labels '%v' in namespace '%s'. Currently available pods: '%v'", n, labels, namespace, foundPods)
 			return false, nil
 		}
 		for _, p := range foundPods.Items {
 			for _, match := range criteria {
 				if !match(a, p) {
-					a.T.Logf("waiting for pods with labels '%v' in namespace '%s'. Currently available pods: '%v'", labels, namespace, foundPods)
+					a.T.Logf("waiting for %d pods with labels '%v' in namespace '%s' with a criteria. Currently available pods: '%v'", n, labels, namespace, foundPods)
 					return false, nil
 				}
 			}
-			pods = append(pods, &p)
+			pod := p // copy
+			pods = append(pods, &pod)
 		}
 		a.T.Logf("found Pods '%v'", foundPods)
 		return true, nil


### PR DESCRIPTION
Tests for https://github.com/codeready-toolchain/member-operator/pull/204

TODO:

- [x] Add tests for other controllers (ReplicaSet, DemploymentConfig, etc). Not only for Deployments.

Update: See https://github.com/codeready-toolchain/toolchain-e2e/pull/174