### PR TITLE
fix: prolong timeout when reaching metrics endpoint

### DIFF
--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -213,7 +213,7 @@ func (a *Awaitility) SetupRouteForService(serviceName, endpoint string) (routev1
 		Namespace: service.Namespace,
 		Name:      service.Name,
 	}, &route); err != nil {
-		require.True(a.T, errors.IsNotFound(err), "failed to get route to access the '%s' service", service.Name)
+		require.True(a.T, errors.IsNotFound(err), "failed to get route to access the '%s' service: %s", service.Name, err.Error())
 		route = routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: service.Namespace,

--- a/wait/metrics.go
+++ b/wait/metrics.go
@@ -18,7 +18,7 @@ func getMetricValue(url string, family string, expectedLabels []string) (float64
 	}
 
 	client := http.Client{
-		Timeout: time.Duration(1 * time.Second),
+		Timeout: time.Duration(10 * time.Second),
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},


### PR DESCRIPTION
When running e2e tests locally, it happened a few times that the e2e tests reached the 1sec limit when getting the metrics endpoint. 
So I made it way longer - I know that it's maybe too much, but it doesn't harm :-) 