### PR TITLE
feat: verify webhook that sets lower priority to users' pods

### DIFF
--- a/make/clean.mk
+++ b/make/clean.mk
@@ -15,6 +15,8 @@ clean-e2e-resources:
 	$(Q)-oc get projects --output=name | grep -E "${QUAY_NAMESPACE}-(toolchain\-)?(member|host)(\-operator)?(\-[0-9]+)?|${QUAY_NAMESPACE}-toolchain\-e2e\-[0-9]+" | xargs oc delete
 	$(Q)-oc get catalogsource --output=name -n openshift-marketplace | grep "source-toolchain-.*${QUAY_NAMESPACE}" | xargs oc delete -n openshift-marketplace
 	$(Q)-oc get ClusterRoleBinding -o name | grep e2e-service-account | xargs oc delete
+	$(Q)-oc delete PriorityClass -l='toolchain.dev.openshift.com/provider=codeready-toolchain'
+	$(Q)-oc delete MutatingWebhookConfiguration -l='toolchain.dev.openshift.com/provider=codeready-toolchain'
 
 .PHONY: clean-e2e-files
 ## Removes files and directories used during e2e test setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -294,6 +294,9 @@ ifeq ($(SET_IMAGE_NAME),)
 				$(eval IMAGE_NAME := quay.io/${QUAY_NAMESPACE}/${REPO_NAME}:${DATE_SUFFIX})
 				$(MAKE) -C ${E2E_REPO_PATH} docker-push QUAY_NAMESPACE=${QUAY_NAMESPACE} IMAGE_TAG=${DATE_SUFFIX}
 				curl https://quay.io/api/v1/repository/${QUAY_NAMESPACE}/${REPO_NAME} 2>/dev/null | jq -r '.tags."${DATE_SUFFIX}".manifest_digest' > ${IMAGE_NAMES_DIR}/${REPO_NAME}_digest
+				if [[ ${REPO_NAME} == "member-operator" ]]; then \
+                    curl https://quay.io/api/v1/repository/${QUAY_NAMESPACE}/${REPO_NAME}-webhook 2>/dev/null | jq -r '.tags."${DATE_SUFFIX}".manifest_digest' > ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook_digest; \
+                fi
             endif
         else
 			# if is running in CI than we expect that it's PR for toolchain-e2e repo (none of the images was provided), so use name that was used by openshift-ci
@@ -310,22 +313,31 @@ endif
 	if [[ -f ${IMAGE_NAMES_DIR}/${REPO_NAME}_digest ]]; then \
 	    DIGEST=`cat ${IMAGE_NAMES_DIR}/${REPO_NAME}_digest`; \
 	    echo quay.io/${QUAY_NAMESPACE}/${REPO_NAME}@$${DIGEST} > ${IMAGE_NAMES_DIR}/${REPO_NAME}; \
+	    if [[ ${REPO_NAME} == "member-operator" ]]; then \
+	        DIGEST=`cat ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook_digest`; \
+	    	echo quay.io/${QUAY_NAMESPACE}/${REPO_NAME}-webhook@$${DIGEST} > ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook; \
+	    fi \
 	else \
 		echo "${IMAGE_NAME}" > ${IMAGE_NAMES_DIR}/${REPO_NAME}; \
+        if [[ ${REPO_NAME} == "member-operator" ]]; then \
+	    	echo "${IMAGE_NAME}" | sed 's/${REPO_NAME}/${REPO_NAME}-webhook/g' > ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook; \
+	    fi \
     fi
 
 
 .PHONY: deploy-operator
 deploy-operator:
 	$(eval IMAGE_NAME := $(shell cat ${IMAGE_NAMES_DIR}/${REPO_NAME}))
-	$(eval REGISTRATION_SERVICE_IMAGE_NAME := $(shell cat ${IMAGE_NAMES_DIR}/registration-service))
 	@echo Using image ${IMAGE_NAME} and namespace ${NAMESPACE} for the repository ${REPO_NAME}
-	$(eval REG_SERVICE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
+	$(eval REGISTRATION_SERVICE_IMAGE_NAME := $(shell cat ${IMAGE_NAMES_DIR}/registration-service))
+	$(eval COMPONENT_IMAGE_REPLACEMENT := ;s|REPLACE_REGISTRATION_SERVICE_IMAGE|${REGISTRATION_SERVICE_IMAGE_NAME}|g)
+	$(eval MEMBER_OPERATOR_WEBHOOK_IMAGE := $(shell cat ${IMAGE_NAMES_DIR}/member-operator-webhook))
+	$(eval COMPONENT_IMAGE_REPLACEMENT := ${COMPONENT_IMAGE_REPLACEMENT};s|REPLACE_MEMBER_OPERATOR_WEBHOOK_IMAGE|${MEMBER_OPERATOR_WEBHOOK_IMAGE}|g)
 ifeq ($(IS_OS_3),)
 		# it is not using OS 3 so we will install operator via CSV
 		$(eval NAME_SUFFIX := ${QUAY_NAMESPACE}-${RESOURCES_SUFFIX})
 		curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/hack/deploy_csv.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml
-		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${NAME_SUFFIX}|;s|^  configMap: .*|&-${NAME_SUFFIX}|${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
+		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g;s|^  name: .*|&-${NAME_SUFFIX}|;s|^  configMap: .*|&-${NAME_SUFFIX}|${COMPONENT_IMAGE_REPLACEMENT}' /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}_source.yaml > /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml
 		cat /tmp/${REPO_NAME}_deploy_csv_${DATE_SUFFIX}.yaml | oc apply -f -
 		# if the namespace already contains the CSV then update it
 		if [[ -n `oc get csv 2>/dev/null || true | grep 'toolchain-${REPO_NAME}'` ]]; then \
@@ -353,7 +365,7 @@ ifeq ($(IS_OS_3),)
 else
 		echo "before curl ${REPO_NAME}"
 		curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/enrich-by-envs-from-yaml.sh | bash -s -- ${E2E_REPO_PATH}/deploy/operator.yaml ${E2E_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml
-		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g${REG_SERVICE_REPLACEMENT}' /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml | oc apply -f -
+		sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g${COMPONENT_IMAGE_REPLACEMENT}' /tmp/${REPO_NAME}_deployment_${DATE_SUFFIX}_source.yaml | oc apply -f -
 endif
 
 .PHONY: display-eval

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -47,6 +47,8 @@ func TestE2EFlow(t *testing.T) {
 		})
 	})
 
+	memberAwait.WaitForUsersPodsWebhook()
+
 	originalToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReady()))
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 	originalMurCount := originalToolchainStatus.Status.HostOperator.MasterUserRecordCount

--- a/wait/member.go
+++ b/wait/member.go
@@ -6,7 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
@@ -20,10 +22,27 @@ import (
 	v1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	admv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+var (
+	appMemberOperatorWebhookLabel = map[string]string{
+		"app": "member-operator-webhook",
+	}
+	codereadyToolchainProviderLabel = map[string]string{
+		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
+	}
+	bothWebhookLabels = map[string]string{
+		"app":                                  "member-operator-webhook",
+		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
+	}
 )
 
 type MemberAwaitility struct {
@@ -221,8 +240,7 @@ func (a *MemberAwaitility) WaitForNamespace(username, ref string) (*v1.Namespace
 		// no match found, so we display the current list of namespaces
 		if len(namespaceList.Items) == 0 {
 			allNSs := &v1.NamespaceList{}
-			ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-			if err := a.Client.List(context.TODO(), allNSs, client.MatchingLabels(ls)); err != nil {
+			if err := a.Client.List(context.TODO(), allNSs, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 				return false, err
 			}
 			allNSNames := make(map[string]map[string]string, len(allNSs.Items))
@@ -257,8 +275,7 @@ func (a *MemberAwaitility) WaitForRoleBinding(namespace *v1.Namespace, name stri
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace.Name, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				allRBs := &rbacv1.RoleBindingList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-				if err := a.Client.List(context.TODO(), allRBs, client.MatchingLabels(ls)); err != nil {
+				if err := a.Client.List(context.TODO(), allRBs, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 					return false, err
 				}
 				a.T.Logf("waiting for availability of RoleBinding '%s' in namespace '%s'. Currently available codeready-toolchain RoleBindings: '%+v'", name, namespace.Name, allRBs)
@@ -281,8 +298,7 @@ func (a *MemberAwaitility) WaitForLimitRange(namespace *v1.Namespace, name strin
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace.Name, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				allLRs := &v1.LimitRangeList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-				if err := a.Client.List(context.TODO(), allLRs, client.MatchingLabels(ls)); err != nil {
+				if err := a.Client.List(context.TODO(), allLRs, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 					return false, err
 				}
 				a.T.Logf("waiting for availability of LimitRange '%s' in namespace '%s'. Currently available codeready-toolchain LimitRanges: '%+v'", name, namespace.Name, allLRs)
@@ -305,8 +321,7 @@ func (a *MemberAwaitility) WaitForNetworkPolicy(namespace *v1.Namespace, name st
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace.Name, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				allNPs := &netv1.NetworkPolicyList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-				if err := a.Client.List(context.TODO(), allNPs, client.MatchingLabels(ls)); err != nil {
+				if err := a.Client.List(context.TODO(), allNPs, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 					return false, err
 				}
 				a.T.Logf("waiting for availability of NetworkPolicy '%s' in namespace '%s'. Currently available codeready-toolchain NetworkPolicies: '%+v'", name, namespace.Name, allNPs)
@@ -329,8 +344,7 @@ func (a *MemberAwaitility) WaitForRole(namespace *v1.Namespace, name string) (*r
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace.Name, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				allRoles := &rbacv1.RoleList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-				if err := a.Client.List(context.TODO(), allRoles, client.MatchingLabels(ls)); err != nil {
+				if err := a.Client.List(context.TODO(), allRoles, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 					return false, err
 				}
 				a.T.Logf("waiting for availability of Role '%s' in namespace '%s'. Currently available codeready-toolchain Roles: '%+v'", name, namespace.Name, allRoles)
@@ -353,7 +367,7 @@ func (a *MemberAwaitility) WaitForClusterResourceQuota(name string) (*quotav1.Cl
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				quotaList := &quotav1.ClusterResourceQuotaList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
+				ls := codereadyToolchainProviderLabel
 				if err := a.Client.List(context.TODO(), quotaList, client.MatchingLabels(ls)); err != nil {
 					return false, err
 				}
@@ -393,8 +407,7 @@ func (a *MemberAwaitility) WaitForIdler(name string, criteria ...IdlerWaitCriter
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				idlerList := &toolchainv1alpha1.IdlerList{}
-				ls := map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"}
-				if err := a.Client.List(context.TODO(), idlerList, client.MatchingLabels(ls)); err != nil {
+				if err := a.Client.List(context.TODO(), idlerList, client.MatchingLabels(codereadyToolchainProviderLabel)); err != nil {
 					return false, err
 				}
 				a.T.Logf("waiting for availability of Idler '%s'. Currently available codeready-toolchain Idlers: '%+v'", name, idlerList)
@@ -587,6 +600,29 @@ func WithPodLabel(key, value string) PodWaitCriterion {
 	return func(a *MemberAwaitility, pod v1.Pod) bool {
 		return pod.Labels[key] == value
 	}
+}
+
+func WithSandboxPriorityClass() PodWaitCriterion {
+	return func(a *MemberAwaitility, pod v1.Pod) bool {
+		return checkPriorityClass(a, pod, "sandbox-users-pods", -10)
+	}
+}
+
+func WithOriginalPriorityClass() PodWaitCriterion {
+	return func(a *MemberAwaitility, pod v1.Pod) bool {
+		if pod.Name != "idler-test-pod-1" {
+			return checkPriorityClass(a, pod, "", 0)
+		}
+		return checkPriorityClass(a, pod, "system-cluster-critical", 2000000000)
+	}
+}
+
+func checkPriorityClass(a *MemberAwaitility, pod v1.Pod, name string, priority int) bool {
+	if pod.Spec.PriorityClassName == name && *pod.Spec.Priority == int32(priority) {
+		return true
+	}
+	a.T.Logf("Priority doesn't match for pod '%s' - Expected prorityClassName: '%s', actual : '%s'; Expected prority: '%d', actual : '%d'", pod.Name, name, pod.Spec.PriorityClassName, priority, *pod.Spec.Priority)
+	return false
 }
 
 // WaitUntilNamespaceDeleted waits until the namespace with the given name is deleted (ie, is not found)
@@ -841,4 +877,120 @@ func (a *MemberAwaitility) GetMemberOperatorPod() (corev1.Pod, error) {
 		return corev1.Pod{}, fmt.Errorf("unexpected number of pods with label 'name=member-operator' in namespace '%s': %d ", a.Namespace, len(pods.Items))
 	}
 	return pods.Items[0], nil
+}
+
+func (a *MemberAwaitility) WaitForUsersPodsWebhook() {
+	a.waitForPriorityClass()
+	a.waitForService()
+	a.waitForDeployment()
+	ca := a.waitForSecret()
+	a.waitForWebhookConfig(ca)
+}
+
+func (a *MemberAwaitility) waitForPriorityClass() {
+	actualPrioClass := &schedulingv1.PriorityClass{}
+	a.waitForResource("", "sandbox-users-pods", actualPrioClass)
+
+	assert.Equal(a.T, codereadyToolchainProviderLabel, actualPrioClass.Labels)
+	assert.Equal(a.T, int32(-10), actualPrioClass.Value)
+	assert.False(a.T, actualPrioClass.GlobalDefault)
+	assert.Equal(a.T, "Priority class for pods in users' namespaces", actualPrioClass.Description)
+}
+
+func (a *MemberAwaitility) waitForResource(namespace, name string, object runtime.Object) {
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+		if err := a.Client.Get(context.TODO(), test.NamespacedName(namespace, name), object); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	require.NoError(a.T, err)
+}
+
+func (a *MemberAwaitility) waitForService() {
+	actualService := &v1.Service{}
+	a.waitForResource(a.Namespace, "member-operator-webhook", actualService)
+
+	assert.Equal(a.T, map[string]string{
+		"app":                                  "member-operator-webhook",
+		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
+	}, actualService.Labels)
+	require.Len(a.T, actualService.Spec.Ports, 1)
+	assert.Equal(a.T, int32(443), actualService.Spec.Ports[0].Port)
+	assert.Equal(a.T, intstr.IntOrString{
+		IntVal: 8443,
+	}, actualService.Spec.Ports[0].TargetPort)
+	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualService.Spec.Selector)
+}
+
+func (a *MemberAwaitility) waitForDeployment() {
+	actualDeployment := &appsv1.Deployment{}
+	a.waitForResource(a.Namespace, "member-operator-webhook", actualDeployment)
+
+	assert.Equal(a.T, bothWebhookLabels, actualDeployment.Labels)
+	assert.Equal(a.T, int32(1), *actualDeployment.Spec.Replicas)
+	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
+
+	template := actualDeployment.Spec.Template
+	assert.Equal(a.T, "member-operator-webhook", template.ObjectMeta.Name)
+	assert.Equal(a.T, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
+	require.Len(a.T, template.Spec.Volumes, 1)
+	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Name)
+	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
+	require.Len(a.T, template.Spec.Containers, 1)
+
+	container := template.Spec.Containers[0]
+	assert.Equal(a.T, "mutator", container.Name)
+	assert.NotEmpty(a.T, container.Image)
+	assert.Equal(a.T, []string{"member-operator-webhook"}, container.Command)
+	assert.Equal(a.T, v1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.NotEmpty(a.T, container.Resources)
+
+	assert.Len(a.T, container.VolumeMounts, 1)
+	assert.Equal(a.T, "webhook-certs", container.VolumeMounts[0].Name)
+	assert.Equal(a.T, "/etc/webhook/certs", container.VolumeMounts[0].MountPath)
+	assert.True(a.T, container.VolumeMounts[0].ReadOnly)
+}
+
+func (a *MemberAwaitility) waitForSecret() []byte {
+	secret := &v1.Secret{}
+	a.waitForResource(a.Namespace, "webhook-certs", secret)
+	assert.NotEmpty(a.T, secret.Data["server-key.pem"])
+	assert.NotEmpty(a.T, secret.Data["server-cert.pem"])
+	ca := secret.Data["ca-cert.pem"]
+	assert.NotEmpty(a.T, ca)
+	return ca
+}
+
+func (a *MemberAwaitility) waitForWebhookConfig(ca []byte) {
+	actualMutWbhConf := &admv1.MutatingWebhookConfiguration{}
+	a.waitForResource("", "member-operator-webhook", actualMutWbhConf)
+	assert.Equal(a.T, bothWebhookLabels, actualMutWbhConf.Labels)
+	require.Len(a.T, actualMutWbhConf.Webhooks, 1)
+
+	webhook := actualMutWbhConf.Webhooks[0]
+	assert.Equal(a.T, "users.pods.webhook.sandbox", webhook.Name)
+	assert.Equal(a.T, []string{"v1"}, webhook.AdmissionReviewVersions)
+	assert.Equal(a.T, admv1.SideEffectClassNone, *webhook.SideEffects)
+	assert.Equal(a.T, int32(5), *webhook.TimeoutSeconds)
+	assert.Equal(a.T, admv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
+	assert.Equal(a.T, admv1.Ignore, *webhook.FailurePolicy)
+	assert.Equal(a.T, admv1.Equivalent, *webhook.MatchPolicy)
+	assert.Equal(a.T, codereadyToolchainProviderLabel, webhook.NamespaceSelector.MatchLabels)
+	assert.Equal(a.T, ca, webhook.ClientConfig.CABundle)
+	assert.Equal(a.T, "member-operator-webhook", webhook.ClientConfig.Service.Name)
+	assert.Equal(a.T, a.Namespace, webhook.ClientConfig.Service.Namespace)
+	assert.Equal(a.T, "/mutate-users-pods", *webhook.ClientConfig.Service.Path)
+	assert.Equal(a.T, int32(443), *webhook.ClientConfig.Service.Port)
+	require.Len(a.T, webhook.Rules, 1)
+
+	rule := webhook.Rules[0]
+	assert.Equal(a.T, []admv1.OperationType{admv1.Create, admv1.Update}, rule.Operations)
+	assert.Equal(a.T, []string{""}, rule.APIGroups)
+	assert.Equal(a.T, []string{"v1"}, rule.APIVersions)
+	assert.Equal(a.T, []string{"pods"}, rule.Resources)
+	assert.Equal(a.T, admv1.NamespacedScope, *rule.Scope)
 }


### PR DESCRIPTION
Verifies that all objects from the webhook template are properly deployed with the expected values
Checks that all pods that are created in the users' namespaces have the lower priority class set as well as the priority value. Pods that are created outside the users' namespaces are not touched by the webhook.

Paired with: https://github.com/codeready-toolchain/member-operator/pull/223