### PR TITLE
Wait for MURs to be deleted before gathering metrics

### DIFF
--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -15,7 +15,7 @@ type MetricsAssertionHelper struct {
 
 type metricsProvider interface {
 	GetMetricValue(family string, labels ...string) float64
-	WaitForUserSignupsBeingDeleted(initialDelay time.Duration) error
+	WaitForTestResourcesCleanup(initialDelay time.Duration) error
 	AssertMetricReachesValue(family string, expectedValue float64, labels ...string)
 }
 
@@ -32,7 +32,7 @@ const (
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
 func InitMetricsAssertion(t *testing.T, a metricsProvider) *MetricsAssertionHelper {
 	// Wait for pending usersignup deletions before capturing baseline values so that test assertions are stable
-	err := a.WaitForUserSignupsBeingDeleted(5 * time.Second)
+	err := a.WaitForTestResourcesCleanup(5 * time.Second)
 	require.NoError(t, err)
 
 	// Capture baseline values


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/352

The above PR updates the logic related to deleting user accounts to verify the deletion is completed before continuing with the MasterUserRecord deletion. As a side effect the MUR deletion can take longer. The `WaitForUserSignupsBeingDeleted` test helper function waits for UserSignups to be deleted before initializing metrics values for testing, however, UserSignups can currently be deleted whilst MURs are still being delete. This caused the MUR count that was captured at the beginning of the test to be inaccurate because some MURs were still being deleted.

This PR updates the e2e tests to also wait for the MURs to be deleted as a fix for the problem. It renames the `WaitForUserSignupsBeingDeleted` function to be the more generic name `WaitForTestResourcesCleanup` which makes sense since it can be implemented on the member awaitility as well.