### PR TITLE
fix: improve logging & checks of member operator webhook

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -70,11 +70,13 @@ print-logs:
 ifneq ($(OPENSHIFT_BUILD_NAMESPACE),)
 	$(MAKE) print-operator-logs REPO_NAME=host-operator NAMESPACE=${HOST_NS}
 	$(MAKE) print-operator-logs REPO_NAME=member-operator NAMESPACE=${MEMBER_NS}
+	$(MAKE) print-operator-logs REPO_NAME=member-operator-webhook NAMESPACE=${MEMBER_NS}
 	$(MAKE) print-operator-logs REPO_NAME=registration-service NAMESPACE=${REGISTRATION_SERVICE_NS}
 else
 	@echo "you can print logs using the commands:"
 	@echo "oc logs deployment.apps/host-operator --namespace ${HOST_NS}"
 	@echo "oc logs deployment.apps/member-operator --namespace ${MEMBER_NS}"
+	@echo "oc logs deployment.apps/member-operator-webhook --namespace ${MEMBER_NS}"
 	@echo "oc logs deployment.apps/registration-service --namespace ${REGISTRATION_SERVICE_NS}"
 endif
 


### PR DESCRIPTION
* print the member-operator-webhook log when tests fail
* print info while checking resources
* wait until the webhook deployment is ready