### PR TITLE
Create more rolebindings and CSVs during setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/onsi/gomega v1.10.4 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
+	github.com/operator-framework/api v0.3.8
 	github.com/operator-framework/operator-sdk v0.19.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.2.0

--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -69,7 +69,8 @@ Note that the template does not take any parameter, and all resources will be cr
 +
 (use `go run setup/main.go --help` to see the other options)
 +
-Note: By default 3000 users are created, of which all 3000 of them will have these resources created in their `stage` namespace. The number of users to create can be configured using the `--users` flag and the number of users with resources created can be configured via the `--active` flag. eg. `go run setup/main.go <path to the user-workloads.yaml file> --users 4000 --active 2000` will create 4000 users and 2000 users will have resources created.
+Note 1: By default 3000 users are created, of which all 3000 of them will have these resources created in their `stage` namespace. The number of users to create can be configured using the `--users` flag and the number of users with resources created can be configured via the `--active` flag. eg. `go run setup/main.go <path to the user-workloads.yaml file> --users 4000 --active 2000` will create 4000 users and 2000 users will have resources created. +
+Note 2: Separate to the resources from the template, CSV resources are automatically created. An all-namespaces scoped operator will be installed as part of the 'preparing' step. This operator will create a CSV resource in each namespace to mimic the behaviour observed in the production cluster. This operator install step can be skipped with the `--skip-csvgen` flag but should not be skipped without good reason. +
 4. Grab some coffee ☕️, populating the cluster with 3000 users will take approx. 2 hrs +
 Note: If for some reason the provisioning users step does not complete (eg. timeout), note down how many users were created and rerun the command with the remaining number of users to be created and a different username prefix. eg. `go run setup/main.go <path to the user-workloads.yaml file> --username zorro --users 500`
 

--- a/setup/cmd/root.go
+++ b/setup/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	cfg "github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/idlers"
+	"github.com/codeready-toolchain/toolchain-e2e/setup/operators"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/resources"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/users"
@@ -93,6 +94,11 @@ func setup(cmd *cobra.Command, args []string) {
 
 	if !term.PromptBoolf("👤 provision %d users in batches of %d on %s", numberOfUsers, userBatches, config.Host) {
 		return
+	}
+
+	term.Infof("⏳ preparing cluster for setup...")
+	if err := operators.EnsureAllNamespacesOperator(cl, hostOperatorNamespace); err != nil {
+		term.Fatalf(err, "failed to ensure the all-namespaces operator is installed")
 	}
 
 	// provision the users

--- a/setup/configuration/configuration.go
+++ b/setup/configuration/configuration.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
 
 	quotav1 "github.com/openshift/api/quota/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -52,7 +53,7 @@ func NewClient(term terminal.Terminal, kubeconfigPath string) (client.Client, *r
 // NewScheme returns the scheme configured with all the needed types
 func NewScheme() (*runtime.Scheme, error) {
 	s := scheme.Scheme
-	builder := append(apis.AddToSchemes, quotav1.Install)
+	builder := append(apis.AddToSchemes, quotav1.Install, operatorsv1alpha1.AddToScheme)
 	err := builder.AddToScheme(s)
 	return s, err
 }

--- a/setup/operators/install_operators.go
+++ b/setup/operators/install_operators.go
@@ -1,0 +1,47 @@
+package operators
+
+import (
+	"context"
+
+	"github.com/codeready-toolchain/toolchain-e2e/setup/resources"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const AllNamespacesOperatorName = "kiali-ossm"
+const AllNamespacesOperatorPrefix = "kiali-operator"
+
+func EnsureAllNamespacesOperator(cl client.Client, csvNamespace string) error {
+	hasCSV, err := resources.HasCSVWithPrefix(cl, AllNamespacesOperatorPrefix, csvNamespace)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	if hasCSV {
+		// CSV is already present, skip the operator install
+		return nil
+	}
+
+	subscription := &v1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AllNamespacesOperatorName,
+			Namespace: "openshift-operators",
+		},
+		Spec: &v1alpha1.SubscriptionSpec{
+			Channel:                "stable",
+			InstallPlanApproval:    v1alpha1.ApprovalAutomatic,
+			Package:                AllNamespacesOperatorName,
+			CatalogSource:          "redhat-operators",
+			CatalogSourceNamespace: "openshift-marketplace",
+		},
+	}
+
+	if err := cl.Create(context.TODO(), subscription); err != nil {
+		return err
+	}
+
+	// Wait for CSV to be created
+	return resources.WaitForCSVWithPrefix(cl, AllNamespacesOperatorPrefix, csvNamespace)
+}

--- a/setup/operators/install_operators.go
+++ b/setup/operators/install_operators.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/codeready-toolchain/toolchain-e2e/setup/resources"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/pkg/errors"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +40,7 @@ func EnsureAllNamespacesOperator(cl client.Client, csvNamespace string) error {
 	}
 
 	if err := cl.Create(context.TODO(), subscription); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to install all-namespaces operator")
 	}
 
 	// Wait for CSV to be created

--- a/setup/operators/install_operators.go
+++ b/setup/operators/install_operators.go
@@ -16,6 +16,7 @@ const (
 	AllNamespacesOperatorPrefix = "kiali-operator"
 )
 
+// EnsureAllNamespacesOperator installs an all-namespaces operator that will generate a CSV resource in each namespace
 func EnsureAllNamespacesOperator(cl client.Client, csvNamespace string) error {
 	hasCSV, err := resources.HasCSVWithPrefix(cl, AllNamespacesOperatorPrefix, csvNamespace)
 	if err != nil && !k8serrors.IsNotFound(err) {

--- a/setup/operators/install_operators.go
+++ b/setup/operators/install_operators.go
@@ -11,8 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const AllNamespacesOperatorName = "kiali-ossm"
-const AllNamespacesOperatorPrefix = "kiali-operator"
+const (
+	AllNamespacesOperatorName   = "kiali-ossm"
+	AllNamespacesOperatorPrefix = "kiali-operator"
+)
 
 func EnsureAllNamespacesOperator(cl client.Client, csvNamespace string) error {
 	hasCSV, err := resources.HasCSVWithPrefix(cl, AllNamespacesOperatorPrefix, csvNamespace)

--- a/setup/operators/install_operators_test.go
+++ b/setup/operators/install_operators_test.go
@@ -1,0 +1,128 @@
+package operators
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
+	"github.com/codeready-toolchain/toolchain-e2e/setup/test"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestEnsureAllNamespacesOperator(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Run("operator not installed", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t) // csv does not exist
+			var checked bool
+			// the first list is empty which indicates the operator is not installed, thereby triggering the installation
+			// the second list returns a CSV which indicates the operator is installed
+			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				if checked {
+					csvList := list.(*v1alpha1.ClusterServiceVersionList)
+					csvList.Items = append(csvList.Items, v1alpha1.ClusterServiceVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kiali-operator",
+							Namespace: "test-ns",
+						},
+					})
+					return nil
+				}
+
+				checked = true
+				return nil
+			}
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.NoError(t, err)
+		})
+		t.Run("operator already installed", func(t *testing.T) {
+			// given
+			csv := &v1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kiali-operator-v1",
+					Namespace: "test-ns",
+				},
+			}
+			cl := test.NewFakeClient(t, csv) // csv exists
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Run("error when checking if operator is installed", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t)
+			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				return fmt.Errorf("Test client error")
+			}
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.EqualError(t, err, "Test client error")
+		})
+
+		t.Run("error when creating subscription", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t)
+			cl.MockCreate = func(ctx context.Context, list runtime.Object, opts ...client.CreateOption) error {
+				return fmt.Errorf("Test client error")
+			}
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.EqualError(t, err, "failed to install all-namespaces operator: Test client error")
+		})
+
+		t.Run("error when waiting for CSV to be created", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t)
+			var checked bool
+			// first time no CSV, second time return error
+			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				if checked {
+					return fmt.Errorf("Test client error")
+				}
+				checked = true
+				return nil
+			}
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.EqualError(t, err, `could not find the expected CSV with prefix 'kiali-operator' in namespace 'test-ns': Test client error`)
+		})
+
+		t.Run("timed out waiting for CSV to be created", func(t *testing.T) {
+			// given
+			configuration.DefaultTimeout = time.Second * 1
+			cl := test.NewFakeClient(t) // csv does not exist
+
+			// when
+			err := EnsureAllNamespacesOperator(cl, "test-ns")
+
+			// then
+			require.EqualError(t, err, `could not find the expected CSV with prefix 'kiali-operator' in namespace 'test-ns': timed out waiting for the condition`)
+		})
+	})
+}

--- a/setup/operators/install_operators_test.go
+++ b/setup/operators/install_operators_test.go
@@ -69,6 +69,7 @@ func TestEnsureAllNamespacesOperator(t *testing.T) {
 			// given
 			cl := test.NewFakeClient(t)
 			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				// the list fails
 				return fmt.Errorf("Test client error")
 			}
 
@@ -96,8 +97,8 @@ func TestEnsureAllNamespacesOperator(t *testing.T) {
 		t.Run("error when waiting for CSV to be created", func(t *testing.T) {
 			// given
 			cl := test.NewFakeClient(t)
+			// first time there's no CSV which will trigger operator install, second time the list to confirm operator installed returns error
 			var checked bool
-			// first time no CSV, second time return error
 			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
 				if checked {
 					return fmt.Errorf("Test client error")

--- a/setup/resources/user-workloads.yaml
+++ b/setup/resources/user-workloads.yaml
@@ -236,14 +236,6 @@ objects:
           - name: nginx
             image: quay.io/bitnami/nginx
   - apiVersion: v1
-    data:
-      username: YWRtaW4=
-      password: MWYyZDFlMmU2N2Rm
-    kind: Secret
-    metadata:
-      name: mysecret2
-    type: Opaque
-  - apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: build-robot
@@ -253,9 +245,140 @@ objects:
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      namespace: default
       name: pod-reader
     rules:
     - apiGroups: [""]
       resources: ["pods"]
       verbs: ["get", "watch", "list"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: read-pods
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      kind: Role
+      name: pod-reader
+      apiGroup: rbac.authorization.k8s.io
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-2
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-3
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-4
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-5
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-6
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-7
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-8
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-9
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-10
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: build-robot-edit-11
+    subjects:
+    - kind: ServiceAccount
+      name: build-robot
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: user-rbac-edit

--- a/setup/resources/wait.go
+++ b/setup/resources/wait.go
@@ -50,7 +50,7 @@ func WaitForCSVWithPrefix(cl client.Client, prefix, namespace string) error {
 	if err := k8swait.Poll(configuration.DefaultRetryInterval, configuration.DefaultTimeout, func() (bool, error) {
 		return HasCSVWithPrefix(cl, prefix, namespace)
 	}); err != nil {
-		return errors.Wrapf(err, "could not find the expected CSV '%s' in namespace '%s'", prefix, namespace)
+		return errors.Wrapf(err, "could not find the expected CSV with prefix '%s' in namespace '%s'", prefix, namespace)
 	}
 	return nil
 }

--- a/setup/resources/wait_test.go
+++ b/setup/resources/wait_test.go
@@ -1,17 +1,22 @@
 package resources_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/resources"
+	"github.com/codeready-toolchain/toolchain-e2e/setup/test"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestWaitForNamespace(t *testing.T) {
@@ -23,7 +28,7 @@ func TestWaitForNamespace(t *testing.T) {
 				Name: "user0001-stage",
 			},
 		}
-		cl := commontest.NewFakeClient(t, ns) // ns exists
+		cl := test.NewFakeClient(t, ns) // ns exists
 
 		// when
 		err := resources.WaitForNamespace(cl, "user0001-stage")
@@ -37,7 +42,7 @@ func TestWaitForNamespace(t *testing.T) {
 		t.Run("timeout", func(t *testing.T) {
 			// given
 			configuration.DefaultTimeout = time.Second * 1
-			cl := commontest.NewFakeClient(t) // ns doesn't exist
+			cl := test.NewFakeClient(t) // ns doesn't exist
 
 			// when
 			err := resources.WaitForNamespace(cl, "user0001-missing")
@@ -47,5 +52,101 @@ func TestWaitForNamespace(t *testing.T) {
 			assert.EqualError(t, err, "namespace 'user0001-missing' does not exist: timed out waiting for the condition")
 		})
 
+	})
+}
+
+func TestHasCSVWithPrefix(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		csv := &v1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-prefix",
+				Namespace: "test-ns",
+			},
+		}
+		cl := test.NewFakeClient(t, csv) // csv exists
+
+		// when
+		res, err := resources.HasCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+		// then
+		require.NoError(t, err)
+		require.True(t, res)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Run("csv does not exist", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t) // csv does not exist
+
+			// when
+			res, err := resources.HasCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+			// then
+			require.NoError(t, err)
+			require.False(t, res)
+		})
+
+		t.Run("client error", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t) // csv does not exist
+			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				return fmt.Errorf("Test client error")
+			}
+
+			// when
+			res, err := resources.HasCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+			// then
+			require.EqualError(t, err, "Test client error")
+			require.False(t, res)
+		})
+	})
+}
+
+func TestWaitForCSVWithPrefix(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		csv := &v1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-prefix",
+				Namespace: "test-ns",
+			},
+		}
+		cl := test.NewFakeClient(t, csv) // csv exists
+
+		// when
+		err := resources.WaitForCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Run("csv does not exist", func(t *testing.T) {
+			// given
+			configuration.DefaultTimeout = time.Second * 1
+			cl := test.NewFakeClient(t) // csv does not exist
+
+			// when
+			err := resources.WaitForCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+			// then
+			require.EqualError(t, err, `could not find the expected CSV with prefix 'test-prefix' in namespace 'test-ns': timed out waiting for the condition`)
+		})
+
+		t.Run("client error", func(t *testing.T) {
+			// given
+			cl := test.NewFakeClient(t) // csv does not exist
+			cl.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				return fmt.Errorf("Test client error")
+			}
+
+			// when
+			err := resources.WaitForCSVWithPrefix(cl, "test-prefix", "test-ns")
+
+			// then
+			require.EqualError(t, err, `could not find the expected CSV with prefix 'test-prefix' in namespace 'test-ns': Test client error`)
+		})
 	})
 }

--- a/setup/test/fakeclient.go
+++ b/setup/test/fakeclient.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"github.com/codeready-toolchain/api/pkg/apis"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	quotav1 "github.com/openshift/api/quota/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func NewFakeClient(t commontest.T, initObjs ...runtime.Object) *commontest.FakeClient {
+	s := scheme.Scheme
+	builder := append(apis.AddToSchemes, quotav1.Install, operatorsv1alpha1.AddToScheme)
+	err := builder.AddToScheme(s)
+	require.NoError(t, err)
+	cl := fake.NewFakeClientWithScheme(s, initObjs...)
+	return &commontest.FakeClient{Client: cl, T: t}
+}


### PR DESCRIPTION
- Adds a prepare step that installs one of the available operators that works at the "All Namespaces" scope. I chose Kiali since it seems pretty lightweight and I couldn't get the OSD route-monitor operator working but we could use any operator that fills this need. Maybe once we onboard SBO we can use that since with the improvements it has a small footprint and will be part of the Sandbox experience which is better than using another operator which can be an external influence on the test results
- Adds 12 RoleBindings to bring the resource numbers w/3000 users in line with production
- Removes an unnecessary secret