### PR TITLE
metrics: add field to store metrics in ToolchainStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace github.com/codeready-toolchain/api => ../api
+
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210322033730-9b79ca615ae9
+	github.com/codeready-toolchain/api v0.0.0-20210426074636-2f2696f1a944
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210323222322-40cc7fc9a3ea
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
@@ -48,7 +48,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => ../api
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210406161444-7f47b238ed37
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -1004,12 +1004,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05 h1:60eVMINemXcrRfLcsqLS7P8h6CoXNSbNZ6hE0Qkpj7c=
-github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910 h1:fOyXE3RWhTFjK5fd7mpJ1tn51jaSi5lEA4QtY/e/jLA=
-github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343 h1:uqpBJ+rF1DFWYO3cxhNtpP2qg8juKBR0VgAuhNyn1xc=
-github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22 h1:whDhmFsy3lCXB8uHbmViSxw5HToYWYlECcGYLSVSCCA=
+github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -1006,6 +1006,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22 h1:whDhmFsy3lCXB8uHbmViSxw5HToYWYlECcGYLSVSCCA=
 github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0 h1:4kcNucoRgMtYUfmZIrUYAjnzb158z62g76opd1/GQSg=
+github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -1024,6 +1024,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xcoulon/api v0.0.0-20210406161444-7f47b238ed37/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -1006,6 +1006,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05 h1:60eVMINemXcrRfLcsqLS7P8h6CoXNSbNZ6hE0Qkpj7c=
 github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910 h1:fOyXE3RWhTFjK5fd7mpJ1tn51jaSi5lEA4QtY/e/jLA=
+github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
-github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210219141158-8bf475892a90 h1:3vATtVvGaNAjFQYDnlXj1gvx24nBfSgeYnIPeITZJvE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210219141158-8bf475892a90/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=

--- a/go.sum
+++ b/go.sum
@@ -1008,6 +1008,8 @@ github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05 h1:60eVMINemXcrRfLcsqL
 github.com/xcoulon/api v0.0.0-20210407074048-9f6680ec2b05/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910 h1:fOyXE3RWhTFjK5fd7mpJ1tn51jaSi5lEA4QtY/e/jLA=
 github.com/xcoulon/api v0.0.0-20210408073004-de35eebdb910/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343 h1:uqpBJ+rF1DFWYO3cxhNtpP2qg8juKBR0VgAuhNyn1xc=
+github.com/xcoulon/api v0.0.0-20210408113742-bf6728155343/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,9 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20210322033730-9b79ca615ae9/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20210426074636-2f2696f1a944 h1:D8wRcU0yJYD+asg10cHlJg5M+/1viZR26bLc1WNnDBc=
+github.com/codeready-toolchain/api v0.0.0-20210426074636-2f2696f1a944/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210323222322-40cc7fc9a3ea h1:0QqoBRm/w4ObdEaGKADQITrazh0BDBhlDUjCwJelpys=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210323222322-40cc7fc9a3ea/go.mod h1:u7e3gVfkbIrF2qICStQfUnWoYxR4hoeVIshSeCQahX8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
@@ -1004,10 +1007,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
-github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22 h1:whDhmFsy3lCXB8uHbmViSxw5HToYWYlECcGYLSVSCCA=
-github.com/xcoulon/api v0.0.0-20210420062555-4a6f14476a22/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0 h1:4kcNucoRgMtYUfmZIrUYAjnzb158z62g76opd1/GQSg=
-github.com/xcoulon/api v0.0.0-20210421143336-3599b87665d0/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -37,7 +37,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 	userSignup := s.createAndCheckUserSignupNoMUR(specApproved, username, email, targetCluster, conditions...)
 
 	// Confirm the MUR was created and ready
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -100,7 +100,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	// finally, all user namespaces are verified.
 	// So, in this test, we verify that namespace resources and cluster resources are updated, on 2 groups of users with different tiers ;)
 
-	count := 2*1 + 1
+	count := 2*MaxPoolSize + 1
 	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.NSTemplateTier{})
 	defer ctx.Cleanup()
 

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -100,9 +100,9 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	// finally, all user namespaces are verified.
 	// So, in this test, we verify that namespace resources and cluster resources are updated, on 2 groups of users with different tiers ;)
 
-	count := 2*MaxPoolSize + 1
+	count := 2*1 + 1
 	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.NSTemplateTier{})
-	defer ctx.Cleanup()
+	// defer ctx.Cleanup()
 
 	// first group of users: the "cheesecake lovers"
 	cheesecakeSyncIndexes := setupAccounts(t, ctx, hostAwait, "cheesecake", "cheesecakelover%02d", memberAwait.ClusterName, count)
@@ -147,7 +147,7 @@ func setupAccounts(t *testing.T, ctx *test.Context, hostAwait *HostAwaitility, t
 	tier := CreateNSTemplateTier(t, ctx, hostAwait, tierName)
 
 	// let's create a few users (more than `maxPoolSize`)
-	users := make([]toolchainv1alpha1.UserSignup, count)
+	users := make([]*toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
 		users[i] = CreateAndApproveSignup(t, hostAwait, fmt.Sprintf(nameFmt, i), targetCluster)
 	}

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -102,7 +102,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	count := 2*1 + 1
 	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, &toolchainv1alpha1.NSTemplateTier{})
-	// defer ctx.Cleanup()
+	defer ctx.Cleanup()
 
 	// first group of users: the "cheesecake lovers"
 	cheesecakeSyncIndexes := setupAccounts(t, ctx, hostAwait, "cheesecake", "cheesecakelover%02d", memberAwait.ClusterName, count)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -317,7 +317,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		require.NoError(s.T(), err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait)
+		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait)
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		s.assertGetSignupStatusProvisioned(identity.Username, token)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -271,7 +271,7 @@ func (s *userManagementTestSuite) TestUserReactivationsMetric() {
 
 		// then
 		require.NoError(t, err)
-		// and verify that the values of the `sandbox_users_per_activations` metric were updated accordingly (ie, decremented)
+		// and verify that the values of the `sandbox_users_per_activations` metric
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "1") // user-0001 has been deleted but metric remains unchanged
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "2") // (unchanged after other usersignup was deleted)
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3") // (unchanged after other usersignup was deleted)
@@ -282,7 +282,7 @@ func (s *userManagementTestSuite) TestUserReactivationsMetric() {
 
 		// then
 		require.NoError(t, err)
-		// and verify that the values of the `sandbox_users_per_activations` metric were updated accordingly (ie, decremented)
+		// and verify that the values of the `sandbox_users_per_activations` metric
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "1") // (same offset as above)
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "2") // user-0002 has been deleted but metric remains unchanged
 		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3") // (unchanged after other usersignup was deleted)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -272,10 +272,10 @@ func (s *userManagementTestSuite) TestUserReactivationsMetric() {
 		// then
 		require.NoError(t, err)
 		// and verify that the values of the `sandbox_users_per_activations` metric were updated accordingly (ie, decremented)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, -1, "activations", "1") // user-0001 is gone, metric was decremented
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "2")  // (unchanged after other usersignup was deleted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3")  // (unchanged after other usersignup was deleted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "4")  // (unchanged after other usersignup was deleted)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "1") // user-0001 has been deleted but metric remains unchanged
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "2") // (unchanged after other usersignup was deleted)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3") // (unchanged after other usersignup was deleted)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "4") // (unchanged after other usersignup was deleted)
 
 		// when deleting user "user-0002"
 		err = s.hostAwait.Client.Delete(context.TODO(), usersignups["user-0002"])
@@ -283,10 +283,10 @@ func (s *userManagementTestSuite) TestUserReactivationsMetric() {
 		// then
 		require.NoError(t, err)
 		// and verify that the values of the `sandbox_users_per_activations` metric were updated accordingly (ie, decremented)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, -1, "activations", "1") // (same offset as above)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, -1, "activations", "2") // user-0002 is gone, metric was decremented
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3")  // (unchanged after other usersignup was deleted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "4")  // (unchanged after other usersignup was deleted)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "1") // (same offset as above)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "2") // user-0002 has been deleted but metric remains unchanged
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "3") // (unchanged after other usersignup was deleted)
+		metricsAssertion.WaitForMetricDelta(UsersPerActivationMetric, 0, "activations", "4") // (unchanged after other usersignup was deleted)
 	})
 }
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -41,7 +41,7 @@ func (s *userManagementTestSuite) SetupSuite() {
 }
 
 func (s *userManagementTestSuite) TearDownTest() {
-	// s.ctx.Cleanup()
+	s.ctx.Cleanup()
 }
 
 func (s *userManagementTestSuite) TestUserDeactivation() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -293,6 +293,21 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 		userSignup, _ = s.createAndCheckUserSignup(true, prefix, "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
 		require.Equal(s.T(), fmt.Sprintf("crt-%s", prefix), userSignup.Status.CompliantUsername)
 	}
+
+	// Create another UserSignups with a forbidden suffix
+	for _, suffix := range []string{"admin"} {
+		// suffix with hyphen
+		userSignup, _ = s.createAndCheckUserSignup(true, "paul-"+suffix, "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
+		require.Equal(s.T(), fmt.Sprintf("paul-%s-crt", suffix), userSignup.Status.CompliantUsername)
+
+		// suffix without delimiter
+		userSignup, _ = s.createAndCheckUserSignup(true, "paul"+suffix, "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
+		require.Equal(s.T(), fmt.Sprintf("paul%s-crt", suffix), userSignup.Status.CompliantUsername)
+
+		// suffix as a name
+		userSignup, _ = s.createAndCheckUserSignup(true, suffix, "paul@hotel.com", s.memberAwait, ApprovedByAdmin()...)
+		require.Equal(s.T(), fmt.Sprintf("%s-crt", suffix), userSignup.Status.CompliantUsername)
+	}
 }
 
 func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *v1alpha1.UserSignup {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -59,7 +59,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -90,7 +90,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -103,7 +103,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
-				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 			})
 		})
 	})
@@ -197,7 +197,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -220,7 +220,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -259,7 +259,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait, s.member2Await)
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -28,9 +28,11 @@ const (
 	UserSignupsAutoDeactivatedMetric = "sandbox_user_signups_auto_deactivated_total"
 	UserSignupsBannedMetric          = "sandbox_user_signups_banned_total"
 
-	// DEPRECATED: use `MasterUserRecordsMetric` instead
+	// DEPRECATED: use `UserAccountsMetric` instead
 	MasterUserRecordMetric = "sandbox_master_user_record_current"
 	UserAccountsMetric     = "sandbox_user_accounts_current"
+
+	ActivationsPerUserMetric = "sandbox_activations_per_user"
 )
 
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -1,6 +1,7 @@
 package testsupport
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ type MetricsAssertionHelper struct {
 
 type metricsProvider interface {
 	GetMetricValue(family string, labels ...string) float64
+	GetMetricValueOrZero(family string, labels ...string) float64
 	WaitForTestResourcesCleanup(initialDelay time.Duration) error
 	AssertMetricReachesValue(family string, expectedValue float64, labels ...string)
 }
@@ -32,7 +34,7 @@ const (
 	MasterUserRecordMetric = "sandbox_master_user_record_current"
 	UserAccountsMetric     = "sandbox_user_accounts_current"
 
-	ActivationsPerUserMetric = "sandbox_activations_per_user"
+	UsersPerActivationMetric = "sandbox_users_per_activations"
 )
 
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
@@ -60,7 +62,14 @@ func (m *MetricsAssertionHelper) captureBaselineValues(memberClusterNames []stri
 	for _, name := range memberClusterNames { // sum of gauge value of all member clusters
 		key := baselineKey(UserAccountsMetric, "cluster_name", name)
 		m.baselineValues[key] += m.await.GetMetricValue(UserAccountsMetric, "cluster_name", name)
+
 	}
+	// capture `sandbox_users_per_activations` with "activations" from "1" to "10"
+	for i := 1; i <= 10; i++ {
+		key := baselineKey(UsersPerActivationMetric, "activations", strconv.Itoa(i))
+		m.baselineValues[key] = m.await.GetMetricValueOrZero(UsersPerActivationMetric, "activations", strconv.Itoa(i))
+	}
+
 }
 
 // WaitForMetricDelta waits for the metric value to reach the adjusted value. The adjusted value is the delta value combined with the baseline value.

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -13,13 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups []toolchainv1alpha1.UserSignup, members ...*wait.MemberAwaitility) {
+func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups []*toolchainv1alpha1.UserSignup, members ...*wait.MemberAwaitility) {
 	for _, signup := range signups {
 		VerifyResourcesProvisionedForSignup(t, hostAwait, signup, "basic", members...)
 	}
 }
 
-func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, signup toolchainv1alpha1.UserSignup, tier string, members ...*wait.MemberAwaitility) {
+func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, signup *toolchainv1alpha1.UserSignup, tier string, members ...*wait.MemberAwaitility) {
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
 	// Get the latest signup version
 	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -17,6 +17,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -111,12 +112,11 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 	require.NoError(t, err)
 
 	// delete the userSignup at the end of the test
-	// t.Cleanup(func() {
-	// 	if err := hostAwait.Client.Delete(context.TODO(), userSignup); err != nil && !errors.IsNotFound(err) {
-	// 		require.NoError(t, err)
-	// 	}
-	// })
-
+	t.Cleanup(func() {
+		if err := hostAwait.Client.Delete(context.TODO(), userSignup); err != nil && !errors.IsNotFound(err) {
+			require.NoError(t, err)
+		}
+	})
 	return userSignup
 }
 

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -293,10 +293,20 @@ func (a *Awaitility) WaitForRouteToBeAvailable(ns, name, endpoint string) (route
 }
 
 // GetMetricValue gets the value of the metric with the given family and label key-value pair
-func (a *Awaitility) GetMetricValue(family string, labels ...string) float64 {
-	value, err := getMetricValue(a.MetricsURL, family, labels)
+// fails if the metric with the given labelAndValues does not exist
+func (a *Awaitility) GetMetricValue(family string, labelAndValues ...string) float64 {
+	value, err := getMetricValue(a.MetricsURL, family, labelAndValues)
 	require.NoError(a.T, err)
 	return value
+}
+
+// GetMetricValue gets the value of the metric with the given family and label key-value pair
+// return 0 if the metric with the given labelAndValues does not exist
+func (a *Awaitility) GetMetricValueOrZero(family string, labelAndValues ...string) float64 {
+	if value, err := getMetricValue(a.MetricsURL, family, labelAndValues); err == nil {
+		return value
+	}
+	return 0
 }
 
 // AssertMetricReachesValue asserts that the exposed metric with the given family

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -633,7 +633,7 @@ func (a *HostAwaitility) WaitUntilNotificationsDeleted(username, notificationTyp
 			return false, nil
 		}
 
-		a.T.Logf("Notification has been deleted'%s'", username)
+		a.T.Logf("Notification has been deleted for user '%s'", username)
 		return true, nil
 	})
 }


### PR DESCRIPTION
E2E Tests for https://github.com/codeready-toolchain/host-operator/pull/401
Checks the new `sandbox_users_per_activations ` metric when users are deactivated and reactivated multiple times