### PR TITLE
Added test to ensure users may not sign up with phone number already in use

### DIFF
--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -519,10 +519,15 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	responseMap := invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusForbidden)
 
-	responseCode, err := strconv.Atoi(responseMap["code"].(string))
-	require.NoError(s.T(), err)
+	require.NotEmpty(s.T(), responseMap)
+	var ok bool
+	if val, ok := responseMap["code"]; ok {
+		responseCode, err := strconv.Atoi(val.(string))
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), http.StatusForbidden, responseCode)
+	}
+	require.True(s.T(), ok)
 
-	require.Equal(s.T(), http.StatusForbidden, responseCode)
 	require.Equal(s.T(), "Forbidden", responseMap["status"])
 	require.Equal(s.T(), "phone number already in use", responseMap["message"])
 	require.Equal(s.T(), "cannot register using phone number: +61408999999", responseMap["details"])

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -539,14 +539,14 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	// Now mark the original UserSignup as deactivated
 	userSignup.Spec.Deactivated = true
 	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = v1alpha1.UserSignupStateLabelValueDeactivated
-	
+
 	// Update the UserSignup
 	err = s.hostAwait.Client.Update(context.TODO(), userSignup)
 	require.NoError(s.T(), err)
 
 	// Now attempt the verification again
 	invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
-		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusForbidden)
+		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup again
 	otherUserSignup, err = s.hostAwait.WaitForUserSignup(otherIdentity.ID.String())

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -500,7 +500,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	otherIdentity := authsupport.NewIdentity()
 	otherEmailValue := uuid.NewV4().String() + "@other.domain"
 	otherEmailClaim := authsupport.WithEmailClaim(otherEmailValue)
-	otherToken, err := authsupport.GenerateSignedE2ETestToken(*identity0, otherEmailClaim)
+	otherToken, err := authsupport.GenerateSignedE2ETestToken(*otherIdentity, otherEmailClaim)
 	require.NoError(s.T(), err)
 
 	// Call the signup endpoint

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -519,16 +519,11 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusForbidden)
 
 	require.NotEmpty(s.T(), responseMap)
-	var ok bool
-	if val, ok := responseMap["code"]; ok {
-		require.NotEmpty(s.T(), val)
-		require.Equal(s.T(), http.StatusForbidden, int(val.(float64)))
-	}
-	require.True(s.T(), ok)
+	require.Equal(s.T(), float64(http.StatusForbidden), responseMap["code"], "code not found in response body map %s", responseMap)
 
 	require.Equal(s.T(), "Forbidden", responseMap["status"])
-	require.Equal(s.T(), "phone number already in use", responseMap["message"])
-	require.Equal(s.T(), "cannot register using phone number: +61408999999", responseMap["details"])
+	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +61408999999", responseMap["message"])
+	require.Equal(s.T(), "phone number already in use", responseMap["details"])
 
 	// Retrieve the updated UserSignup
 	otherUserSignup, err = s.hostAwait.WaitForUserSignup(otherIdentity.ID.String())

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -515,8 +516,16 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	assert.Equal(s.T(), otherEmailValue, otherEmailAnnotation)
 
 	// Initiate the verification process using the same phone number as previously
-	invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
+	responseMap := invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusForbidden)
+
+	responseCode, err := strconv.Atoi(responseMap["code"].(string))
+	require.NoError(s.T(), err)
+
+	require.Equal(s.T(), http.StatusForbidden, responseCode)
+	require.Equal(s.T(), "Forbidden", responseMap["status"])
+	require.Equal(s.T(), "phone number already in use", responseMap["message"])
+	require.Equal(s.T(), "cannot register using phone number: +61408999999", responseMap["details"])
 
 	// Retrieve the updated UserSignup
 	otherUserSignup, err = s.hostAwait.WaitForUserSignup(otherIdentity.ID.String())

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -530,7 +530,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Confirm there is no verification code annotation value
-	require.Nil(s.T(), otherUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(s.T(), otherUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -512,7 +511,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 		wait.UntilUserSignupHasConditions(VerificationRequired()...),
 		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
-	otherEmailAnnotation := userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
+	otherEmailAnnotation := otherUserSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
 	assert.Equal(s.T(), otherEmailValue, otherEmailAnnotation)
 
 	// Initiate the verification process using the same phone number as previously
@@ -522,9 +521,8 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NotEmpty(s.T(), responseMap)
 	var ok bool
 	if val, ok := responseMap["code"]; ok {
-		responseCode, err := strconv.Atoi(val.(string))
-		require.NoError(s.T(), err)
-		require.Equal(s.T(), http.StatusForbidden, responseCode)
+		require.NotEmpty(s.T(), val)
+		require.Equal(s.T(), http.StatusForbidden, int(val.(float64)))
 	}
 	require.True(s.T(), ok)
 

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -95,7 +95,7 @@ func WaitForDeployments(t *testing.T, obj runtime.Object) (*framework.Context, *
 func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.HostAwaitility, namespace string) *wait.MemberAwaitility {
 	memberClusterE2e, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", namespace, wait.ReadyToolchainCluster)
 	require.NoError(t, err)
-	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberClusterE2e, 3*time.Second)
+	memberConfig, err := cluster.NewClusterConfig(f.Client.Client, &memberClusterE2e, 6*time.Second)
 	require.NoError(t, err)
 
 	kubeClient, err := kubernetes.NewForConfig(memberConfig)


### PR DESCRIPTION
Added e2e test for https://github.com/codeready-toolchain/registration-service/pull/168

Fixes https://issues.redhat.com/browse/CRT-883

This PR also includes an increase to the timeout of client requests to the host API, to allow a greater threshold when running in CRC.

Signed-off-by: Shane Bryzak <shane@localhost.localdomain>