### PR TITLE
chore: verify that UserSignup has corresponding state label values set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20201008102715-afd628dfa930
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'

--- a/go.sum
+++ b/go.sum
@@ -160,10 +160,6 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e h1:XVp2vhAUGhh3SymWiLwaqqehfjs120p5wo/64yvgvWQ=
-github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
-github.com/codeready-toolchain/api v0.0.0-20200925000842-d2e82e080a5a h1:zdLP2nVrHV+pzx39GIdz9iAunjaFQzS7G1XfjeUDk14=
-github.com/codeready-toolchain/api v0.0.0-20200925000842-d2e82e080a5a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200930070243-e124e69e7a0d h1:sBJBRMtOtaVEuiI79AjUNkD7SP1JFWPaLvh4WX5Jurc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200930070243-e124e69e7a0d/go.mod h1:VhMZjATgVT/YrbXuEj+erSsxKCXoyF9uCHLs6hOt2VA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
@@ -636,6 +632,8 @@ github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matousjobanek/api v0.0.0-20201008102715-afd628dfa930 h1:1sNFbsl5G0APxPKGLUs9EVOaurBLK9oap5GAvAAen/k=
+github.com/matousjobanek/api v0.0.0-20201008102715-afd628dfa930/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -150,7 +150,6 @@ func ApprovedAndVerificationRequired() []toolchainv1alpha1.Condition {
 	}
 }
 
-
 func VerificationRequired() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -27,7 +27,7 @@ func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, memberA
 func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, signup toolchainv1alpha1.UserSignup, tier string) {
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
 	// Get the latest signup version
-	userSignup, err := hostAwait.WaitForUserSignup(signup.Name)
+	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 	require.NoError(t, err)
 
 	// First, wait for the MasterUserRecord to exist, no matter what status

--- a/wait/host.go
+++ b/wait/host.go
@@ -192,6 +192,20 @@ func UntilUserSignupHasConditions(conditions ...toolchainv1alpha1.Condition) Use
 	}
 }
 
+// UntilUserSignupHasStateLabel returns a `UserAccountWaitCriterion` which checks that the given
+// USerAccount has toolchain.dev.openshift.com/state equal to the given value
+func UntilUserSignupHasStateLabel(expLabelValue string) UserSignupWaitCriterion {
+	return func(a *HostAwaitility, ua *toolchainv1alpha1.UserSignup) bool {
+		if ua.Labels != nil && ua.Labels[toolchainv1alpha1.UserSignupStateLabelKey] == expLabelValue {
+			a.T.Logf("the toolchain.dev.openshift.com/state label value matches '%s`", expLabelValue)
+			return true
+		}
+		a.T.Logf("the toolchain.dev.openshift.com/state label of '%s' UserSignup doesn't match. Actual labels: '%v'; Expected value: '%s'",
+			ua.Name, ua.Labels, expLabelValue)
+		return false
+	}
+}
+
 // WaitForUserSignup waits until there is a UserSignup available with the given name and set of status conditions
 func (a *HostAwaitility) WaitForUserSignup(name string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
 	var userSignup *toolchainv1alpha1.UserSignup


### PR DESCRIPTION
verifies that UserSignup has the corresponding values of the `state` label set

removes `createUserSignupAndAssertPendingApproval` function since it wasn't used anywhere

paired with https://github.com/codeready-toolchain/host-operator/pull/298