### PR TITLE
fix: create dummy basic tier before deploying the host operator

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -257,11 +257,12 @@ ifneq ($(IS_OS_3),)
 	cat ${HOST_REPO_PATH}/deploy/cluster_role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(HOST_NS)/ | oc apply -f -
 	oc apply -f ${HOST_REPO_PATH}/deploy/crds
 endif
-	$(MAKE) build-operator E2E_REPO_PATH=${HOST_REPO_PATH} REPO_NAME=host-operator SET_IMAGE_NAME=${HOST_IMAGE_NAME} IS_OTHER_IMAGE_SET=${MEMBER_IMAGE_NAME}${REG_IMAGE_NAME}
-	$(MAKE) deploy-operator E2E_REPO_PATH=${HOST_REPO_PATH} REPO_NAME=host-operator NAMESPACE=$(HOST_NS)
 	# also, add a single `NSTemplateTier` resource before the host-operator controller is deployed. This resource will be updated
 	# as the controller starts (which is a use-case for CRT-231)
+	oc apply -f ${HOST_REPO_PATH}/deploy/crds/toolchain_v1alpha1_nstemplatetier_crd.yaml
 	oc apply -f deploy/host-operator/nstemplatetier-basic.yaml -n $(HOST_NS)
+	$(MAKE) build-operator E2E_REPO_PATH=${HOST_REPO_PATH} REPO_NAME=host-operator SET_IMAGE_NAME=${HOST_IMAGE_NAME} IS_OTHER_IMAGE_SET=${MEMBER_IMAGE_NAME}${REG_IMAGE_NAME}
+	$(MAKE) deploy-operator E2E_REPO_PATH=${HOST_REPO_PATH} REPO_NAME=host-operator NAMESPACE=$(HOST_NS)
 
 .PHONY: build-registration
 build-registration:

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -105,6 +105,7 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 // email is set in "user-email" annotation
 // setTargetCluster defines if the UserSignup will be created with Spec.TargetCluster set to the first found member cluster name
 func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, username string, email string, setTargetCluster bool) *toolchainv1alpha1.UserSignup {
+	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
 	targetCluster := ""
 	if setTargetCluster {
 		memberCluster, ok, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, wait.ReadyToolchainCluster)


### PR DESCRIPTION
in the last few CI runs, there were failures when waiting for updated NSTemplateTier `basic` resource: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/codeready-toolchain_member-operator/222/pull-ci-codeready-toolchain-member-operator-master-e2e/1332392569098735616/build-log.txt
My best guess is that the setup logic waits for the host-operator being deployed and then it applies the dummy basic resource. But if the setup logic is too slow, then it updates the already created `basic` tier to the dummy version that cannot be then "fixed" by the operator logic.

To fix this, I deploy the `NSTemplateTier` CRD and create the dummy `basic` tier before deploying the host-operator

paired with: https://github.com/codeready-toolchain/host-operator/pull/327
