### PR TITLE
Update e2e setup to deploy 2nd member operator

### DIFF
--- a/make/perf.mk
+++ b/make/perf.mk
@@ -14,6 +14,7 @@ test-perf: deploy-e2e perf-run
 perf-run:
 	oc get toolchaincluster -n $(HOST_NS)
 	oc get toolchaincluster -n $(MEMBER_NS)
+	oc get toolchaincluster -n ${MEMBER_NS_2}
 	-oc new-project $(TEST_NS) --display-name perf-tests 1>/dev/null
-	ARTIFACT_DIR=${ARTIFACT_DIR} USER_COUNT=3000 USER_BATCH_SIZE=100 MEMBER_NS=${MEMBER_NS} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/perf --no-setup --operator-namespace $(TEST_NS) --verbose --go-test-flags "-timeout=120m -failfast" || \
-	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
+	ARTIFACT_DIR=${ARTIFACT_DIR} USER_COUNT=3000 USER_BATCH_SIZE=100 MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} operator-sdk test local ./test/perf --no-setup --operator-namespace $(TEST_NS) --verbose --go-test-flags "-timeout=120m -failfast" || \
+	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)

--- a/make/test.mk
+++ b/make/test.mk
@@ -236,11 +236,12 @@ ifneq ($(IS_OS_3),)
 endif
 	$(MAKE) build-operator E2E_REPO_PATH=${MEMBER_REPO_PATH} REPO_NAME=member-operator SET_IMAGE_NAME=${MEMBER_IMAGE_NAME} IS_OTHER_IMAGE_SET=${HOST_IMAGE_NAME}${REG_IMAGE_NAME}
 	
-	$(MAKE) deploy-member MEMBER_NS_TO_DEPLOY=$(MEMBER_NS)
+	$(MAKE) deploy-member MEMBER_REPO_PATH=${MEMBER_REPO_PATH} MEMBER_NS_TO_DEPLOY=$(MEMBER_NS)
 	
+	@echo "Deploying second member without a deploy webhook since it can cause problems with the tests"
 	$(eval TMP_ENV_YAML := /tmp/${ENVIRONMENT}_${DATE_SUFFIX}.yaml)
 	sed 's|member-operator:|member-operator:\n  deploy-webhook: 'false'|' ${MEMBER_REPO_PATH}/deploy/env/${ENVIRONMENT}.yaml > ${TMP_ENV_YAML}
-	$(MAKE) deploy-member MEMBER_NS_TO_DEPLOY=$(MEMBER_NS_2) ENV_YAML=${TMP_ENV_YAML}
+	$(MAKE) deploy-member MEMBER_REPO_PATH=${MEMBER_REPO_PATH} MEMBER_NS_TO_DEPLOY=$(MEMBER_NS_2) ENV_YAML=${TMP_ENV_YAML}
 
 .PHONY: deploy-member
 deploy-member:

--- a/make/test.mk
+++ b/make/test.mk
@@ -110,10 +110,10 @@ endif
 
 .PHONY: setup-toolchainclusters
 setup-toolchainclusters:
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
 
 ###########################################################
 #
@@ -253,8 +253,8 @@ deploy-member:
 
 .PHONY: e2e-service-account
 e2e-service-account:
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/toolchain-common/master/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
 
 .PHONY: deploy-host
 deploy-host: build-registration

--- a/make/test.mk
+++ b/make/test.mk
@@ -111,9 +111,9 @@ endif
 .PHONY: setup-toolchainclusters
 setup-toolchainclusters:
 	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
 	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
 
 ###########################################################
 #
@@ -254,7 +254,7 @@ deploy-member:
 .PHONY: e2e-service-account
 e2e-service-account:
 	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
-	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2
 
 .PHONY: deploy-host
 deploy-host: build-registration

--- a/make/test.mk
+++ b/make/test.mk
@@ -110,10 +110,10 @@ endif
 
 .PHONY: setup-toolchainclusters
 setup-toolchainclusters:
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
 
 ###########################################################
 #
@@ -253,8 +253,8 @@ deploy-member:
 
 .PHONY: e2e-service-account
 e2e-service-account:
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
-	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
+	curl -sSL https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh | bash -s -- -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
 
 .PHONY: deploy-host
 deploy-host: build-registration

--- a/make/test.mk
+++ b/make/test.mk
@@ -110,10 +110,10 @@ endif
 
 .PHONY: setup-toolchainclusters
 setup-toolchainclusters:
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS)   -hn $(HOST_NS) -s
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t host   -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
 
 ###########################################################
 #
@@ -253,8 +253,8 @@ deploy-member:
 
 .PHONY: e2e-service-account
 e2e-service-account:
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
-	/Users/rajiv/go/src/github.com/codeready-toolchain/toolchain-common/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s
+	https://raw.githubusercontent.com/rajivnathan/toolchain-common/multiMember/scripts/add-cluster.sh -t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -ms
 
 .PHONY: deploy-host
 deploy-host: build-registration

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -37,7 +37,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 	userSignup := s.createAndCheckUserSignupNoMUR(specApproved, username, email, targetCluster, conditions...)
 
 	// Confirm the MUR was created and ready
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -16,9 +16,10 @@ import (
 
 type baseUserIntegrationTest struct {
 	suite.Suite
-	ctx         *framework.Context
-	hostAwait   *wait.HostAwaitility
-	memberAwait *wait.MemberAwaitility
+	ctx          *framework.Context
+	hostAwait    *wait.HostAwaitility
+	memberAwait  *wait.MemberAwaitility
+	memberAwait2 *wait.MemberAwaitility
 }
 
 // createAndCheckUserSignup creates a new UserSignup resoruce with the given values:
@@ -34,8 +35,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 	userSignup := s.createAndCheckUserSignupNoMUR(specApproved, username, email, setTargetCluster, conditions...)
 
 	// Confirm the MUR was created and ready
-
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait)
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -111,7 +111,7 @@ func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *v1alpha1.Us
 	notifications, err := s.hostAwait.WaitForNotifications(userSignup.Status.CompliantUsername, v1alpha1.NotificationTypeDeactivated, 1, wait.UntilNotificationHasConditions(Sent()))
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), notifications)
-	require.Equal(s.T(), 1, len(notifications))
+	require.Len(s.T(), notifications, 1)
 	notification := notifications[0]
 	assert.Contains(s.T(), notification.Name, userSignup.Status.CompliantUsername+"-deactivated-")
 	assert.Equal(s.T(), userSignup.Namespace, notification.Namespace)

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type baseUserIntegrationTest struct {
@@ -26,7 +28,7 @@ type baseUserIntegrationTest struct {
 // specApproved defines if the UserSignup should be manually approved
 // username defines the required username set in the spec
 // email is set in "user-email" annotation
-// setTargetCluster defines if the UserSignup will be created with Spec.TargetCluster set to the first found member cluster name
+// targetCluster ensures the UserSignup is created with Spec.TargetCluster set to member cluster associated with the provided member awaitility, a 'nil' value will skip setting Spec.TargetCluster
 //
 // The method then waits until the UserSignup contains the given set of conditions and the corresponding MUR is created
 func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, username string, email string, targetCluster *wait.MemberAwaitility,
@@ -46,7 +48,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 // specApproved defines if the UserSignup should be manually approved
 // username defines the required username set in the spec
 // email is set in "user-email" annotation
-// setTargetCluster defines if the UserSignup will be created with Spec.TargetCluster set to the first found member cluster name
+// targetCluster ensures the UserSignup is created with Spec.TargetCluster set to member cluster associated with the provided member awaitility, a 'nil' value will skip setting Spec.TargetCluster
 //
 // The method then waits until the UserSignup contains the given set of conditions
 func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved bool, username string, email string, targetCluster *wait.MemberAwaitility,
@@ -93,4 +95,58 @@ func newBannedUser(host *wait.HostAwaitility, email string) *v1alpha1.BannedUser
 			Email: email,
 		},
 	}
+}
+
+func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *v1alpha1.UserSignup, mur *v1alpha1.MasterUserRecord) {
+	userSignup, err := s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+		us.Spec.Deactivated = true
+	})
+	require.NoError(s.T(), err)
+	s.T().Logf("user signup '%s' set to deactivated", userSignup.Name)
+
+	err = s.hostAwait.WaitUntilMasterUserRecordDeleted(mur.Name)
+	require.NoError(s.T(), err)
+
+	// "deactivated"
+	notifications, err := s.hostAwait.WaitForNotifications(userSignup.Status.CompliantUsername, v1alpha1.NotificationTypeDeactivated, 1, wait.UntilNotificationHasConditions(Sent()))
+	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), notifications)
+	require.Equal(s.T(), 1, len(notifications))
+	notification := notifications[0]
+	assert.Contains(s.T(), notification.Name, userSignup.Status.CompliantUsername+"-deactivated-")
+	assert.Equal(s.T(), userSignup.Namespace, notification.Namespace)
+	assert.Equal(s.T(), "userdeactivated", notification.Spec.Template)
+	assert.Equal(s.T(), userSignup.Name, notification.Spec.UserID)
+
+	err = s.hostAwait.WaitUntilNotificationsDeleted(userSignup.Status.CompliantUsername, v1alpha1.NotificationTypeDeactivated)
+	require.NoError(s.T(), err)
+
+	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+		wait.UntilUserSignupHasConditions(Deactivated()...),
+		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueDeactivated))
+	require.NoError(s.T(), err)
+	require.True(s.T(), userSignup.Spec.Deactivated, "usersignup should be deactivated")
+}
+
+func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *v1alpha1.UserSignup, mur *v1alpha1.MasterUserRecord) {
+	err := s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: userSignup.Namespace,
+		Name:      userSignup.Name,
+	}, userSignup)
+	require.NoError(s.T(), err)
+
+	userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+		us.Spec.Deactivated = false
+	})
+	require.NoError(s.T(), err)
+	s.T().Logf("user signup '%s' reactivated", userSignup.Name)
+
+	_, err = s.hostAwait.WaitForMasterUserRecord(mur.Name)
+	require.NoError(s.T(), err)
+
+	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+		wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
+		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+	require.NoError(s.T(), err)
+	require.False(s.T(), userSignup.Spec.Deactivated, "usersignup should not be deactivated")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,7 +20,7 @@ import (
 func TestE2EFlow(t *testing.T) {
 	// given
 	// full flow from usersignup with approval down to namespaces creation
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
 	defer ctx.Cleanup()
 	hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Disabled())
 	consoleURL := memberAwait.GetConsoleURL()
@@ -64,9 +64,9 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup := CreateAndApproveSignup(t, hostAwait, johnsmithName)
+	johnSignup := CreateAndApproveSignup(t, hostAwait, johnsmithName, memberAwait.ClusterName)
 	extrajohnName := "extrajohn"
-	johnExtraSignup := CreateAndApproveSignup(t, hostAwait, extrajohnName)
+	johnExtraSignup := CreateAndApproveSignup(t, hostAwait, extrajohnName, memberAwait.ClusterName)
 
 	VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, johnSignup, "basic")
 	VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, johnExtraSignup, "basic")

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -33,12 +33,12 @@ const (
 func TestNSTemplateTiers(t *testing.T) {
 	// given
 	tierList := &toolchainv1alpha1.NSTemplateTierList{}
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, tierList)
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, tierList)
 	defer ctx.Cleanup()
 
 	// Create and approve "testingtiers" signups
 	testingTiersName := "testingtiers"
-	testingtiers := CreateAndApproveSignup(t, hostAwait, testingTiersName)
+	testingtiers := CreateAndApproveSignup(t, hostAwait, testingTiersName, memberAwait.ClusterName)
 
 	// all tiers to check - keep the basic as the last one, it will verify downgrade back to the default tier at the end of the test
 	tiersToCheck := []string{"advanced", "team", "basicdeactivationdisabled", "basic"}
@@ -101,13 +101,13 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	// So, in this test, we verify that namespace resources and cluster resources are updated, on 2 groups of users with different tiers ;)
 
 	count := 2*MaxPoolSize + 1
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, &toolchainv1alpha1.NSTemplateTier{})
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.NSTemplateTier{})
 	defer ctx.Cleanup()
 
 	// first group of users: the "cheesecake lovers"
-	cheesecakeSyncIndexes := setupAccounts(t, ctx, hostAwait, "cheesecake", "cheesecakelover%02d", count)
+	cheesecakeSyncIndexes := setupAccounts(t, ctx, hostAwait, "cheesecake", "cheesecakelover%02d", memberAwait.ClusterName, count)
 	// second group of users: the "cookie lovers"
-	cookieSyncIndexes := setupAccounts(t, ctx, hostAwait, "cookie", "cookielover%02d", count)
+	cookieSyncIndexes := setupAccounts(t, ctx, hostAwait, "cookie", "cookielover%02d", memberAwait.ClusterName, count)
 
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespaces (ie, same number of namespaces) but keep the ClusterResources refs
 	updateTemplateTier(t, hostAwait, "cheesecake", "advanced", "")
@@ -142,14 +142,14 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 // 2. creating 10 users (signups, MURs, etc.)
 // 3. promoting the users to the new tier
 // returns the tier, users and their "syncIndexes"
-func setupAccounts(t *testing.T, ctx *test.Context, hostAwait *HostAwaitility, tierName, nameFmt string, count int) map[string]string {
+func setupAccounts(t *testing.T, ctx *test.Context, hostAwait *HostAwaitility, tierName, nameFmt, targetCluster string, count int) map[string]string {
 	// first, let's create the a new NSTemplateTier (to avoid messing with other tiers)
 	tier := CreateNSTemplateTier(t, ctx, hostAwait, tierName)
 
 	// let's create a few users (more than `maxPoolSize`)
 	users := make([]toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
-		users[i] = CreateAndApproveSignup(t, hostAwait, fmt.Sprintf(nameFmt, i))
+		users[i] = CreateAndApproveSignup(t, hostAwait, fmt.Sprintf(nameFmt, i), targetCluster)
 	}
 	// and wait until there are all provisioned
 	for i := range users {
@@ -231,6 +231,9 @@ func verifyResourceUpdates(t *testing.T, hostAwait *HostAwaitility, memberAwaiti
 			UntilUserAccountHasConditions(Provisioned()),
 			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Name, tier.Name, templateRefs)),
 			UntilUserAccountMatchesMur(hostAwait))
+		if err != nil {
+			t.Logf("Failing UserSignup: %+v", usersignup)
+		}
 		require.NoError(t, err)
 		_, err = hostAwait.WaitForMasterUserRecord(usersignup.Status.CompliantUsername,
 			UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
@@ -251,7 +254,7 @@ func verifyResourceUpdates(t *testing.T, hostAwait *HostAwaitility, memberAwaiti
 func TestTierTemplates(t *testing.T) {
 	// given
 	tierList := &toolchainv1alpha1.NSTemplateTierList{}
-	ctx, hostAwait, _ := WaitForDeployments(t, tierList)
+	ctx, hostAwait, _, _ := WaitForDeployments(t, tierList)
 	defer ctx.Cleanup()
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
@@ -264,7 +267,7 @@ func TestTierTemplates(t *testing.T) {
 func TestUpdateOfNamespacesWithLegacyLabels(t *testing.T) {
 	// given
 	tierList := &toolchainv1alpha1.NSTemplateTierList{}
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, tierList)
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, tierList)
 	defer ctx.Cleanup()
 	for _, nsType := range []string{"code", "dev", "stage"} {
 		err := memberAwait.Client.Create(context.TODO(), &corev1.Namespace{
@@ -282,7 +285,7 @@ func TestUpdateOfNamespacesWithLegacyLabels(t *testing.T) {
 	}
 
 	// when
-	legacySignup := CreateAndApproveSignup(t, hostAwait, "legacy")
+	legacySignup := CreateAndApproveSignup(t, hostAwait, "legacy", memberAwait.ClusterName)
 
 	// then
 	VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, legacySignup, "basic")

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -55,7 +55,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	var changeTierRequestNames []string
 
 	// wait for the user to be provisioned for the first time
-	VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, testingtiers, "basic")
+	VerifyResourcesProvisionedForSignup(t, hostAwait, testingtiers, "basic", memberAwait)
 	for _, tierToCheck := range tiersToCheck {
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
@@ -82,7 +82,7 @@ func TestNSTemplateTiers(t *testing.T) {
 			require.NoError(t, err)
 			_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, testingtiers, tierToCheck)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, testingtiers, tierToCheck, memberAwait)
 			changeTierRequestNames = append(changeTierRequestNames, changeTierRequest.Name)
 		})
 	}
@@ -288,5 +288,5 @@ func TestUpdateOfNamespacesWithLegacyLabels(t *testing.T) {
 	legacySignup := CreateAndApproveSignup(t, hostAwait, "legacy", memberAwait.ClusterName)
 
 	// then
-	VerifyResourcesProvisionedForSignup(t, hostAwait, memberAwait, legacySignup, "basic")
+	VerifyResourcesProvisionedForSignup(t, hostAwait, legacySignup, "basic", memberAwait)
 }

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -231,10 +231,7 @@ func verifyResourceUpdates(t *testing.T, hostAwait *HostAwaitility, memberAwaiti
 			UntilUserAccountHasConditions(Provisioned()),
 			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Name, tier.Name, templateRefs)),
 			UntilUserAccountMatchesMur(hostAwait))
-		if err != nil {
-			t.Logf("Failing UserSignup: %+v", usersignup)
-		}
-		require.NoError(t, err)
+		require.NoError(t, err, "Failing UserSignup: %+v", usersignup)
 		_, err = hostAwait.WaitForMasterUserRecord(usersignup.Status.CompliantUsername,
 			UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
 			UntilMasterUserRecordHasNotSyncIndex(syncIndex),

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -295,11 +295,12 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 
 		// Approve usersignup.
 		userSignup.Spec.Approved = true
+		userSignup.Spec.TargetCluster = s.memberAwait.ClusterName
 		err = s.hostAwait.Client.Update(context.TODO(), userSignup)
 		require.NoError(s.T(), err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait)
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		s.assertGetSignupStatusProvisioned(identity.Username, token)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -43,7 +43,7 @@ type registrationServiceTestSuite struct {
 
 func (s *registrationServiceTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.hostAwait, s.memberAwait = WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
 	s.namespace = s.hostAwait.RegistrationServiceNs
 	s.route = s.hostAwait.RegistrationServiceURL
 }
@@ -125,7 +125,7 @@ func (s *registrationServiceTestSuite) TestWoopra() {
 
 	s.Run("get woopra domain 200 OK", func() {
 		// Call woopra domain endpoint.
-		assertNotSecuredGetResponseEquals("woopra-domain",  "test woopra domain")
+		assertNotSecuredGetResponseEquals("woopra-domain", "test woopra domain")
 	})
 
 	s.Run("get segment write key 200 OK", func() {

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestToolchainClusterE2E(t *testing.T) {
 	toolchainClusterList := &v1alpha1.ToolchainClusterList{}
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, toolchainClusterList)
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, toolchainClusterList)
 	defer ctx.Cleanup()
 
 	verifyToolchainCluster(t, hostAwait.Awaitility, memberAwait.Awaitility)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -48,7 +48,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// Initialize metrics assertion counts
 		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
 
-		userSignup, mur := s.createAndCheckUserSignup(true, "usertodeactivate", "usertodeactivate@redhat.com", true, ApprovedByAdmin()...)
+		userSignup, mur := s.createAndCheckUserSignup(true, "usertodeactivate", "usertodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 
 		t.Run("verify metrics are correct after creating usersignup", func(t *testing.T) {
 			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
@@ -126,7 +126,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// Initialize metrics assertion counts
 		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
 
-		userSignup, mur := s.createAndCheckUserSignup(true, "usernodeactivate", "usernodeactivate@redhat.com", true, ApprovedByAdmin()...)
+		userSignup, mur := s.createAndCheckUserSignup(true, "usernodeactivate", "usernodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 
 		// Get the basic tier that has deactivation disabled
 		basicDeactivationDisabledTier, err := s.hostAwait.WaitForNSTemplateTier("basicdeactivationdisabled")
@@ -179,8 +179,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// Initialize metrics assertion counts
 		metricsAssertion := InitMetricsAssertion(s.T(), s.hostAwait)
 
-		userSignup, mur := s.createAndCheckUserSignup(true, "usertoautodeactivate", "usertoautodeactivate@redhat.com", true, ApprovedByAdmin()...)
-		deactivationExcludedUserSignup, excludedMur := s.createAndCheckUserSignup(true, "userdeactivationexcluded", "userdeactivationexcluded@excluded.com", true, ApprovedByAdmin()...)
+		userSignup, mur := s.createAndCheckUserSignup(true, "usertoautodeactivate", "usertoautodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
+		deactivationExcludedUserSignup, excludedMur := s.createAndCheckUserSignup(true, "userdeactivationexcluded", "userdeactivationexcluded@excluded.com", s.memberAwait, ApprovedByAdmin()...)
 
 		// Get the basic tier that has deactivation enabled
 		basicTier, err := s.hostAwait.WaitForNSTemplateTier("basic")
@@ -241,7 +241,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
 
 		// Create a new UserSignup and confirm it was approved automatically
-		userSignup, _ := s.createAndCheckUserSignup(false, "banprovisioned", "banprovisioned@test.com", true, ApprovedAutomatically()...)
+		userSignup, _ := s.createAndCheckUserSignup(false, "banprovisioned", "banprovisioned@test.com", s.memberAwait, ApprovedAutomatically()...)
 
 		// Create the BannedUser
 		s.createAndCheckBannedUser(userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
@@ -276,7 +276,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.createAndCheckBannedUser(email)
 
 		// Check that no MUR created
-		userSignup := s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, true, Banned()...)
+		userSignup := s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, s.memberAwait, Banned()...)
 		assert.Equal(t, v1alpha1.UserSignupStateLabelValueBanned, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
 		mur, err := s.hostAwait.GetMasterUserRecord(wait.WithMurName("testuser" + id))
 		require.NoError(s.T(), err)
@@ -333,7 +333,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
 
 		// Create a new UserSignup and confirm it was approved automatically
-		userSignup, mur := s.createAndCheckUserSignup(false, "banandunban", "banandunban@test.com", true, ApprovedAutomatically()...)
+		userSignup, mur := s.createAndCheckUserSignup(false, "banandunban", "banandunban@test.com", s.memberAwait, ApprovedAutomatically()...)
 
 		// Create the BannedUser
 		bannedUser := s.createAndCheckBannedUser(userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -52,7 +52,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		userSignup, mur := s.createAndCheckUserSignup(true, "usertodeactivate", "usertodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 
 		// User on member cluster 2
-		userSignupMember2, murMember2 := s.createAndCheckUserSignup(true, "usertodeactivate", "usertodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
+		userSignupMember2, murMember2 := s.createAndCheckUserSignup(true, "usertodeactivate2", "usertodeactivate2@redhat.com", s.memberAwait2, ApprovedByAdmin()...)
 
 		t.Run("verify metrics are correct after creating usersignup", func(t *testing.T) {
 			metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -34,7 +34,7 @@ type userManagementTestSuite struct {
 
 func (s *userManagementTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.hostAwait, s.memberAwait = WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
 }
 
 func (s *userManagementTestSuite) TearDownTest() {
@@ -378,7 +378,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval())
 
 	// Create UserSignup
-	userSignup := CreateAndApproveSignup(s.T(), s.hostAwait, "janedoe")
+	userSignup := CreateAndApproveSignup(s.T(), s.hostAwait, "janedoe", s.memberAwait.ClusterName)
 
 	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, userSignup, "basic")
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -380,7 +380,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	// Create UserSignup
 	userSignup := CreateAndApproveSignup(s.T(), s.hostAwait, "janedoe", s.memberAwait.ClusterName)
 
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait)
 
 	// Get MasterUserRecord
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username)
@@ -424,6 +424,6 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, userSignup, "basic")
+		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait)
 	})
 }

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -39,7 +39,7 @@ func (s *userWorkloadsTestSuite) TearDownTest() {
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	// Provision a user to idle with a short idling timeout
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
-	s.createAndCheckUserSignup(true, "test-idler", "test-idler@redhat.com", true, ApprovedByAdmin()...)
+	s.createAndCheckUserSignup(true, "test-idler", "test-idler@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 	idler, err := s.memberAwait.WaitForIdler("test-idler-dev", wait.IdlerConditions(Running()))
 	require.NoError(s.T(), err)
 

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -29,7 +29,7 @@ type userWorkloadsTestSuite struct {
 }
 
 func (s *userWorkloadsTestSuite) SetupSuite() {
-	s.ctx, s.hostAwait, s.memberAwait = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
+	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
 }
 
 func (s *userWorkloadsTestSuite) TearDownTest() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -26,7 +26,7 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 
 func (s *userSignupIntegrationTest) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.hostAwait, s.memberAwait = WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
 }
 
 func (s *userSignupIntegrationTest) TearDownTest() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -26,7 +26,7 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 
 func (s *userSignupIntegrationTest) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.hostAwait, s.memberAwait, s.memberAwait2 = WaitForDeployments(s.T(), userSignupList)
 }
 
 func (s *userSignupIntegrationTest) TearDownTest() {
@@ -59,7 +59,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 		})
 	})
 
@@ -89,7 +89,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -101,7 +102,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
 					wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
-				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+
+				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 			})
 		})
 	})
@@ -161,7 +163,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 		})
 	})
 
@@ -184,7 +186,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 		})
 	})
 
@@ -223,7 +225,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, s.memberAwait, *userSignup, "basic")
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.memberAwait2)
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -38,14 +38,14 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
 
 	// when & then
-	s.createAndCheckUserSignup(false, "automatic1", "automatic1@redhat.com", false, ApprovedAutomatically()...)
+	s.createAndCheckUserSignup(false, "automatic1", "automatic1@redhat.com", nil, ApprovedAutomatically()...)
 
 	s.T().Run("set low capacity threshold and expect that user won't be approved nor provisioned", func(t *testing.T) {
 		// given
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled().ResourceCapThreshold(1))
 
 		// when
-		userSignup := s.createAndCheckUserSignupNoMUR(false, "automatic2", "automatic2@redhat.com", false, PendingApprovalNoCluster()...)
+		userSignup := s.createAndCheckUserSignupNoMUR(false, "automatic2", "automatic2@redhat.com", nil, PendingApprovalNoCluster()...)
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -71,10 +71,10 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled().MaxUsersNumber(initialMurCount))
 
 		// when
-		userSignup1 := s.createAndCheckUserSignupNoMUR(false, "waitinglist1", "waitinglist1@redhat.com", false, PendingApprovalNoCluster()...)
+		userSignup1 := s.createAndCheckUserSignupNoMUR(false, "waitinglist1", "waitinglist1@redhat.com", nil, PendingApprovalNoCluster()...)
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
-		userSignup2 := s.createAndCheckUserSignupNoMUR(false, "waitinglist2", "waitinglist2@redhat.com", false, PendingApprovalNoCluster()...)
+		userSignup2 := s.createAndCheckUserSignupNoMUR(false, "waitinglist2", "waitinglist2@redhat.com", nil, PendingApprovalNoCluster()...)
 
 		// then
 		s.userIsNotProvisioned(t, userSignup1)
@@ -123,12 +123,12 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
-			userSignup, _ := s.createAndCheckUserSignup(true, "manual1", "manual1@redhat.com", false, ApprovedByAdmin()...)
+			userSignup, _ := s.createAndCheckUserSignup(true, "manual1", "manual1@redhat.com", nil, ApprovedByAdmin()...)
 			assert.Equal(t, v1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
-			userSignup := s.createAndCheckUserSignupNoMUR(false, "manual2", "manual2@redhat.com", false, PendingApproval()...)
+			userSignup := s.createAndCheckUserSignupNoMUR(false, "manual2", "manual2@redhat.com", nil, PendingApproval()...)
 
 			// then
 			s.userIsNotProvisioned(t, userSignup)
@@ -142,14 +142,14 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Disabled())
 
 	// when & then
-	s.createAndCheckUserSignup(true, "manualwithcapacity1", "manualwithcapacity1@redhat.com", false, ApprovedByAdmin()...)
+	s.createAndCheckUserSignup(true, "manualwithcapacity1", "manualwithcapacity1@redhat.com", nil, ApprovedByAdmin()...)
 
 	s.T().Run("set low capacity threshold and expect that user won't provisioned even when is approved manually", func(t *testing.T) {
 		// given
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Disabled().ResourceCapThreshold(1))
 
 		// when
-		userSignup := s.createAndCheckUserSignupNoMUR(true, "manualwithcapacity2", "manualwithcapacity2@redhat.com", false, ApprovedByAdminNoCluster()...)
+		userSignup := s.createAndCheckUserSignupNoMUR(true, "manualwithcapacity2", "manualwithcapacity2@redhat.com", nil, ApprovedByAdminNoCluster()...)
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -172,7 +172,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Disabled().MaxUsersNumber(1))
 
 		// when
-		userSignup := s.createAndCheckUserSignupNoMUR(true, "manualwithcapacity3", "manualwithcapacity3@redhat.com", false, ApprovedByAdminNoCluster()...)
+		userSignup := s.createAndCheckUserSignupNoMUR(true, "manualwithcapacity3", "manualwithcapacity3@redhat.com", nil, ApprovedByAdminNoCluster()...)
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -195,7 +195,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Disabled().ResourceCapThreshold(1).MaxUsersNumber(1))
 
 		// when & then
-		userSignup, _ := s.createAndCheckUserSignup(true, "withtargetcluster", "withtargetcluster@redhat.com", true, ApprovedByAdmin()...)
+		userSignup, _ := s.createAndCheckUserSignup(true, "withtargetcluster", "withtargetcluster@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 		assert.Equal(t, v1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
 	})
 }
@@ -214,7 +214,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	// Create user signup
 	s.hostAwait.UpdateHostOperatorConfig(test.AutomaticApproval().Enabled())
 
-	userSignup := NewUserSignup(s.T(), s.hostAwait, s.memberAwait, "reginald@alpha.com", "reginald@alpha.com", false)
+	userSignup := NewUserSignup(s.T(), s.hostAwait, "reginald@alpha.com", "reginald@alpha.com")
 
 	err := s.hostAwait.FrameworkClient.Create(context.TODO(), userSignup, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)
@@ -230,33 +230,33 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {
 	// Create UserSignup with a username that we don't need to transform
-	userSignup, _ := s.createAndCheckUserSignup(true, "paul-no-need-to-transform", "paulnoneedtotransform@hotel.com", true, ApprovedByAdmin()...)
+	userSignup, _ := s.createAndCheckUserSignup(true, "paul-no-need-to-transform", "paulnoneedtotransform@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-no-need-to-transform", userSignup.Status.CompliantUsername)
 
 	// Create UserSignup with a username to transform
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", true, ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the original username matching the transformed username of the existing signup
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul", "paulathotel@hotel.com", true, ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul", "paulathotel@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-2", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the same original username but different user ID
-	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", true, ApprovedByAdmin()...)
+	userSignup, _ = s.createAndCheckUserSignup(true, "paul@hotel.com", "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 	require.Equal(s.T(), "paul-3", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignups with a forbidden prefix
 	for _, prefix := range []string{"kube", "openshift", "default", "redhat"} {
 		// prefix with hyphen
-		userSignup, _ = s.createAndCheckUserSignup(true, prefix+"-paul", "paul@hotel.com", true, ApprovedByAdmin()...)
+		userSignup, _ = s.createAndCheckUserSignup(true, prefix+"-paul", "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 		require.Equal(s.T(), fmt.Sprintf("crt-%s-paul", prefix), userSignup.Status.CompliantUsername)
 
 		// prefix without delimiter
-		userSignup, _ = s.createAndCheckUserSignup(true, prefix+"paul", "paul@hotel.com", true, ApprovedByAdmin()...)
+		userSignup, _ = s.createAndCheckUserSignup(true, prefix+"paul", "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 		require.Equal(s.T(), fmt.Sprintf("crt-%spaul", prefix), userSignup.Status.CompliantUsername)
 
 		// prefix as a name
-		userSignup, _ = s.createAndCheckUserSignup(true, prefix, "paul@hotel.com", true, ApprovedByAdmin()...)
+		userSignup, _ = s.createAndCheckUserSignup(true, prefix, "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 		require.Equal(s.T(), fmt.Sprintf("crt-%s", prefix), userSignup.Status.CompliantUsername)
 	}
 }
@@ -265,7 +265,8 @@ func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAsser
 	// Create a new UserSignup
 	username := "testuser" + uuid.NewV4().String()
 	email := username + "@test.com"
-	userSignup := NewUserSignup(s.T(), s.hostAwait, s.memberAwait, username, email, true)
+	userSignup := NewUserSignup(s.T(), s.hostAwait, username, email)
+	userSignup.Spec.TargetCluster = s.memberAwait.ClusterName
 
 	// Set approved to true
 	userSignup.Spec.Approved = true

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -33,7 +33,7 @@ func TestPerformance(t *testing.T) {
 	logger, out, err := initLogger()
 	require.NoError(t, err)
 	defer out.Close()
-	ctx, hostAwait, memberAwait := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
+	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.UserSignupList{})
 	hostAwait.Timeout = 5 * time.Minute
 	memberAwait.Timeout = 5 * time.Minute
 	defer ctx.Cleanup()

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -2,7 +2,6 @@ package testsupport
 
 import (
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -94,9 +93,9 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *
 }
 
 func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.HostAwaitility, namespace string) *wait.MemberAwaitility {
-	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", namespace, wait.ReadyToolchainCluster)
+	memberClusterE2e, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", namespace, wait.ReadyToolchainCluster)
 	require.NoError(t, err)
-	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberCluster, 3*time.Second)
+	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberClusterE2e, 3*time.Second)
 	require.NoError(t, err)
 
 	kubeClient, err := kubernetes.NewForConfig(memberConfig)
@@ -109,7 +108,10 @@ func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.H
 	})
 
 	require.NoError(t, err)
-	clusterName := strings.Replace(memberCluster.Name, "e2e-", "member-", 1)
+
+	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition("member", namespace, wait.ReadyToolchainCluster)
+	require.NoError(t, err)
+	clusterName := memberCluster.Name
 	return wait.NewMemberAwaitility(t, memberClient, namespace, clusterName)
 }
 

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -29,7 +29,7 @@ import (
 // that represents the current operator that is the target of the e2e test it retrieves namespace names.
 // Also waits for the registration service to be deployed (with 3 replica)
 // Returns the test context and an instance of Awaitility that contains all necessary information
-func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *wait.HostAwaitility, *wait.MemberAwaitility) {
+func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *wait.HostAwaitility, *wait.MemberAwaitility, *wait.MemberAwaitility) {
 	schemeBuilder := newSchemeBuilder()
 	err := framework.AddToFrameworkScheme(schemeBuilder.AddToScheme, obj)
 	require.NoError(t, err, "failed to add custom resource to framework scheme")
@@ -41,6 +41,7 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *
 	t.Log("Initialized cluster resources")
 
 	memberNs := os.Getenv(wait.MemberNsVar)
+	memberNs2 := os.Getenv(wait.MemberNsVar2)
 	hostNs := os.Getenv(wait.HostNsVar)
 	registrationServiceNs := os.Getenv(wait.RegistrationServiceVar)
 
@@ -72,21 +73,9 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *
 	hostAwait.MetricsURL = hostMetricsRoute.Status.Ingress[0].Host
 
 	// wait for member operator to be ready
-	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", memberNs, wait.ReadyToolchainCluster)
-	require.NoError(t, err)
-	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberCluster, 3*time.Second)
-	require.NoError(t, err)
+	memberAwait := getMemberAwaitility(t, f, hostAwait, memberNs)
 
-	kubeClient, err := kubernetes.NewForConfig(memberConfig)
-	require.NoError(t, err)
-	err = sdkutil.WaitForDeployment(t, kubeClient, memberNs, "member-operator", 1, wait.DefaultOperatorRetryInterval, wait.DefaultOperatorTimeout)
-	require.NoError(t, err, "failed while waiting for member operator deployment")
-
-	memberClient, err := client.New(memberConfig, client.Options{
-		Scheme: f.Scheme,
-	})
-	require.NoError(t, err)
-	memberAwait := wait.NewMemberAwaitility(t, memberClient, memberNs)
+	memberAwait2 := getMemberAwaitility(t, f, hostAwait, memberNs2)
 
 	// setup member metrics route for metrics verification in tests
 	memberMetricsRoute, err := memberAwait.SetupRouteForService("member-operator-metrics", "/metrics")
@@ -97,7 +86,26 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *
 	require.NoError(t, err)
 
 	t.Log("both operators are ready and in running state")
-	return ctx, hostAwait, memberAwait
+	return ctx, hostAwait, memberAwait, memberAwait2
+}
+
+func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.HostAwaitility, namespace string) *wait.MemberAwaitility {
+	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", namespace, wait.ReadyToolchainCluster)
+	require.NoError(t, err)
+	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberCluster, 3*time.Second)
+	require.NoError(t, err)
+
+	kubeClient, err := kubernetes.NewForConfig(memberConfig)
+	require.NoError(t, err)
+	err = sdkutil.WaitForDeployment(t, kubeClient, namespace, "member-operator", 1, wait.DefaultOperatorRetryInterval, wait.DefaultOperatorTimeout)
+	require.NoError(t, err, "failed while waiting for member operator deployment")
+
+	memberClient, err := client.New(memberConfig, client.Options{
+		Scheme: f.Scheme,
+	})
+
+	require.NoError(t, err)
+	return wait.NewMemberAwaitility(t, memberClient, namespace, memberCluster.ClusterName)
 }
 
 func newSchemeBuilder() runtime.SchemeBuilder {

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -1,7 +1,6 @@
 package testsupport
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -34,8 +33,6 @@ CurrentMembers:
 				if currentMemberStatus.ClusterName == memberClusterName {
 					assert.Equal(t, previousMemberStatus.UserAccountCount+increase, currentMemberStatus.UserAccountCount)
 					found = true
-				} else {
-					assert.Equal(t, previousMemberStatus.UserAccountCount, currentMemberStatus.UserAccountCount)
 				}
 				continue CurrentMembers
 			}
@@ -43,9 +40,7 @@ CurrentMembers:
 		if currentMemberStatus.ClusterName == memberClusterName {
 			assert.Equal(t, increase, currentMemberStatus.UserAccountCount)
 			found = true
-		} else {
-			assert.Fail(t, fmt.Sprintf("There is an extra UserAccount count for member cluster %s", currentMemberStatus.ClusterName))
 		}
 	}
-	assert.True(t, found, "There is missing UserAccount count for member cluster")
+	assert.True(t, found, "There is a missing UserAccount count for member cluster '%s'", memberClusterName)
 }

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -106,6 +106,6 @@ func getMurTargetMember(t *testing.T, mur *toolchainv1alpha1.MasterUserRecord, m
 		}
 	}
 
-	t.Errorf("Unable to find a target member cluster for the MasterUserRecord: +%v", mur)
+	require.FailNowf(t, "Unable to find a target member cluster", "MasterUserRecord: %+v", mur)
 	return nil
 }

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -29,7 +29,7 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwait
 	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 	require.NoError(t, err)
 
-	memberAwait := getMemberForVerification(t, mur, members)
+	memberAwait := getMurTargetMember(t, mur, members)
 
 	// Then wait for the associated UserAccount to be provisioned
 	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
@@ -97,7 +97,7 @@ func ExpectedUserAccount(userID string, tier string, templateRefs tiers.Template
 	}
 }
 
-func getMemberForVerification(t *testing.T, mur *toolchainv1alpha1.MasterUserRecord, members []*wait.MemberAwaitility) *wait.MemberAwaitility {
+func getMurTargetMember(t *testing.T, mur *toolchainv1alpha1.MasterUserRecord, members []*wait.MemberAwaitility) *wait.MemberAwaitility {
 	for _, member := range members {
 		for _, ua := range mur.Spec.UserAccounts {
 			if ua.TargetCluster == member.ClusterName {
@@ -106,6 +106,6 @@ func getMemberForVerification(t *testing.T, mur *toolchainv1alpha1.MasterUserRec
 		}
 	}
 
-	t.Errorf("Unable to find a matching cluster for the MasterUserRecord: +%v", mur)
+	t.Errorf("Unable to find a target member cluster for the MasterUserRecord: +%v", mur)
 	return nil
 }

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/wait"
@@ -23,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func CreateMultipleSignups(t *testing.T, ctx *framework.Context, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, capacity int) []toolchainv1alpha1.UserSignup {
+func CreateMultipleSignups(t *testing.T, ctx *framework.Context, hostAwait *wait.HostAwaitility, targetCluster *wait.MemberAwaitility, capacity int) []toolchainv1alpha1.UserSignup {
 	signups := make([]toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
 		name := fmt.Sprintf("multiple-signup-testuser-%d", i)
@@ -35,8 +34,11 @@ func CreateMultipleSignups(t *testing.T, ctx *framework.Context, hostAwait *wait
 			continue
 		}
 		// Create an approved UserSignup resource
-		userSignup := NewUserSignup(t, hostAwait, memberAwait, name, fmt.Sprintf("multiple-signup-testuser-%d@test.com", i), true)
+		userSignup := NewUserSignup(t, hostAwait, name, fmt.Sprintf("multiple-signup-testuser-%d@test.com", i))
 		userSignup.Spec.Approved = true
+		if targetCluster != nil {
+			userSignup.Spec.TargetCluster = targetCluster.ClusterName
+		}
 		err := hostAwait.FrameworkClient.Create(context.TODO(), userSignup, CleanupOptions(ctx))
 		hostAwait.T.Logf("created usersignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)
 		require.NoError(t, err)
@@ -107,15 +109,8 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 // username defines the required username set in the spec
 // email is set in "user-email" annotation
 // setTargetCluster defines if the UserSignup will be created with Spec.TargetCluster set to the first found member cluster name
-func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, username string, email string, setTargetCluster bool) *toolchainv1alpha1.UserSignup {
+func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, username string, email string) *toolchainv1alpha1.UserSignup {
 	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
-	targetCluster := ""
-	if setTargetCluster {
-		memberCluster, ok, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, wait.ReadyToolchainCluster)
-		require.NoError(t, err)
-		require.True(t, ok)
-		targetCluster = memberCluster.Name
-	}
 
 	return &toolchainv1alpha1.UserSignup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -129,8 +124,7 @@ func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wa
 			},
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
-			Username:      username,
-			TargetCluster: targetCluster,
+			Username: username,
 		},
 	}
 }

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -45,7 +45,7 @@ func CreateMultipleSignups(t *testing.T, ctx *framework.Context, hostAwait *wait
 	return signups
 }
 
-func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, username string) toolchainv1alpha1.UserSignup {
+func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, username, targetCluster string) toolchainv1alpha1.UserSignup {
 	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
 	// 1. Create a UserSignup resource via calling registration service
 	identity := &authsupport.Identity{
@@ -64,6 +64,7 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 	require.Equal(t, userSignup.Spec.Company, identity.Username+"-Company-Name")
 
 	// 2. approve the UserSignup
+	userSignup.Spec.TargetCluster = "member-rajivdev-01-25-9xj2f"
 	userSignup.Spec.Approved = true
 	err = hostAwait.Client.Update(context.TODO(), userSignup)
 	require.NoError(t, err)
@@ -87,7 +88,6 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 		assert.Equal(t, "userprovisioned", notification.Spec.Template)
 		assert.Equal(t, mur.Spec.UserID, notification.Spec.UserID)
 	}
-
 
 	err = hostAwait.WaitUntilNotificationsDeleted(mur.Name, toolchainv1alpha1.NotificationTypeProvisioned)
 	require.NoError(t, err)

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -64,7 +64,7 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 	require.Equal(t, userSignup.Spec.Company, identity.Username+"-Company-Name")
 
 	// 2. approve the UserSignup
-	userSignup.Spec.TargetCluster = "member-rajivdev-01-25-9xj2f"
+	userSignup.Spec.TargetCluster = targetCluster
 	userSignup.Spec.Approved = true
 	err = hostAwait.Client.Update(context.TODO(), userSignup)
 	require.NoError(t, err)

--- a/wait/awaitility.go
+++ b/wait/awaitility.go
@@ -31,6 +31,7 @@ const (
 	DefaultRetryInterval             = time.Millisecond * 100 // make it short because a "retry interval" is waited before the first test
 	DefaultTimeout                   = time.Second * 60
 	MemberNsVar                      = "MEMBER_NS"
+	MemberNsVar2                     = "MEMBER_NS_2"
 	HostNsVar                        = "HOST_NS"
 	RegistrationServiceVar           = "REGISTRATION_SERVICE_NS"
 	ToolchainClusterConditionTimeout = 180 * time.Second
@@ -39,6 +40,7 @@ const (
 type Awaitility struct {
 	T             *testing.T
 	Client        client.Client
+	ClusterName   string
 	Namespace     string
 	Type          cluster.Type
 	RetryInterval time.Duration

--- a/wait/member.go
+++ b/wait/member.go
@@ -50,10 +50,11 @@ type MemberAwaitility struct {
 	*Awaitility
 }
 
-func NewMemberAwaitility(t *testing.T, cl client.Client, ns string) *MemberAwaitility {
+func NewMemberAwaitility(t *testing.T, cl client.Client, ns, clusterName string) *MemberAwaitility {
 	return &MemberAwaitility{
 		Awaitility: &Awaitility{
 			Client:        cl,
+			ClusterName:   clusterName,
 			T:             t,
 			Namespace:     ns,
 			Type:          cluster.Member,
@@ -132,7 +133,7 @@ func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccou
 		obj := &toolchainv1alpha1.UserAccount{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
-				a.T.Logf("waiting for availability of useraccount '%s'", name)
+				a.T.Logf("waiting for availability of useraccount '%s' in namespace '%s'", name, a.Namespace)
 				return false, nil
 			}
 			return false, err
@@ -975,7 +976,7 @@ func (a *MemberAwaitility) waitForDeployment() {
 }
 
 func (a *MemberAwaitility) waitForSecret() []byte {
-	a.T.Logf("checking prensence of Secret resource '%s' in namesapace '%s'", "webhook-certs", a.Namespace)
+	a.T.Logf("checking presence of Secret resource '%s' in namesapace '%s'", "webhook-certs", a.Namespace)
 	secret := &v1.Secret{}
 	a.waitForResource(a.Namespace, "webhook-certs", secret)
 	assert.NotEmpty(a.T, secret.Data["server-key.pem"])
@@ -986,7 +987,7 @@ func (a *MemberAwaitility) waitForSecret() []byte {
 }
 
 func (a *MemberAwaitility) waitForWebhookConfig(ca []byte) {
-	a.T.Logf("checking prensence of MutatingWebhookConfiguration resource '%s'", "sandbox-users-pods")
+	a.T.Logf("checking presence of MutatingWebhookConfiguration resource '%s'", "sandbox-users-pods")
 	actualMutWbhConf := &admv1.MutatingWebhookConfiguration{}
 	a.waitForResource("", "member-operator-webhook", actualMutWbhConf)
 	assert.Equal(a.T, bothWebhookLabels, actualMutWbhConf.Labels)


### PR DESCRIPTION
Related prerequisite PR: https://github.com/codeready-toolchain/toolchain-common/pull/147

This PR updates the e2e tests to deploy a second member operator.

Change summary
- update test makefile to deploy the 2nd member with the same environment as the 1st member except it does not create a webhook deployment
  - webhook deployment not created because the member operator code creates a `MutatingWebhookConfiguration` named 'member-operator-webhook' but since `MutatingWebhookConfiguration` is a cluster scoped resource and this cluster has 2 member operators in different namespaces trying to create the same resource by the same name it causes a conflict
- UserSignup creation functions are updated to accept a specific target cluster, if not specified users can be created in either namespace
  - Updated the `VerifyResourcesProvisionedForSignup` function to automatically look up the targeted member cluster in order to properly verify the resources 
- MemberAwaitility now includes a `ClusterName` that can be used when creating UserSignups to set the TargetCluster when desired
- init.go `WaitForDeployments` is updated to return a 2nd memberAwait for dealing with resources in the 2nd member namespace
- added a new user `targetedjohn` to the TestE2EFlow test to specifically test creating a UserSignup with a targetCluster to the 2nd member operator namespace

Verified both e2e and perf tests work with these changes.