### PR TITLE
Update README.adoc replacing resource-rate with active users flag

### DIFF
--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -69,7 +69,7 @@ Note that the template does not take any parameter, and all resources will be cr
 +
 (use `go run setup/main.go --help` to see the other options)
 +
-Note: By default 3000 users are created, of which 600 of them will have these resources created. The number of users to create can be configured using the `--users` flag and the number of users with resources created can be configured via the `--resource-rate` flag. eg. `go run setup/main.go <path to the user-workloads.yaml file> --users 4000 --resource-rate 2` will create 4000 users and 2000 users will have resources created.
+Note: By default 3000 users are created, of which all 3000 of them will have these resources created in their `stage` namespace. The number of users to create can be configured using the `--users` flag and the number of users with resources created can be configured via the `--active` flag. eg. `go run setup/main.go <path to the user-workloads.yaml file> --users 4000 --active 2000` will create 4000 users and 2000 users will have resources created.
 4. Grab some coffee ☕️, populating the cluster with 3000 users will take approx. 2 hrs +
 Note: If for some reason the provisioning users step does not complete (eg. timeout), note down how many users were created and rerun the command with the remaining number of users to be created and a different username prefix. eg. `go run setup/main.go <path to the user-workloads.yaml file> --username zorro --users 500`
 


### PR DESCRIPTION
The `--active` flag can be used to control the number of users that have the template resources created in one of their namespaces.