### PR TITLE
Fix panic when 2nd member is not assigned

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -34,7 +34,7 @@ type userManagementTestSuite struct {
 
 func (s *userManagementTestSuite) SetupSuite() {
 	userSignupList := &v1alpha1.UserSignupList{}
-	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
+	s.ctx, s.hostAwait, s.memberAwait, s.memberAwait2 = WaitForDeployments(s.T(), userSignupList)
 }
 
 func (s *userManagementTestSuite) TearDownTest() {

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -29,7 +29,7 @@ type userWorkloadsTestSuite struct {
 }
 
 func (s *userWorkloadsTestSuite) SetupSuite() {
-	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
+	s.ctx, s.hostAwait, s.memberAwait, s.memberAwait2 = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
 }
 
 func (s *userWorkloadsTestSuite) TearDownTest() {


### PR DESCRIPTION
Fixes panics that can happen during e2e tests because the memberAwait2 cluster may be referenced by some parts of a test's common functions but was not assigned during initialization.

Sample failure:
```
--- FAIL: TestUserManagement (109.17s)
    --- PASS: TestUserManagement/TestUserBanning (72.62s)
        --- PASS: TestUserManagement/TestUserBanning/ban_provisioned_usersignup (32.88s)
            --- PASS: TestUserManagement/TestUserBanning/ban_provisioned_usersignup/verify_metrics_are_correct_after_user_banned (0.62s)
        --- PASS: TestUserManagement/TestUserBanning/create_usersignup_with_preexisting_banneduser (1.76s)
            --- PASS: TestUserManagement/TestUserBanning/create_usersignup_with_preexisting_banneduser/verify_metrics_are_correct_after_user_signup (0.53s)
        --- PASS: TestUserManagement/TestUserBanning/register_new_user_with_preexisting_ban (0.06s)
        --- PASS: TestUserManagement/TestUserBanning/ban_provisioned_usersignup#01 (32.51s)
            --- PASS: TestUserManagement/TestUserBanning/ban_provisioned_usersignup#01/unban_the_banned_user (0.33s)
    --- FAIL: TestUserManagement/TestUserDeactivation (28.64s)
        --- FAIL: TestUserManagement/TestUserDeactivation/verify_user_deactivation_on_each_member_cluster (28.63s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x164b7c9]

goroutine 25796 [running]:
testing.tRunner.func1.1(0x1813620, 0x2a3e2c0)
	/usr/local/go/src/testing/testing.go:988 +0x30d
testing.tRunner.func1(0xc00108c900)
	/usr/local/go/src/testing/testing.go:991 +0x3f9
panic(0x1813620, 0x2a3e2c0)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/codeready-toolchain/toolchain-e2e/testsupport.getMurTargetMember(0xc00108c7e0, 0xc000d48480, 0xc0005d3cf8, 0x2, 0x2, 0x0)
	/tmp/toolchain-e2e/testsupport/user_assertions.go:103 +0x99
github.com/codeready-toolchain/toolchain-e2e/testsupport.VerifyResourcesProvisionedForSignup(0xc00108c7e0, 0xc001233640, 0x0, 0x0, 0x0, 0x0, 0xc00100d4d0, 0x24, 0x0, 0x0, ...)
	/tmp/toolchain-e2e/testsupport/user_assertions.go:32 +0x375
github.com/codeready-toolchain/toolchain-e2e/test/e2e.(*baseUserIntegrationTest).createAndCheckUserSignup(0xc000b9e280, 0xc0011ee301, 0x1a43b25, 0x11, 0x1a59c27, 0x1c, 0x0, 0xc0011ee360, 0x3, 0x3, ...)
	/tmp/toolchain-e2e/test/e2e/base_user_test.go:40 +0x185
github.com/codeready-toolchain/toolchain-e2e/test/e2e.(*userManagementTestSuite).TestUserDeactivation.func1(0xc00108c900)
	/tmp/toolchain-e2e/test/e2e/user_management_test.go:55 +0x1b6
testing.tRunner(0xc00108c900, 0xc00082d580)
	/usr/local/go/src/testing/testing.go:1039 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1090 +0x372
FAIL	github.com/codeready-toolchain/toolchain-e2e/test/e2e	1095.185s
FAIL
```