### PR TITLE
fix: make sure build/_output/bin dir exists

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -205,6 +205,7 @@ ifneq ($(CLONEREFS_OPTIONS),)
 	fi;
 	$(MAKE) -C ${E2E_REPO_PATH} build
 	# operators are built, now copy the operators' binaries to make them available for CI
+	mkdir -p build/_output/bin/ || true
 	cp ${E2E_REPO_PATH}/build/_output/bin/* build/_output/bin/
 endif
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -206,7 +206,10 @@ ifneq ($(CLONEREFS_OPTIONS),)
 	$(MAKE) -C ${E2E_REPO_PATH} build
 	# operators are built, now copy the operators' binaries to make them available for CI
 	mkdir -p build/_output/bin/ || true
+	ls ${E2E_REPO_PATH}/build/_output/bin/
+	ls build/_output/bin/
 	cp ${E2E_REPO_PATH}/build/_output/bin/* build/_output/bin/
+	ls build/_output/bin/
 endif
 
 ###########################################################


### PR DESCRIPTION
make sure build/_output/bin dir exists before copying the binary files