### PR TITLE
chore: Rename user_signups_provisioned_total to user_signups_approved_total

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,7 +53,7 @@ func TestE2EFlow(t *testing.T) {
 
 	// Get baseline metrics before creating any users
 	baseUserSignups := hostAwait.GetMetricValue("sandbox_user_signups_total")
-	baseUserSignupsProvisioned := hostAwait.GetMetricValue("sandbox_user_signups_provisioned_total")
+	baseUserSignupsApproved := hostAwait.GetMetricValue("sandbox_user_signups_approved_total")
 	baseCurrentMURs := hostAwait.GetMetricValue("sandbox_master_user_record_current")
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
@@ -74,7 +74,7 @@ func TestE2EFlow(t *testing.T) {
 
 	t.Run("verify metrics are correct at the beginning", func(t *testing.T) {
 		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+7)
-		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+7)
+		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+7)
 		hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+7)
 	})
 
@@ -238,7 +238,7 @@ func TestE2EFlow(t *testing.T) {
 
 	t.Run("verify metrics are correct at the end", func(t *testing.T) {
 		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+7)
-		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+7)
+		hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+7)
 		hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+6)
 	})
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -46,7 +46,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	// Get baseline metrics before creating any users
 	baseUserSignups := s.hostAwait.GetMetricValue("sandbox_user_signups_total")
-	baseUserSignupsProvisioned := s.hostAwait.GetMetricValue("sandbox_user_signups_provisioned_total")
+	baseUserSignupsApproved := s.hostAwait.GetMetricValue("sandbox_user_signups_approved_total")
 	baseCurrentMURs := s.hostAwait.GetMetricValue("sandbox_master_user_record_current")
 	baseUserSignupsDeactivated := s.hostAwait.GetMetricValue("sandbox_user_signups_deactivated_total")
 	baseUserSignupsAutoDeactivated := s.hostAwait.GetMetricValue("sandbox_user_signups_auto_deactivated_total")
@@ -58,7 +58,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		t.Run("verify metrics are correct at the beginning", func(t *testing.T) {
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+2)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+2)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated)
 		})
@@ -119,7 +119,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		t.Run("verify metrics are correct after reactivating the user", func(t *testing.T) {
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)                        // no change
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+3) // one more because of reactivated user
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)       // one more because of reactivated user
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)                // one more because of reactivated user
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+1) // no change
 		})
@@ -136,7 +136,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		t.Run("verify metrics are correct after moving users to new tiers", func(t *testing.T) {
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+3)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+1)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated)
@@ -188,7 +188,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		t.Run("verify metrics are correct after auto deactivation", func(t *testing.T) {
 			// Only the user with domain not on the exclusion list should be auto-deactivated
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+3)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+1)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+2)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated+1)
@@ -199,7 +199,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 func (s *userManagementTestSuite) TestUserBanning() {
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
 		baseUserSignups := s.hostAwait.GetMetricValue("sandbox_user_signups_total")
-		baseUserSignupsProvisioned := s.hostAwait.GetMetricValue("sandbox_user_signups_provisioned_total")
+		baseUserSignupsApproved := s.hostAwait.GetMetricValue("sandbox_user_signups_approved_total")
 		baseCurrentMURs := s.hostAwait.GetMetricValue("sandbox_master_user_record_current")
 		baseUserSignupsBanned := s.hostAwait.GetMetricValue("sandbox_user_signups_banned_total")
 
@@ -227,7 +227,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		t.Run("verify metrics are correct after user banned", func(t *testing.T) {
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+1)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned+1)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+1)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_banned_total", baseUserSignupsBanned+1)
 		})
@@ -241,7 +241,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.createAndCheckBannedUser(email)
 
 		baseUserSignups := s.hostAwait.GetMetricValue("sandbox_user_signups_total")
-		baseUserSignupsProvisioned := s.hostAwait.GetMetricValue("sandbox_user_signups_provisioned_total")
+		baseUserSignupsApproved := s.hostAwait.GetMetricValue("sandbox_user_signups_approved_total")
 		baseCurrentMURs := s.hostAwait.GetMetricValue("sandbox_master_user_record_current")
 		baseUserSignupsBanned := s.hostAwait.GetMetricValue("sandbox_user_signups_banned_total")
 
@@ -255,7 +255,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		t.Run("verify metrics are correct after user signup", func(t *testing.T) {
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+1)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_provisioned_total", baseUserSignupsProvisioned) // not provisioned because banned before signup
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved) // not provisioned because banned before signup
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_banned_total", baseUserSignupsBanned+1)
 		})

--- a/wait/metrics_test.go
+++ b/wait/metrics_test.go
@@ -38,9 +38,9 @@ sandbox_user_signups_banned_total 0
 # HELP sandbox_user_signups_deactivated_total Total number of Deactivated User Signups
 # TYPE sandbox_user_signups_deactivated_total counter
 sandbox_user_signups_deactivated_total 0
-# HELP sandbox_user_signups_provisioned_total Total number of Provisioned User Signups
-# TYPE sandbox_user_signups_provisioned_total counter
-sandbox_user_signups_provisioned_total 7
+# HELP sandbox_user_signups_approved_total Total number of Approved User Signups
+# TYPE sandbox_user_signups_approved_total counter
+sandbox_user_signups_approved_total 7
 # HELP sandbox_user_signups_total Total number of unique User Signups
 # TYPE sandbox_user_signups_total counter
 sandbox_user_signups_total 7
@@ -99,7 +99,7 @@ func TestGetMetricValue(t *testing.T) {
 			result, err := getMetricValue(url, "non_existent_counter", []string{})
 			// then
 			require.Error(t, err)
-			require.EqualError(t, err, "Metric 'non_existent_counter{[]}' not found")
+			require.EqualError(t, err, "metric 'non_existent_counter{[]}' not found")
 			assert.Equal(t, float64(-1), result)
 		})
 
@@ -108,7 +108,7 @@ func TestGetMetricValue(t *testing.T) {
 			result, err := getMetricValue(url, "workqueue_depth", []string{"name", "non-existent-controller"})
 			// then
 			require.Error(t, err)
-			require.EqualError(t, err, "Metric 'workqueue_depth{[name non-existent-controller]}' not found")
+			require.EqualError(t, err, "metric 'workqueue_depth{[name non-existent-controller]}' not found")
 			assert.Equal(t, float64(-1), result)
 		})
 
@@ -117,7 +117,7 @@ func TestGetMetricValue(t *testing.T) {
 			result, err := getMetricValue(url, "workqueue_depth", []string{"name"})
 			// then
 			require.Error(t, err)
-			require.EqualError(t, err, "Received odd number of label arguments, labels must be key-value pairs")
+			require.EqualError(t, err, "received odd number of label arguments, labels must be key-value pairs")
 			assert.Equal(t, float64(-1), result)
 		})
 	})


### PR DESCRIPTION
Rename user_signups_provisioned_total to user_signups_approved_total since approved doesn't necessarily mean provisioned.

Also fix metrics_test.go.