### PR TITLE
e2e test updated to check apiEndpoint is returned by Registration Service's signup service

### DIFF
--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -562,6 +563,10 @@ func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username
 	assert.True(s.T(), mpStatus["ready"].(bool))
 	assert.Equal(s.T(), "Provisioned", mpStatus["reason"])
 	assert.Equal(s.T(), s.memberAwait.GetConsoleURL(), mp["consoleURL"])
+	memberCluster, _, err := s.hostAwait.GetToolchainCluster(cluster.Member, s.memberAwait.Namespace, nil)
+	if err != nil {
+		assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
+	}
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusPendingApproval(username, bearerToken string) {

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -563,10 +563,10 @@ func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username
 	assert.True(s.T(), mpStatus["ready"].(bool))
 	assert.Equal(s.T(), "Provisioned", mpStatus["reason"])
 	assert.Equal(s.T(), s.memberAwait.GetConsoleURL(), mp["consoleURL"])
-	memberCluster, _, err := s.hostAwait.GetToolchainCluster(cluster.Member, s.memberAwait.Namespace, nil)
-	if err != nil {
-		assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
-	}
+	memberCluster, found, err := s.hostAwait.GetToolchainCluster(cluster.Member, s.memberAwait.Namespace, nil)
+	require.NoError(s.T(), err)
+	require.True(s.T(), found)
+	assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusPendingApproval(username, bearerToken string) {


### PR DESCRIPTION
e2e test updated to check apiEndpoint is returned by Registration Service's signup service (GET /api/v1/signup) for an approved user.

wrt fix: https://issues.redhat.com/browse/CRT-971
changes in registration service : https://github.com/codeready-toolchain/registration-service/pull/176