### PR TITLE
chore: support member-operator-webhook image

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -205,7 +205,7 @@ ifneq ($(CLONEREFS_OPTIONS),)
 	fi;
 	$(MAKE) -C ${E2E_REPO_PATH} build
 	# operators are built, now copy the operators' binaries to make them available for CI
-	cp ${E2E_REPO_PATH}/build/_output/bin/${REPO_NAME} build/_output/bin/${REPO_NAME}
+	cp ${E2E_REPO_PATH}/build/_output/bin/* build/_output/bin/
 endif
 
 ###########################################################

--- a/openshift-ci/Dockerfile.member.webhook.deploy
+++ b/openshift-ci/Dockerfile.member.webhook.deploy
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV WEBHOOK=/usr/local/bin/member-operator-webhook \
+    USER_UID=1001 \
+    USER_NAME=member-operator-webhook \
+    LANG=en_US.utf8
+
+ # install webhook binary
+COPY member-operator-webhook ${WEBHOOK}
+
+USER ${USER_UID}
+
+ENTRYPOINT [ "/usr/local/bin/member-operator-webhook" ]


### PR DESCRIPTION
This PR adds a support for member-operator-webhook image so it can be built as part of openshift-ci setup

used here: https://github.com/openshift/release/pull/13872