### PR TITLE
Improve error messaging

### DIFF
--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -555,7 +555,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, requiredStatus, resp.StatusCode)
+	require.Equal(t, requiredStatus, resp.StatusCode, "unexpected response status with body: %s", body)
 
 	return body
 }


### PR DESCRIPTION
This is just for improving error messaging in reg-service tests.

It's paired with https://github.com/codeready-toolchain/registration-service/pull/141 but will fail until https://github.com/codeready-toolchain/host-operator/pull/320 is merged.