### PR TITLE
Update tests for basic-no-deactivation tier

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -41,7 +41,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	testingtiers := CreateAndApproveSignup(t, hostAwait, testingTiersName)
 
 	// all tiers to check - keep the basic as the last one, it will verify downgrade back to the default tier at the end of the test
-	tiersToCheck := []string{"advanced", "team", "basic-no-deactivation", "basic"}
+	tiersToCheck := []string{"advanced", "team", "basicdeactivationdisabled", "basic"}
 
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.NSTemplateTierList{}
@@ -256,7 +256,7 @@ func TestTierTemplates(t *testing.T) {
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
 	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))
-	// verify that we have 15 tier templates (basic: 4, advanced: 4, basic-no-deactivation 4, team 3)
+	// verify that we have 15 tier templates (basic: 4, advanced: 4, basicdeactivationdisabled 4, team 3)
 	require.NoError(t, err)
 	assert.Len(t, allTiers.Items, 15)
 }

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -41,7 +41,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	testingtiers := CreateAndApproveSignup(t, hostAwait, testingTiersName)
 
 	// all tiers to check - keep the basic as the last one, it will verify downgrade back to the default tier at the end of the test
-	tiersToCheck := []string{"advanced", "team", "basic"}
+	tiersToCheck := []string{"advanced", "team", "basic-no-deactivation", "basic"}
 
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.NSTemplateTierList{}
@@ -247,9 +247,9 @@ func TestTierTemplates(t *testing.T) {
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
 	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))
-	// verify that we have 11 tier templates (4+4+3)
+	// verify that we have 15 tier templates (basic: 4, advanced: 4, basic-no-deactivation 4, team 3)
 	require.NoError(t, err)
-	assert.Len(t, allTiers.Items, 11)
+	assert.Len(t, allTiers.Items, 15)
 }
 
 func TestUpdateOfNamespacesWithLegacyLabels(t *testing.T) {

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -62,6 +62,15 @@ func TestNSTemplateTiers(t *testing.T) {
 		// are different from `000000a` which is the value specified in the initial manifest (used for basic tier)
 		WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
 
+		// verify each tier's tier object values, this corresponds to the NSTemplateTier resource that each tier has
+		t.Run(fmt.Sprintf("tier object check for %s", tierToCheck), func(t *testing.T) {
+			tierChecks, err := tiers.NewChecks(tierToCheck)
+			require.NoError(t, err)
+			for _, check := range tierChecks.GetTierObjectChecks() {
+				check(t, hostAwait)
+			}
+		})
+
 		t.Run(fmt.Sprintf("promote to %s tier", tierToCheck), func(t *testing.T) {
 			// given
 			changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, testingTiersName, tierToCheck)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -128,9 +128,9 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		})
 	})
 
-	s.T().Run("tests for basic tier with deactivation disabled", func(t *testing.T) {
+	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
 		// Let's create a tier with deactivation disabled
-		noDeactivationTier := CreateNSTemplateTier(t, s.ctx, s.hostAwait, "deactivation-tier")
+		noDeactivationTier := CreateNSTemplateTier(t, s.ctx, s.hostAwait, "no-deactivation-tier")
 
 		// Move the user to the new tier without deactivation enabled
 		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignup.Spec.Username, *noDeactivationTier).Spec.UserAccounts[0].SyncIndex

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -172,9 +172,9 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			// Only the user with domain not on the exclusion list should be auto-deactivated
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
 			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+1)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated+1)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+1)
+			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated)
 		})
 	})
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -44,18 +44,16 @@ func (s *userManagementTestSuite) TearDownTest() {
 func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
 
-	// Get metrics assertion helper for testing metrics
-	metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
-
-	userSignup, mur := s.createAndCheckUserSignup(true, "iris", "iris@redhat.com", true, ApprovedByAdmin()...)
-	deactivationExcludedUserSignup, excludedMur := s.createAndCheckUserSignup(true, "pupil", "pupil@excluded.com", true, ApprovedByAdmin()...)
-
 	s.T().Run("deactivate a user", func(t *testing.T) {
+		// Initialize metrics assertion counts
+		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
 
-		t.Run("verify metrics are correct after creating usersignups", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)
+		userSignup, mur := s.createAndCheckUserSignup(true, "usertodeactivate", "usertodeactivate@redhat.com", true, ApprovedByAdmin()...)
+
+		t.Run("verify metrics are correct after creating usersignup", func(t *testing.T) {
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1)
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)
 			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 0)
 		})
 
@@ -86,63 +84,68 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.True(t, userSignup.Spec.Deactivated, "usersignup should be deactivated")
 
 		t.Run("verify metrics are correct after deactivation", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)            // one less because of deactivated user
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 0)            // one less because of deactivated user
 			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1) // one more because of deactivated user
 		})
-	})
 
-	s.T().Run("reactivate a deactivated user", func(t *testing.T) {
-		err := s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: userSignup.Namespace,
-			Name:      userSignup.Name,
-		}, userSignup)
-		require.NoError(s.T(), err)
+		s.T().Run("reactivate a deactivated user", func(t *testing.T) {
+			err := s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{
+				Namespace: userSignup.Namespace,
+				Name:      userSignup.Name,
+			}, userSignup)
+			require.NoError(s.T(), err)
 
-		userSignup, err := s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
-			us.Spec.Deactivated = false
-		})
-		require.NoError(s.T(), err)
-		s.T().Logf("user signup '%s' reactivated", userSignup.Name)
+			userSignup, err := s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+				us.Spec.Deactivated = false
+			})
+			require.NoError(s.T(), err)
+			s.T().Logf("user signup '%s' reactivated", userSignup.Name)
 
-		_, err = s.hostAwait.WaitForMasterUserRecord(mur.Name)
-		require.NoError(s.T(), err)
+			_, err = s.hostAwait.WaitForMasterUserRecord(mur.Name)
+			require.NoError(s.T(), err)
 
-		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
-		require.NoError(s.T(), err)
-		require.False(t, userSignup.Spec.Deactivated, "usersignup should not be deactivated")
+			userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
+				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+			require.NoError(s.T(), err)
+			require.False(t, userSignup.Spec.Deactivated, "usersignup should not be deactivated")
 
-		t.Run("verify metrics are correct after reactivating the user", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)            // no change
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)    // one more because of reactivated user
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)            // one more because of reactivated user
-			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1) // no change
+			t.Run("verify metrics are correct after reactivating the user", func(t *testing.T) {
+				metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)            // no change
+				metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)    // one more because of reactivated user
+				metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)            // one more because of reactivated user
+				metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1) // no change
+			})
 		})
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
+		// Initialize metrics assertion counts
+		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
+
+		userSignup, mur := s.createAndCheckUserSignup(true, "usernodeactivate", "usernodeactivate@redhat.com", true, ApprovedByAdmin()...)
+
 		// Get the basic tier that has deactivation disabled
 		basicDeactivationDisabledTier, err := s.hostAwait.WaitForNSTemplateTier("basicdeactivationdisabled")
 		require.NoError(t, err)
 
 		// Move the user to the new tier without deactivation enabled
 		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignup.Spec.Username, *basicDeactivationDisabledTier).Spec.UserAccounts[0].SyncIndex
-
-		t.Run("verify metrics are correct after moving user to new tier", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)            // no change
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)    // no change
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)            // no change
-			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1) // no change
-		})
-
-		// We cannot wait days so for the purposes of the e2e tests we use a hack to change the provisioned time to a time far enough
-		// in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
-		// time should test the behaviour of the deactivation controller reconciliation.
-		mur, err := s.hostAwait.WaitForMasterUserRecord(mur.Name,
+		mur, err = s.hostAwait.WaitForMasterUserRecord(mur.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
 			wait.UntilMasterUserRecordHasNotSyncIndex(murSyncIndex))
 		require.NoError(s.T(), err)
+
+		t.Run("verify metrics are correct after moving user to new tier", func(t *testing.T) {
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)            // 1 new signup
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1)    // 1 more approved signup
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)            // 1 mur for the approved signup
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 0) // signup not deactivated
+		})
+
+		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
+		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
+		// time should test the behaviour of the deactivation controller reconciliation.
 		manyManyDaysAgo := 999999999999999
 		durationDelta := time.Duration(manyManyDaysAgo) * time.Hour * 24
 		updatedProvisionedTime := &metav1.Time{Time: time.Now().Add(-durationDelta)}
@@ -161,32 +164,41 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.Error(s.T(), err)
 
 		t.Run("verify metrics are correct after provisioned time changed", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                // no change
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)        // no change
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)                // no change
-			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1)     // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1)        // no change
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 0)     // no change
 			metricsAssertion.WaitForMetricDelta(UserSignupsAutoDeactivatedMetric, 0) // no change
 		})
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
+		// Initialize metrics assertion counts
+		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
+
+		userSignup, mur := s.createAndCheckUserSignup(true, "usertoautodeactivate", "usertoautodeactivate@redhat.com", true, ApprovedByAdmin()...)
+		deactivationExcludedUserSignup, excludedMur := s.createAndCheckUserSignup(true, "userdeactivationexcluded", "userdeactivationexcluded@excluded.com", true, ApprovedByAdmin()...)
+
 		// Get the basic tier that has deactivation enabled
 		basicTier, err := s.hostAwait.WaitForNSTemplateTier("basic")
 		require.NoError(t, err)
 
-		// Move 2 users to the new tier with deactivation enabled - 1 with a domain that matches the deactivation exclusion list and 1 that does not
-		excludedSyncIndex := MoveUserToTier(t, s.hostAwait, deactivationExcludedUserSignup.Spec.Username, *basicTier).Spec.UserAccounts[0].SyncIndex
-		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignup.Spec.Username, *basicTier).Spec.UserAccounts[0].SyncIndex
-
-		mur, err := s.hostAwait.WaitForMasterUserRecord(mur.Name,
-			wait.UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
-			wait.UntilMasterUserRecordHasNotSyncIndex(murSyncIndex))
+		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
+		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
+		// time should test the behaviour of the deactivation controller reconciliation.
+		tierDeactivationDuration := time.Duration(basicTier.Spec.DeactivationTimeoutDays) * time.Hour * 24
+		mur, err = s.hostAwait.UpdateMasterUserRecordStatus(mur.Name, func(mur *v1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+		})
 		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted", mur.Name)
 
-		excludedMur, err := s.hostAwait.WaitForMasterUserRecord(excludedMur.Name,
-			wait.UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
-			wait.UntilMasterUserRecordHasNotSyncIndex(excludedSyncIndex))
+		// Use the same method above to change the provisioned time for the excluded user
+		excludedMur, err = s.hostAwait.UpdateMasterUserRecordStatus(excludedMur.Name, func(mur *v1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+		})
 		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted", excludedMur.Name)
 
 		// The non-excluded user should be deactivated
 		err = s.hostAwait.WaitUntilMasterUserRecordDeleted(mur.Name)
@@ -209,9 +221,9 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		t.Run("verify metrics are correct after auto deactivation", func(t *testing.T) {
 			// Only the user with domain not on the exclusion list should be auto-deactivated
 			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)
 			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 1)
-			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 2)
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1)
 			metricsAssertion.WaitForMetricDelta(UserSignupsAutoDeactivatedMetric, 1)
 		})
 	})

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -129,12 +129,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// Move the user to the new tier without deactivation enabled
 		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignup.Spec.Username, *basicDeactivationDisabledTier).Spec.UserAccounts[0].SyncIndex
 
-		t.Run("verify metrics are correct after moving users to new tiers", func(t *testing.T) {
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+1)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated)
+		t.Run("verify metrics are correct after moving user to new tier", func(t *testing.T) {
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)            // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)    // no change
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)            // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1) // no change
 		})
 
 		// We cannot wait days so for the purposes of the e2e tests we use a hack to change the provisioned time to a time far enough
@@ -161,13 +160,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		err = s.hostAwait.WaitUntilMasterUserRecordDeleted(mur.Name)
 		require.Error(s.T(), err)
 
-		t.Run("verify metrics are correct after auto deactivation", func(t *testing.T) {
-			// Only the user with domain not on the exclusion list should be auto-deactivated
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_total", baseUserSignups+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_approved_total", baseUserSignupsApproved+3)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_master_user_record_current", baseCurrentMURs+2)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_deactivated_total", baseUserSignupsDeactivated+1)
-			s.hostAwait.WaitUntilMetricHasValue("sandbox_user_signups_auto_deactivated_total", baseUserSignupsAutoDeactivated)
+		t.Run("verify metrics are correct after provisioned time changed", func(t *testing.T) {
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)        // no change
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1)     // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsAutoDeactivatedMetric, 0) // no change
 		})
 	})
 
@@ -180,12 +178,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		excludedSyncIndex := MoveUserToTier(t, s.hostAwait, deactivationExcludedUserSignup.Spec.Username, *basicTier).Spec.UserAccounts[0].SyncIndex
 		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignup.Spec.Username, *basicTier).Spec.UserAccounts[0].SyncIndex
 
-		t.Run("verify metrics are correct after moving users to new tiers", func(t *testing.T) {
-			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)
-			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)
-			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)
-			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1)
-			metricsAssertion.WaitForMetricDelta(UserSignupsAutoDeactivatedMetric, 0)
+		t.Run("verify metrics are correct after moving user to new tier", func(t *testing.T) {
+			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 3)        // no change
+			metricsAssertion.WaitForMetricDelta(CurrentMURsMetric, 2)                // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 1)     // no change
+			metricsAssertion.WaitForMetricDelta(UserSignupsAutoDeactivatedMetric, 0) // no change
 		})
 
 		// We cannot wait days for deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time to a time far enough

--- a/tiers/checks.go
+++ b/tiers/checks.go
@@ -33,6 +33,10 @@ func NewChecks(tier string) (TierChecks, error) {
 	case "basic":
 		return &basicTierChecks{}, nil
 
+	case "basic-no-deactivation":
+		// we want the basic-no-deactivation tier to have the same resources as the basic tier with the only difference being auto deactivation disabled
+		return &basicTierChecks{}, nil
+
 	case "advanced":
 		return &advancedTierChecks{}, nil
 

--- a/tiers/checks.go
+++ b/tiers/checks.go
@@ -22,10 +22,10 @@ import (
 
 // tier names
 const (
-	basic               = "basic"
-	basicNoDeactivation = "basic-no-deactivation"
-	advanced            = "advanced"
-	team                = "team"
+	basic                     = "basic"
+	basicdeactivationdisabled = "basicdeactivationdisabled"
+	advanced                  = "advanced"
+	team                      = "team"
 )
 
 var (
@@ -41,9 +41,9 @@ func NewChecks(tier string) (TierChecks, error) {
 	case basic:
 		return &basicTierChecks{tierName: basic}, nil
 
-	case basicNoDeactivation:
-		// we want the basic-no-deactivation tier to have the same resources as the basic tier with the only difference being auto deactivation disabled
-		return &basicNoDeactivationTierChecks{basicTierChecks{tierName: basicNoDeactivation}}, nil
+	case basicdeactivationdisabled:
+		// we want the basicdeactivationdisabled tier to have the same resources as the basic tier with the only difference being auto deactivation disabled
+		return &basicdeactivationdisabledTierChecks{basicTierChecks{tierName: basicdeactivationdisabled}}, nil
 
 	case advanced:
 		return &advancedTierChecks{tierName: advanced}, nil
@@ -63,11 +63,11 @@ type TierChecks interface {
 	GetTierObjectChecks() []tierObjectCheck
 }
 
-type basicNoDeactivationTierChecks struct {
+type basicdeactivationdisabledTierChecks struct {
 	basicTierChecks
 }
 
-func (a *basicNoDeactivationTierChecks) GetTierObjectChecks() []tierObjectCheck {
+func (a *basicdeactivationdisabledTierChecks) GetTierObjectChecks() []tierObjectCheck {
 	return []tierObjectCheck{nsTemplateTier(a.tierName, 0)}
 }
 

--- a/tiers/checks.go
+++ b/tiers/checks.go
@@ -20,6 +20,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// tier names
+const (
+	basic               = "basic"
+	basicNoDeactivation = "basic-no-deactivation"
+	advanced            = "advanced"
+	team                = "team"
+)
+
 var (
 	providerMatchingLabels = client.MatchingLabels(map[string]string{"toolchain.dev.openshift.com/provider": "codeready-toolchain"})
 	commonChecks           = []namespaceObjectsCheck{
@@ -30,18 +38,18 @@ var (
 
 func NewChecks(tier string) (TierChecks, error) {
 	switch tier {
-	case "basic":
-		return &basicTierChecks{}, nil
+	case basic:
+		return &basicTierChecks{tierName: basic}, nil
 
-	case "basic-no-deactivation":
+	case basicNoDeactivation:
 		// we want the basic-no-deactivation tier to have the same resources as the basic tier with the only difference being auto deactivation disabled
-		return &basicTierChecks{}, nil
+		return &basicNoDeactivationTierChecks{basicTierChecks{tierName: basicNoDeactivation}}, nil
 
-	case "advanced":
-		return &advancedTierChecks{}, nil
+	case advanced:
+		return &advancedTierChecks{tierName: advanced}, nil
 
-	case "team":
-		return &teamTierChecks{}, nil
+	case team:
+		return &teamTierChecks{tierName: team}, nil
 
 	default:
 		return nil, fmt.Errorf("no assertion implementation found for %s", tier)
@@ -52,9 +60,23 @@ type TierChecks interface {
 	GetNamespaceObjectChecks(nsType string) []namespaceObjectsCheck
 	GetClusterObjectChecks() []clusterObjectsCheck
 	GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs
+	GetTierObjectChecks() []tierObjectCheck
+}
+
+type basicNoDeactivationTierChecks struct {
+	basicTierChecks
+}
+
+func (a *basicNoDeactivationTierChecks) GetTierObjectChecks() []tierObjectCheck {
+	return []tierObjectCheck{nsTemplateTier(a.tierName, 0)}
 }
 
 type basicTierChecks struct {
+	tierName string
+}
+
+func (a *basicTierChecks) GetTierObjectChecks() []tierObjectCheck {
+	return []tierObjectCheck{nsTemplateTier(a.tierName, 1)}
 }
 
 func (a *basicTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObjectsCheck {
@@ -68,8 +90,8 @@ func (a *basicTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObj
 }
 
 func (a *basicTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, "basic")
-	verifyNsTypes(hostAwait.T, "basic", templateRefs, "code", "dev", "stage")
+	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
+	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "code", "dev", "stage")
 	return templateRefs
 }
 
@@ -107,6 +129,11 @@ func networkPolicyByType(nsType string) []namespaceObjectsCheck {
 }
 
 type advancedTierChecks struct {
+	tierName string
+}
+
+func (a *advancedTierChecks) GetTierObjectChecks() []tierObjectCheck {
+	return []tierObjectCheck{nsTemplateTier(a.tierName, 0)}
 }
 
 func (a *advancedTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObjectsCheck {
@@ -127,8 +154,8 @@ func (a *advancedTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 }
 
 func (a *advancedTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, "advanced")
-	verifyNsTypes(hostAwait.T, "advanced", templateRefs, "code", "dev", "stage")
+	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
+	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "code", "dev", "stage")
 	return templateRefs
 }
 
@@ -144,6 +171,11 @@ func (a *advancedTierChecks) limitRangeByType(nsType string) namespaceObjectsChe
 }
 
 type teamTierChecks struct {
+	tierName string
+}
+
+func (a *teamTierChecks) GetTierObjectChecks() []tierObjectCheck {
+	return []tierObjectCheck{nsTemplateTier(a.tierName, 0)}
 }
 
 func (a *teamTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObjectsCheck {
@@ -158,8 +190,8 @@ func (a *teamTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObje
 }
 
 func (a *teamTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, "team")
-	verifyNsTypes(hostAwait.T, "team", templateRefs, "dev", "stage")
+	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
+	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "stage")
 	return templateRefs
 }
 
@@ -188,6 +220,16 @@ func verifyNsTypes(t *testing.T, tier string, templateRefs TemplateRefs, expecte
 type namespaceObjectsCheck func(t *testing.T, ns *v1.Namespace, memberAwait *wait.MemberAwaitility, userName string)
 
 type clusterObjectsCheck func(t *testing.T, memberAwait *wait.MemberAwaitility, userName string)
+
+type tierObjectCheck func(t *testing.T, hostAwait *wait.HostAwaitility)
+
+func nsTemplateTier(tierName string, days int) tierObjectCheck {
+	return func(t *testing.T, hostAwait *wait.HostAwaitility) {
+		tier, err := hostAwait.WaitForNSTemplateTier(tierName)
+		require.NoError(t, err)
+		require.Equal(t, days, tier.Spec.DeactivationTimeoutDays)
+	}
+}
 
 func userEditRoleBinding() namespaceObjectsCheck {
 	return func(t *testing.T, ns *v1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {

--- a/wait/host.go
+++ b/wait/host.go
@@ -165,6 +165,19 @@ func (a *HostAwaitility) UpdateUserSignupSpec(userSignupName string, modifyUserS
 // MasterUserRecordWaitCriterion checks if a MasterUserRecord meets the given condition
 type MasterUserRecordWaitCriterion func(a *HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord) bool
 
+// UntilMasterUserRecordHasProvisionedTime checks if MasterUserRecord status has the given provisioned time
+func UntilMasterUserRecordHasProvisionedTime(expectedTime *v1.Time) MasterUserRecordWaitCriterion {
+	return func(a *HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord) bool {
+		if expectedTime.Time == mur.Status.ProvisionedTime.Time {
+			a.T.Logf("MasterUserRecord '%s' status has the expected provisioned time", mur.Name)
+			return true
+		}
+		a.T.Logf("waiting for status of MasterUserRecord '%s' to have the expected provisioned time. Actual: '%s'; Expected: '%s'",
+			mur.Name, mur.Status.ProvisionedTime.String(), expectedTime.String())
+		return false
+	}
+}
+
 // UntilMasterUserRecordHasCondition checks if MasterUserRecord status has the given conditions (among others)
 func UntilMasterUserRecordHasCondition(condition toolchainv1alpha1.Condition) MasterUserRecordWaitCriterion {
 	return func(a *HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord) bool {


### PR DESCRIPTION
Tests for https://github.com/codeready-toolchain/host-operator/pull/329

- Updates the nstemplatetier tests to include the new `basic-no-deactivation` tier.
- Adds a deactivation test to check that users in tiers without deactivation are indeed not deactivated.