### PR TITLE
Remove code namespaces from idler setup

### DIFF
--- a/setup/idlers/update_idler.go
+++ b/setup/idlers/update_idler.go
@@ -17,7 +17,7 @@ import (
 )
 
 func UpdateTimeout(cl client.Client, username string, timeout time.Duration) error {
-	for _, suffix := range []string{"code", "dev", "stage"} { // TODO: hard coded suffixes, we could probably get them from the tier instead
+	for _, suffix := range []string{"dev", "stage"} { // TODO: hard coded suffixes, we could probably get them from the tier instead
 		idlerName := fmt.Sprintf("%s-%s", username, suffix)
 		idler, err := getIdler(cl, idlerName)
 		if err != nil {


### PR DESCRIPTION
The setup tool was broken because the idler Get would time out due to the -code namespace removal after the switch to the Base tier. This is a temporary fix, we should get the namespace names from the tier.