### PR TITLE
fix: improve waiting for updated tier

### DIFF
--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -94,10 +94,6 @@ func DeactivationTimeoutDays(timeoutDurationDays int) TierModifier {
 
 func WaitUntilBasicNSTemplateTierIsUpdated(t *testing.T, hostAwait *HostAwaitility) {
 	_, err := hostAwait.WaitForNSTemplateTier("basic",
-		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-code-000000a"))),
-		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-dev-000000a"))),
-		UntilNSTemplateTierSpec(Not(HasNSTemplateRefs("basic-stage-000000a"))),
-		UntilNSTemplateTierSpec(Not(HasClusterResourcesTemplateRef("basic-clusterresources-000000a"))),
-	)
+		UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
 	require.NoError(t, err)
 }

--- a/tiers/templaterefs.go
+++ b/tiers/templaterefs.go
@@ -14,7 +14,7 @@ type TemplateRefs struct {
 
 // GetTemplateRefs returns the expected templateRefs for all the namespace templates and the optional cluster resources template for the given tier
 func GetTemplateRefs(hostAwait *wait.HostAwaitility, tier string) TemplateRefs {
-	templateTier, err := hostAwait.WaitForNSTemplateTier(tier, wait.UntilNSTemplateTierSpec(wait.Not(wait.HasNSTemplateRefs("000000a"))))
+	templateTier, err := hostAwait.WaitForNSTemplateTier(tier, wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
 	require.NoError(hostAwait.T, err)
 	nsRefs := make([]string, 0, len(templateTier.Spec.Namespaces))
 	for _, ns := range templateTier.Spec.Namespaces {

--- a/wait/host.go
+++ b/wait/host.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -483,22 +484,15 @@ func UntilNSTemplateTierStatusUpdates(count int) NSTemplateTierWaitCriterion {
 	}
 }
 
-// Not negates the given matcher
-func Not(match NSTemplateTierSpecMatcher) NSTemplateTierSpecMatcher {
-	return func(s toolchainv1alpha1.NSTemplateTierSpec) bool {
-		return !match(s)
-	}
-}
-
-// Has.NSTemplateRefs checks that ALL namespaces' `TemplateRef` match the given value
-func HasNSTemplateRefs(r string) NSTemplateTierSpecMatcher {
+// HasNoTemplateRefWithSuffix checks that ALL namespaces' `TemplateRef` doesn't have the suffix
+func HasNoTemplateRefWithSuffix(suffix string) NSTemplateTierSpecMatcher {
 	return func(s toolchainv1alpha1.NSTemplateTierSpec) bool {
 		for _, ns := range s.Namespaces {
-			if ns.TemplateRef != r {
+			if strings.HasSuffix(ns.TemplateRef, suffix) {
 				return false
 			}
 		}
-		return true
+		return !strings.HasSuffix(s.ClusterResources.TemplateRef, suffix)
 	}
 }
 


### PR DESCRIPTION
improve waiting for updated tier - the current wait checks the template refs incorrectly - we should just check the suffix that refers to the commit sha.