### PR TITLE
Updated e2e tests for removed code NS for advanced and test tiers

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -265,9 +265,9 @@ func TestTierTemplates(t *testing.T) {
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
 	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))
-	// verify that we have 25 tier templates (base: 3, basedeactivationdisabled 3, basic: 4, advanced: 4, basicdeactivationdisabled 4, team 3, test 4)
+	// verify that we have 23 tier templates (base: 3, basedeactivationdisabled 3, basic: 4, advanced: 3, basicdeactivationdisabled 4, team 3, test 3)
 	require.NoError(t, err)
-	assert.Len(t, allTiers.Items, 25)
+	assert.Len(t, allTiers.Items, 23)
 }
 
 func TestUpdateOfNamespacesWithLegacyLabels(t *testing.T) {

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -223,12 +223,10 @@ func (a *advancedTierChecks) GetNamespaceObjectChecks(nsType string) []namespace
 	checks = append(checks, commonNetworkPolicyChecks()...)
 
 	switch nsType {
-	case "code":
-		checks = append(checks, networkPolicyAllowFromCRW(), networkPolicyAllowFromOtherNamespace("dev", "stage"), numberOfNetworkPolicies(5))
 	case "dev":
-		checks = append(checks, networkPolicyAllowFromCRW(), networkPolicyAllowFromOtherNamespace("code", "stage"), numberOfNetworkPolicies(5))
+		checks = append(checks, networkPolicyAllowFromCRW(), networkPolicyAllowFromOtherNamespace("stage"), numberOfNetworkPolicies(5))
 	case "stage":
-		checks = append(checks, networkPolicyAllowFromOtherNamespace("code", "dev"), numberOfNetworkPolicies(4))
+		checks = append(checks, networkPolicyAllowFromOtherNamespace("dev"), numberOfNetworkPolicies(4))
 	}
 	return checks
 }
@@ -250,7 +248,7 @@ func (a *advancedTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 
 func (a *advancedTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
 	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "code", "dev", "stage")
+	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "stage")
 	return templateRefs
 }
 
@@ -270,7 +268,7 @@ func (a *testTierChecks) GetNamespaceObjectChecks(nsType string) []namespaceObje
 
 func (a *testTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
 	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "code", "stage")
+	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "stage")
 	return templateRefs
 }
 


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/404

Updates the tests with the removal of the `-code` namespace from the advanced and test tiers.