### PR TITLE
chore: verify waiting list for UserSignup

### DIFF
--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -37,16 +37,14 @@ func PendingApproval() []toolchainv1alpha1.Condition {
 func PendingApprovalNoCluster() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
 		{
-			Type:    toolchainv1alpha1.UserSignupApproved,
-			Status:  corev1.ConditionFalse,
-			Reason:  "PendingApproval",
-			Message: "no suitable member cluster found - capacity was reached",
+			Type:   toolchainv1alpha1.UserSignupApproved,
+			Status: corev1.ConditionFalse,
+			Reason: "PendingApproval",
 		},
 		{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  "NoClusterAvailable",
-			Message: "no suitable member cluster found - capacity was reached",
+			Type:   toolchainv1alpha1.UserSignupComplete,
+			Status: corev1.ConditionFalse,
+			Reason: "NoClusterAvailable",
 		},
 		{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
@@ -126,21 +124,6 @@ func ApprovedAutomaticallyAndBanned() []toolchainv1alpha1.Condition {
 			Type:   toolchainv1alpha1.UserSignupComplete,
 			Status: corev1.ConditionTrue,
 			Reason: "Banned",
-		},
-		{
-			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: corev1.ConditionFalse,
-			Reason: "UserIsActive",
-		},
-	}
-}
-
-func ApprovedAndVerificationRequired() []toolchainv1alpha1.Condition {
-	return []toolchainv1alpha1.Condition{
-		{
-			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: corev1.ConditionFalse,
-			Reason: "VerificationRequired",
 		},
 		{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,


### PR DESCRIPTION
verify waiting list for UserSignup, which means that the controller will approve the oldest unapproved UserSignup when there is a member cluster with free capacity

paired with: https://github.com/codeready-toolchain/host-operator/pull/306