### PR TITLE
Update tests to use base tier as default

### DIFF
--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -37,7 +37,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 	userSignup := s.createAndCheckUserSignupNoMUR(specApproved, username, email, targetCluster, conditions...)
 
 	// Confirm the MUR was created and ready
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 	require.NoError(s.T(), err)
 
@@ -54,7 +54,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved bool, username string, email string, targetCluster *wait.MemberAwaitility,
 	conditions ...v1alpha1.Condition) *v1alpha1.UserSignup {
 
-	WaitUntilBasicNSTemplateTierIsUpdated(s.T(), s.hostAwait)
+	WaitUntilBaseNSTemplateTierIsUpdated(s.T(), s.hostAwait)
 	// Create a new UserSignup with the given approved flag
 	userSignup := NewUserSignup(s.T(), s.hostAwait, username, email)
 	userSignup.Spec.Approved = specApproved

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,9 +70,9 @@ func TestE2EFlow(t *testing.T) {
 	targetedJohnName := "targetedjohn"
 	targetedJohnSignup := CreateAndApproveSignup(t, hostAwait, targetedJohnName, member2Await.ClusterName)
 
-	VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-	VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
-	VerifyResourcesProvisionedForSignup(t, hostAwait, targetedJohnSignup, "basic", member2Await)
+	VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+	VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+	VerifyResourcesProvisionedForSignup(t, hostAwait, targetedJohnSignup, "base", member2Await)
 
 	johnsmithMur, err := hostAwait.GetMasterUserRecord(wait.WithMurName(johnsmithName))
 	require.NoError(t, err)
@@ -101,8 +101,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
@@ -116,8 +116,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -132,8 +132,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
@@ -148,14 +148,14 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
 			// given
-			namespaces := make([]*corev1.Namespace, 0, 3)
-			templateRefs := tiers.GetTemplateRefs(hostAwait, "basic")
+			namespaces := make([]*corev1.Namespace, 0, 2)
+			templateRefs := tiers.GetTemplateRefs(hostAwait, "base")
 			for _, ref := range templateRefs.Namespaces {
 				ns, err := memberAwait.WaitForNamespace(johnSignup.Spec.Username, ref)
 				require.NoError(t, err)
@@ -173,8 +173,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := memberAwait.WaitForNamespace(johnSignup.Spec.Username, ref)
 				require.NoError(t, err)
 			}
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 		})
 
 		t.Run("delete useraccount and expect recreation", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestE2EFlow(t *testing.T) {
 
 			// then the user account should be recreated
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "basic", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
 		})
 	})
 
@@ -229,9 +229,6 @@ func TestE2EFlow(t *testing.T) {
 		err = memberAwait.WaitUntilClusterResourceQuotasDeleted(johnsmithName)
 		assert.NoError(t, err, "ClusterResourceQuotas were not deleted")
 
-		err = memberAwait.WaitUntilNamespaceDeleted(johnsmithName, "code")
-		assert.NoError(t, err, "johnsmith-code namespace is not deleted")
-
 		err = memberAwait.WaitUntilNamespaceDeleted(johnsmithName, "dev")
 		assert.NoError(t, err, "johnsmith-dev namespace is not deleted")
 
@@ -239,7 +236,7 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "basic", memberAwait)
+		VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
 
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -318,7 +319,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		require.NoError(s.T(), err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait)
+		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait)
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		s.assertGetSignupStatusProvisioned(identity.Username, token)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -95,12 +95,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		userSignupMember1, murMember1 := s.createAndCheckUserSignup(true, "usernodeactivate", "usernodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 
-		// Get the basic tier that has deactivation disabled
-		basicDeactivationDisabledTier, err := s.hostAwait.WaitForNSTemplateTier("basicdeactivationdisabled")
+		// Get the base tier that has deactivation disabled
+		baseDeactivationDisabledTier, err := s.hostAwait.WaitForNSTemplateTier("basedeactivationdisabled")
 		require.NoError(t, err)
 
 		// Move the user to the new tier without deactivation enabled
-		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignupMember1.Spec.Username, *basicDeactivationDisabledTier).Spec.UserAccounts[0].SyncIndex
+		murSyncIndex := MoveUserToTier(t, s.hostAwait, userSignupMember1.Spec.Username, *baseDeactivationDisabledTier).Spec.UserAccounts[0].SyncIndex
 		murMember1, err = s.hostAwait.WaitForMasterUserRecord(murMember1.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
 			wait.UntilMasterUserRecordHasNotSyncIndex(murSyncIndex))
@@ -153,14 +153,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		userSignupMember1, murMember1 := s.createAndCheckUserSignup(true, "usertoautodeactivate", "usertoautodeactivate@redhat.com", s.memberAwait, ApprovedByAdmin()...)
 		deactivationExcludedUserSignupMember1, excludedMurMember1 := s.createAndCheckUserSignup(true, "userdeactivationexcluded", "userdeactivationexcluded@excluded.com", s.memberAwait, ApprovedByAdmin()...)
 
-		// Get the basic tier that has deactivation enabled
-		basicTier, err := s.hostAwait.WaitForNSTemplateTier("basic")
+		// Get the base tier that has deactivation enabled
+		baseTier, err := s.hostAwait.WaitForNSTemplateTier("base")
 		require.NoError(t, err)
 
 		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
 		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
 		// time should test the behaviour of the deactivation controller reconciliation.
-		tierDeactivationDuration := time.Duration(basicTier.Spec.DeactivationTimeoutDays) * time.Hour * 24
+		tierDeactivationDuration := time.Duration(baseTier.Spec.DeactivationTimeoutDays) * time.Hour * 24
 		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *v1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
@@ -357,7 +357,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	// Create UserSignup
 	userSignup := CreateAndApproveSignup(s.T(), s.hostAwait, "janedoe", s.memberAwait.ClusterName)
 
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait)
 
 	// Get MasterUserRecord
 	mur, err := s.hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username)
@@ -401,6 +401,6 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "basic", s.memberAwait)
+		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait)
 	})
 }

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -59,7 +59,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -90,7 +90,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -103,7 +103,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
-				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 			})
 		})
 	})
@@ -197,7 +197,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -220,7 +220,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
 				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 		})
 	})
 
@@ -259,7 +259,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "basic", s.memberAwait, s.member2Await)
+	VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, *userSignup, "base", s.memberAwait, s.member2Await)
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -240,3 +240,10 @@ func Running() toolchainv1alpha1.Condition {
 		Reason: "Running",
 	}
 }
+
+func Complete() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionTrue,
+	}
+}

--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -24,22 +24,22 @@ var toBeComplete = toolchainv1alpha1.Condition{
 }
 
 func CreateNSTemplateTier(t *testing.T, ctx *test.Context, hostAwait *HostAwaitility, tierName string, modifiers ...TierModifier) *toolchainv1alpha1.NSTemplateTier {
-	// We'll use the `basic` tier as a source of inspiration.
-	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
-	basicTier := &toolchainv1alpha1.NSTemplateTier{}
+	// We'll use the `base` tier as a source of inspiration.
+	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
+	baseTier := &toolchainv1alpha1.NSTemplateTier{}
 	err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{
 		Namespace: hostAwait.Namespace,
-		Name:      "basic",
-	}, basicTier)
+		Name:      "base",
+	}, baseTier)
 	require.NoError(t, err)
 
-	// now let's create the new NSTemplateTier with the same templates as the "basic" tier
+	// now let's create the new NSTemplateTier with the same templates as the "base" tier
 	tier := &toolchainv1alpha1.NSTemplateTier{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: basicTier.Namespace,
+			Namespace: baseTier.Namespace,
 			Name:      tierName,
 		},
-		Spec: basicTier.Spec,
+		Spec: baseTier.Spec,
 	}
 
 	err = Modify(tier, modifiers...)
@@ -92,8 +92,8 @@ func DeactivationTimeoutDays(timeoutDurationDays int) TierModifier {
 	}
 }
 
-func WaitUntilBasicNSTemplateTierIsUpdated(t *testing.T, hostAwait *HostAwaitility) {
-	_, err := hostAwait.WaitForNSTemplateTier("basic",
+func WaitUntilBaseNSTemplateTierIsUpdated(t *testing.T, hostAwait *HostAwaitility) {
+	_, err := hostAwait.WaitForNSTemplateTier("base",
 		UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
 	require.NoError(t, err)
 }

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -15,7 +15,7 @@ import (
 
 func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups []toolchainv1alpha1.UserSignup, members ...*wait.MemberAwaitility) {
 	for _, signup := range signups {
-		VerifyResourcesProvisionedForSignup(t, hostAwait, signup, "basic", members...)
+		VerifyResourcesProvisionedForSignup(t, hostAwait, signup, "base", members...)
 	}
 }
 

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -21,8 +21,8 @@ func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups
 
 func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, signup toolchainv1alpha1.UserSignup, tier string, members ...*wait.MemberAwaitility) {
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
-	// Get the latest signup version
-	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved), wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
+	// Get the latest signup version, wait for usersignup to have the approved label and wait for the complete status to ensure the compliantusername is available
+	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved), wait.ContainsCondition(Complete()))
 	require.NoError(t, err)
 
 	// First, wait for the MasterUserRecord to exist, no matter what status

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -22,7 +22,7 @@ func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups
 func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, signup toolchainv1alpha1.UserSignup, tier string, members ...*wait.MemberAwaitility) {
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
 	// Get the latest signup version
-	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved), wait.UntilUserSignupHasConditions(ApprovedByAdmin()...))
 	require.NoError(t, err)
 
 	// First, wait for the MasterUserRecord to exist, no matter what status

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -48,7 +48,7 @@ func CreateMultipleSignups(t *testing.T, ctx *framework.Context, hostAwait *wait
 }
 
 func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, username, targetCluster string) toolchainv1alpha1.UserSignup {
-	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
+	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
 	// 1. Create a UserSignup resource via calling registration service
 	identity := &authsupport.Identity{
 		ID:       uuid.NewV4(),
@@ -110,7 +110,7 @@ func CreateAndApproveSignup(t *testing.T, hostAwait *wait.HostAwaitility, userna
 // email is set in "user-email" annotation
 // setTargetCluster defines if the UserSignup will be created with Spec.TargetCluster set to the first found member cluster name
 func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, username string, email string) *toolchainv1alpha1.UserSignup {
-	WaitUntilBasicNSTemplateTierIsUpdated(t, hostAwait)
+	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
 
 	name := uuid.NewV4().String()
 

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -242,7 +242,7 @@ func UntilMasterUserRecordHasUserAccountStatuses(expUaStatuses ...toolchainv1alp
 type UserSignupWaitCriterion func(a *HostAwaitility, ua *toolchainv1alpha1.UserSignup) bool
 
 // UntilUserSignupHasConditions returns a `UserAccountWaitCriterion` which checks that the given
-// USerAccount has exactly all the given status conditions
+// UserAccount has exactly all the given status conditions
 func UntilUserSignupHasConditions(conditions ...toolchainv1alpha1.Condition) UserSignupWaitCriterion {
 	return func(a *HostAwaitility, ua *toolchainv1alpha1.UserSignup) bool {
 		if test.ConditionsMatch(ua.Status.Conditions, conditions...) {
@@ -250,6 +250,19 @@ func UntilUserSignupHasConditions(conditions ...toolchainv1alpha1.Condition) Use
 			return true
 		}
 		a.T.Logf("waiting for status condition of UserSignup '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Status.Conditions, conditions)
+		return false
+	}
+}
+
+// ContainsCondition returns a `UserAccountWaitCriterion` which checks that the given
+// UserAccount contains the given status condition
+func ContainsCondition(condition toolchainv1alpha1.Condition) UserSignupWaitCriterion {
+	return func(a *HostAwaitility, ua *toolchainv1alpha1.UserSignup) bool {
+		if test.ContainsCondition(ua.Status.Conditions, condition) {
+			a.T.Logf("UserSignup '%s' status conditions contains expected condition", ua.Name)
+			return true
+		}
+		a.T.Logf("waiting for status condition of UserSignup '%s' to contain the expected. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Status.Conditions, condition)
 		return false
 	}
 }


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/402

The above PR changes auto approval to use the base tier by default. This PR updates the e2e tests to reflect that as well and use the base tier instead of the basic tier in most tests since the basic tier will likely be removed in the future.