### PR TITLE
fix: oc command fails that --all-namespaces cannot be applied for deletion

### DIFF
--- a/make/clean.mk
+++ b/make/clean.mk
@@ -10,7 +10,10 @@ clean:
 ##    * operator namespaces created during both the dev and e2e test setup (for both operators host and member)
 ##    * all CatalogSources that were created as part of operator deployment
 clean-e2e-resources:
-	$(Q)-oc delete usersignups --all --all-namespaces
+	$(Q)-for todelete in `oc get usersignup --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}={.metadata.namespace}{"\n"}{end}'`; do \
+		echo "oc delete usersignup $${todelete%=*} -n $${todelete#*=}"; \
+		oc delete usersignup $${todelete%=*} -n $${todelete#*=}; \
+	done
 	$(Q)-oc wait --for=delete namespaces -l toolchain.dev.openshift.com/provider=codeready-toolchain
 	$(Q)-oc get projects --output=name | grep -E "${QUAY_NAMESPACE}-(toolchain\-)?(member|host)(\-operator)?(\-[0-9]+)?|${QUAY_NAMESPACE}-toolchain\-e2e\-[0-9]+" | xargs oc delete
 	$(Q)-oc get catalogsource --output=name -n openshift-marketplace | grep "source-toolchain-.*${QUAY_NAMESPACE}" | xargs oc delete -n openshift-marketplace


### PR DESCRIPTION
oc command fails when using --all-namespaces for deletion:
```
$ oc delete usersignups --all --all-namespaces
Error: unknown flag: --all-namespaces


Usage:
  oc delete ([-f FILENAME] | TYPE [(NAME | -l label | --all)]) [flags]

Examples:
  # Delete a pod using the type and ID specified in pod.json.
  oc delete -f pod.json
  
  # Delete a pod based on the type and ID in the JSON passed into stdin.
  cat pod.json | oc delete -f -
  
  # Delete pods and services with label name=myLabel.
  oc delete pods,services -l name=myLabel
  
  # Delete a pod with name node-1-vsjnm.
  oc delete pod node-1-vsjnm
  
  # Delete all resources associated with a running app, includes
  # buildconfig,deploymentconfig,service,imagestream,route and pod,
  # where 'appName' is listed in 'Labels' of 'oc describe [resource] [resource name]' output.
  oc delete all -l app=appName
  
  # Delete all pods
  oc delete pods --all

Options:
      --all=false: Delete all resources, including uninitialized ones, in the namespace of the specified resource types.
      --cascade=true: If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController).  Default true.
      --field-selector='': Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
  -f, --filename=[]: containing the resource to delete.
      --force=false: Only used when grace-period=0. If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.
      --grace-period=-1: Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).
      --ignore-not-found=false: Treat "resource not found" as a successful delete. Defaults to "true" when --all is specified.
      --include-uninitialized=false: If true, the kubectl command applies to uninitialized objects. If explicitly set to false, this flag overrides other flags that make the kubectl commands apply to uninitialized objects, e.g., "--all". Objects with empty metadata.initializers are regarded as initialized.
      --now=false: If true, resources are signaled for immediate shutdown (same as --grace-period=1).
  -o, --output='': Output mode. Use "-o name" for shorter output (resource/name).
  -R, --recursive=false: Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
  -l, --selector='': Selector (label query) to filter on, not including uninitialized ones.
      --timeout=0s: The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object
      --wait=true: If true, wait for resources to be gone before returning. This waits for finalizers.

Use "oc options" for a list of global command-line options (applies to all commands).
```