### PR TITLE
fix: use correct member-operator-webhook image name built from master

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -323,7 +323,7 @@ endif
 	else \
 		echo "${IMAGE_NAME}" > ${IMAGE_NAMES_DIR}/${REPO_NAME}; \
         if [[ ${REPO_NAME} == "member-operator" ]]; then \
-	    	echo "${IMAGE_NAME}" | sed 's/${REPO_NAME}/${REPO_NAME}-webhook/g' > ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook; \
+	    	echo `echo "${IMAGE_NAME}" | cut -d ":" -f1`":${REPO_NAME}-webhook" > ${IMAGE_NAMES_DIR}/${REPO_NAME}-webhook; \
 	    fi \
     fi
 


### PR DESCRIPTION
previous wrong image name:
```
registry.svc.ci.openshift.org/codeready-toolchain/member-operator-webhook-v0.1:member-operator-webhook
```
the new correct one

```
registry.svc.ci.openshift.org/codeready-toolchain/member-operator-v0.1:member-operator-webhook
```
