### PR TITLE
Create a README for installing the Dev Sandbox in a development environment

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -38,15 +38,7 @@ If you still don't know what to do with e2e tests in some use-cases, go to <<Wha
 
 === Prerequisites if Running Locally
 
-==== Pre-installed Tools
-* go
-* git
-* operator-sdk 0.19.2
-* sed
-* yamllint
-* jq
-* yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
-* docker (if building from source)
+Install the link:required_tools.adoc[required tools].
 
 ==== OpenShift 4.2+
 
@@ -55,9 +47,13 @@ If you still don't know what to do with e2e tests in some use-cases, go to <<Wha
 * Make sure that the visibility of all repositories `host-operator`, `member-operator` and `registration-service` in quay is set to `public` (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings https://quay.io/repository/<your-username>/registration-service?tab=settings)
 * Log in to the target OpenShift 4.2+ cluster with cluster admin privileges using `oc login`
 
+==== Running in a Development Environment
+
+See the procedure to install the Dev Sandbox in a development environment link:dev_install.adoc[here].
+
 ==== Multi-cluster Environment
 
-See the procedure to configure a Host cluster and a Member cluster at link:multicluster_setup.adoc[here].
+See the procedure to configure a Host cluster and a Member cluster link:multicluster_setup.adoc[here].
 
 === Running End-to-End Tests
 

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -31,7 +31,7 @@ Option #2: Configure your own Keycloak server and set up authentication on the O
 == Install
 
 . Clone this repository +
-`git clone `+git@github.com+`:codeready-toolchain/toolchain-e2e.git`
+`+git clone git@github.com:codeready-toolchain/toolchain-e2e.git+`
 . Run the following to install the Dev Sandbox operators +
 `make dev-deploy-e2e`
 . Run `oc get toolchainstatus -n <quay-io-username>-host-operator` and ensure the Ready status is `True`

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -4,10 +4,13 @@ This document describes how to install Dev Sandbox in a development environment.
 
 == Prereqs
 
-. Ensure you have access to an OpenShift 4.6+ cluster with cluster admin privileges and log in using `oc login`
+=== OpenShift Cluster
+Ensure you have access to an OpenShift 4.6+ cluster with cluster admin privileges and log in using `oc login`
 
-. Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
+=== Required Tools
+Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
 
+=== Quay
 . Register for a quay.io account if you don't have one
 . Make sure you have set the `QUAY_NAMESPACE` variable: +
 `export QUAY_NAMESPACE=<quay-username>`
@@ -18,16 +21,17 @@ This document describes how to install Dev Sandbox in a development environment.
  * https://quay.io/repository/<your-username>/member-operator-webhook?tab=settings
  * https://quay.io/repository/<your-username>/registration-service?tab=settings
 
-. Configure authentication for the cluster:
-
-Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO.
-
+=== Authentication
+. Configure authentication for the cluster: +
++
+Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO. +
++
 Option #2: Configure your own Keycloak server and set up authentication on the OpenShift cluster: https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html
 
 == Install
 
 . Clone this repository +
-`git clone git@github.com:codeready-toolchain/toolchain-e2e.git`
+`git clone `+git@github.com+`:codeready-toolchain/toolchain-e2e.git`
 . Run the following to install the Dev Sandbox operators +
 `make dev-deploy-e2e`
 . Run `oc get toolchainstatus -n <quay-io-username>-host-operator` and ensure the Ready status is `True`

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -34,6 +34,7 @@ Option #2: Configure your own Keycloak server and set up authentication on the O
 `+git clone git@github.com:codeready-toolchain/toolchain-e2e.git+`
 . Run the following to install the Dev Sandbox operators +
 `make dev-deploy-e2e`
+. Make note of the Registration Service URL that is printed at the end
 . Run `oc get toolchainstatus -n <quay-io-username>-host-operator` and ensure the Ready status is `True`
 +
 ```
@@ -41,9 +42,7 @@ NAME               MURS   READY   LAST UPDATED
 toolchain-status   0      True    2021-03-24T22:39:36Z
 ```
 
-=== Register/Login via the Registration Service
-
-. The `make dev-deploy-e2e` prints the Registration Service URL. Open the link in a browser and sign up for an account.
+. Open the Registration Service URL in a browser and sign up for an account.
 
 . Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval"
 
@@ -54,7 +53,9 @@ toolchain-status   0      True    2021-03-24T22:39:36Z
 Manual approval means each usersignup must be approved by editing the usersignup resource for a particular user.
 
 . Approve the usersignup
-`oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>`
+```
+oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>
+```
 
 ==== Automatic Approval
 
@@ -77,8 +78,8 @@ EOF
 === Using the Sandbox
 
 After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options. +
-1. _kube:admin_ +
-2. _The authentication method configured in the prereq step_ +
+1. Option #1: _kube:admin_ +
+2. Option #2: The authentication method configured in the <<Authentication>> step +
 Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.
 
 After logging in a user will have access to only the namespaces created for them.

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -44,7 +44,7 @@ toolchain-status   0      True    2021-03-24T22:39:36Z
 
 . Open the Registration Service URL in a browser and sign up for an account.
 
-. Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval" +
+. Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval"
 image::https://user-images.githubusercontent.com/20015929/114627893-01845d00-9c84-11eb-848e-0f85a1b3c01f.png[]
 
 === Approve The User
@@ -82,8 +82,8 @@ After approval the registration service will display a link to start using the S
  +
 Option #1: _kube:admin_ +
 Option #2: The authentication method configured in the <<Authentication>> step + 
- +
-image::https://user-images.githubusercontent.com/20015929/114628295-a141eb00-9c84-11eb-8be3-45f013e19378.png[] +
+
+image::https://user-images.githubusercontent.com/20015929/114628295-a141eb00-9c84-11eb-8be3-45f013e19378.png[]
 Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.
 
 After logging in a user will have access to only the namespaces created for them.

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -54,7 +54,7 @@ image::https://user-images.githubusercontent.com/20015929/114627893-01845d00-9c8
 
 Manual approval means each usersignup must be approved by editing the usersignup resource for a particular user.
 
-. Run the following command to get the name of the usersignup resource:+
+. Run the following command to get the name of the usersignup resource: +
 `oc get usersignup` +
 +
 The name should be a UUID eg. 66e54c45-9868-4a25-81ca-d56b600c8491
@@ -68,7 +68,7 @@ oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup nam
 
 Automatic approval means enabling automatic approval in the Dev Sandbox configuration. Users will be automatically approved and provisioned without admin intervention.
 
-. Enable automatic approval
+. Enable automatic approval +
 ```
 cat <<EOF | oc apply -f -
 apiVersion: toolchain.dev.openshift.com/v1alpha1

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -77,9 +77,11 @@ EOF
 
 === Using the Sandbox
 
-After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options. +
-1. Option #1: _kube:admin_ +
-2. Option #2: The authentication method configured in the <<Authentication>> step +
+After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options.: +
+ +
+Option #1: _kube:admin_ +
+Option #2: The authentication method configured in the <<Authentication>> step + 
+ +
 Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.
 
 After logging in a user will have access to only the namespaces created for them.

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -59,7 +59,8 @@ Manual approval means each usersignup must be approved by editing the usersignup
 +
 The name should be a UUID eg. 66e54c45-9868-4a25-81ca-d56b600c8491
 
-. Approve the usersignup +
+. Approve the usersignup
++
 ```
 oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>
 ```
@@ -68,7 +69,8 @@ oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup nam
 
 Automatic approval means enabling automatic approval in the Dev Sandbox configuration. Users will be automatically approved and provisioned without admin intervention.
 
-. Enable automatic approval +
+. Enable automatic approval
++
 ```
 cat <<EOF | oc apply -f -
 apiVersion: toolchain.dev.openshift.com/v1alpha1

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -70,6 +70,15 @@ spec:
 EOF
 ```
 
+=== Using the Sandbox
+
+After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options. +
+1. _kube:admin_ +
+2. _The authentication method configured in the prereq step_ +
+Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.
+
+After logging in a user will have access to only the namespaces created for them.
+
 == Cleanup
 === Remove Only Users and Their Namespaces
 

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -44,7 +44,8 @@ toolchain-status   0      True    2021-03-24T22:39:36Z
 
 . Open the Registration Service URL in a browser and sign up for an account.
 
-. Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval"
+. Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval" +
+image::https://user-images.githubusercontent.com/20015929/114627893-01845d00-9c84-11eb-848e-0f85a1b3c01f.png[]
 
 === Approve The User
 

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -12,9 +12,10 @@ Install the link:required_tools.adoc[required tools].
 
 === Quay
 . Register for a quay.io account if you don't have one
-. Make sure you have set the `QUAY_NAMESPACE` variable: +
+. Make sure you have set the _QUAY_NAMESPACE_ variable: +
 `export QUAY_NAMESPACE=<quay-username>`
-. Log in to quay.io using `docker login quay.io`
+. Log in to quay.io using +
+`docker login quay.io`
 . Make sure that the visibility of the `host-operator`, `member-operator`, `member-operator-webhook` and `registration-service` repositories on quay.io are all set to `public`:
  * https://quay.io/repository/<your-username>/host-operator?tab=settings
  * https://quay.io/repository/<your-username>/member-operator?tab=settings
@@ -53,7 +54,12 @@ image::https://user-images.githubusercontent.com/20015929/114627893-01845d00-9c8
 
 Manual approval means each usersignup must be approved by editing the usersignup resource for a particular user.
 
-. Approve the usersignup
+. Run the following command to get the name of the usersignup resource:+
+`oc get usersignup` +
++
+The name should be a UUID eg. 66e54c45-9868-4a25-81ca-d56b600c8491
+
+. Approve the usersignup +
 ```
 oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>
 ```

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -1,20 +1,22 @@
 = Dev Sandbox Development Install
 
-This document describes how to install Dev Sandbox for Development.
+This document describes how to install Dev Sandbox in a development environment.
 
 == Prereqs
 
+. Ensure you have access to an OpenShift 4.6+ cluster with cluster admin privileges and log in using `oc login`
+
 . Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
 
-. Make sure you have set the `QUAY_NAMESPACE` variable: `export QUAY_NAMESPACE=<quay-username>`
-. Log in to the quay.io using `docker login quay.io`
-. Make sure that the visibility of the `host-operator`, `member-operator`, `member-operator-webhook` and `registration-service` repositories on quay.io is set to `public`:
+. Register for a quay.io account if you don't have one
+. Make sure you have set the `QUAY_NAMESPACE` variable: +
+`export QUAY_NAMESPACE=<quay-username>`
+. Log in to quay.io using `docker login quay.io`
+. Make sure that the visibility of the `host-operator`, `member-operator`, `member-operator-webhook` and `registration-service` repositories on quay.io are all set to `public`:
  * https://quay.io/repository/<your-username>/host-operator?tab=settings
  * https://quay.io/repository/<your-username>/member-operator?tab=settings
  * https://quay.io/repository/<your-username>/member-operator-webhook?tab=settings
  * https://quay.io/repository/<your-username>/registration-service?tab=settings
-
-. Log in to the target OpenShift 4.6+ cluster with cluster admin privileges using `oc login`
 
 . Configure authentication for the cluster:
 
@@ -22,8 +24,7 @@ Option #1: Contact a member of the Dev Sandbox Team for instructions on how to c
 
 Option #2: Configure your own Keycloak server and set up authentication on the OpenShift cluster: https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html
 
-
-== Install the Dev Sandbox
+== Install
 
 . Clone this repository +
 `git clone git@github.com:codeready-toolchain/toolchain-e2e.git`
@@ -36,24 +37,22 @@ NAME               MURS   READY   LAST UPDATED
 toolchain-status   0      True    2021-03-24T22:39:36Z
 ```
 
-=== New User Sign Up
+=== Register/Login via the Registration Service
 
-With the cluster now under load, it's time to evaluate the environment.
+. The `make dev-deploy-e2e` prints the Registration Service URL. Open the link in a browser and sign up for an account.
 
-1. Use your operators as a user would and evaluate the performance.
-2. Monitor the cluster's performance using the Monitoring view in the OpenShift Console.
-3. Monitor the memory usage of operators. There are many more resources created on this cluster than most operators have been tested with so it's important to look for any possible areas for concern.
+. Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval"
 
-== Approve The User
+=== Approve The User
 
-=== Manual Approval
+==== Manual Approval
 
 Manual approval means each usersignup must be approved by editing the usersignup resource for a particular user.
 
 . Approve the usersignup
 `oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>`
 
-=== Automatic Approval
+==== Automatic Approval
 
 Automatic approval means enabling automatic approval in the Dev Sandbox configuration. Users will be automatically approved and provisioned without admin intervention.
 
@@ -71,11 +70,11 @@ spec:
 EOF
 ```
 
-=== Cleanup
-== Remove Only Users and Their Namespaces
+== Cleanup
+=== Remove Only Users and Their Namespaces
 
 Run `make clean-users`
 
-== Remove All Sandbox-related Resources
+=== Remove All Sandbox-related Resources
 
 Run `make clean-e2e-resources`

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -23,9 +23,9 @@ Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-ins
 
 === Authentication
 Configure authentication for the cluster using one of the following options: +
-+
+ +
 Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO. +
-+
+ +
 Option #2: Configure your own Keycloak server and set up authentication on the OpenShift cluster: https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html
 
 == Install

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -22,7 +22,7 @@ Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-ins
  * https://quay.io/repository/<your-username>/registration-service?tab=settings
 
 === Authentication
-. Configure authentication for the cluster: +
+Configure authentication for the cluster using one of the following options: +
 +
 Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO. +
 +

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -22,10 +22,9 @@ Install the link:required_tools.adoc[required tools].
  * https://quay.io/repository/<your-username>/registration-service?tab=settings
 
 === Authentication
-Configure authentication for the cluster using one of the following options: +
- +
+Configure authentication for the cluster using one of the following options:
+
 Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO. +
- +
 Option #2: Configure your own Keycloak server and set up authentication on the OpenShift cluster: https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html
 
 == Install
@@ -79,10 +78,10 @@ EOF
 
 === Using the Sandbox
 
-After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options.: +
- +
+After approval the registration service will display a link to start using the Sandbox. The link will go to the user's Dev Console, but first, a login page will appear with two options.:
+
 Option #1: _kube:admin_ +
-Option #2: The authentication method configured in the <<Authentication>> step + 
+Option #2: The authentication method configured in the <<Authentication>> step
 
 image::https://user-images.githubusercontent.com/20015929/114628295-a141eb00-9c84-11eb-8be3-45f013e19378.png[]
 Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -8,7 +8,7 @@ This document describes how to install Dev Sandbox in a development environment.
 Ensure you have access to an OpenShift 4.6+ cluster with cluster admin privileges and log in using `oc login`
 
 === Required Tools
-Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
+Install the link:required_tools.adoc[required tools].
 
 === Quay
 . Register for a quay.io account if you don't have one

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -83,6 +83,7 @@ After approval the registration service will display a link to start using the S
 Option #1: _kube:admin_ +
 Option #2: The authentication method configured in the <<Authentication>> step + 
  +
+image::https://user-images.githubusercontent.com/20015929/114628295-a141eb00-9c84-11eb-8be3-45f013e19378.png[] +
 Select option 2 and log in using the same account used from the <<Register/Login via the Registration Service>> step.
 
 After logging in a user will have access to only the namespaces created for them.

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -1,0 +1,81 @@
+= Dev Sandbox Development Install
+
+This document describes how to install Dev Sandbox for Development.
+
+== Prereqs
+
+. Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
+
+. Make sure you have set the `QUAY_NAMESPACE` variable: `export QUAY_NAMESPACE=<quay-username>`
+. Log in to the quay.io using `docker login quay.io`
+. Make sure that the visibility of the `host-operator`, `member-operator`, `member-operator-webhook` and `registration-service` repositories on quay.io is set to `public`:
+ * https://quay.io/repository/<your-username>/host-operator?tab=settings
+ * https://quay.io/repository/<your-username>/member-operator?tab=settings
+ * https://quay.io/repository/<your-username>/member-operator-webhook?tab=settings
+ * https://quay.io/repository/<your-username>/registration-service?tab=settings
+
+. Log in to the target OpenShift 4.6+ cluster with cluster admin privileges using `oc login`
+
+. Configure authentication for the cluster:
+
+Option #1: Contact a member of the Dev Sandbox Team for instructions on how to configure the cluster to use our internal Dev SSO.
+
+Option #2: Configure your own Keycloak server and set up authentication on the OpenShift cluster: https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html
+
+
+== Install the Dev Sandbox
+
+. Clone this repository +
+`git clone git@github.com:codeready-toolchain/toolchain-e2e.git`
+. Run the following to install the Dev Sandbox operators +
+`make dev-deploy-e2e`
+. Run `oc get toolchainstatus -n <quay-io-username>-host-operator` and ensure the Ready status is `True`
++
+```
+NAME               MURS   READY   LAST UPDATED
+toolchain-status   0      True    2021-03-24T22:39:36Z
+```
+
+=== New User Sign Up
+
+With the cluster now under load, it's time to evaluate the environment.
+
+1. Use your operators as a user would and evaluate the performance.
+2. Monitor the cluster's performance using the Monitoring view in the OpenShift Console.
+3. Monitor the memory usage of operators. There are many more resources created on this cluster than most operators have been tested with so it's important to look for any possible areas for concern.
+
+== Approve The User
+
+=== Manual Approval
+
+Manual approval means each usersignup must be approved by editing the usersignup resource for a particular user.
+
+. Approve the usersignup
+`oc patch usersignup -p '{"spec":{"approved":true}}' --type=merge <usersignup name> -n <host operator namespace>`
+
+=== Automatic Approval
+
+Automatic approval means enabling automatic approval in the Dev Sandbox configuration. Users will be automatically approved and provisioned without admin intervention.
+
+. Enable automatic approval
+```
+cat <<EOF | oc apply -f -
+apiVersion: toolchain.dev.openshift.com/v1alpha1
+kind: HostOperatorConfig
+metadata:
+  name: config
+  namespace: <host operator namespace>
+spec:
+  automaticApproval:
+    enabled: true
+EOF
+```
+
+=== Cleanup
+== Remove Only Users and Their Namespaces
+
+Run `make clean-users`
+
+== Remove All Sandbox-related Resources
+
+Run `make clean-e2e-resources`

--- a/dev_install.adoc
+++ b/dev_install.adoc
@@ -45,6 +45,7 @@ toolchain-status   0      True    2021-03-24T22:39:36Z
 . Open the Registration Service URL in a browser and sign up for an account.
 
 . Wait for the message "Your OpenShift Developer Sandbox account is waiting for approval"
+
 image::https://user-images.githubusercontent.com/20015929/114627893-01845d00-9c84-11eb-848e-0f85a1b3c01f.png[]
 
 === Approve The User

--- a/required_tools.adoc
+++ b/required_tools.adoc
@@ -1,0 +1,9 @@
+== Required Pre-installed Tools
+* go
+* git
+* operator-sdk 0.19.2
+* sed
+* yamllint
+* jq
+* yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
+* docker (if building from source)

--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -42,7 +42,7 @@ platform:
 publish: External
 ----
 
-. Ensure you have the https://github.com/codeready-toolchain/toolchain-e2e#pre-installed-tools[required tools] installed
+. Install the link:required_tools.adoc[required tools].
 
 . Install your operator(s)
 

--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -66,7 +66,7 @@ Note #2: Only resources that a user has permissions to create will be successful
 == Dev Sandbox Setup
 
 . Clone this repository +
-`git clone git@github.com:codeready-toolchain/toolchain-e2e.git`
+`+git clone git@github.com:codeready-toolchain/toolchain-e2e.git+`
 . Run the following to install the Dev Sandbox operators +
 `make dev-deploy-e2e`
 . Run `oc get toolchainstatus -n <quay-io-username>-host-operator` and ensure the Ready status is `True`

--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -48,7 +48,7 @@ publish: External
 
 . Create an OpenShift template file that defines resources for testing the performance of your onboarding operator and any other resources that users typically create when using your operator. A Dev Sandbox template is provided with a default set of resources to help mimic a production environment https://raw.githubusercontent.com/codeready-toolchain/toolchain-e2e/master/setup/resources/user-workloads.yaml[user-workloads.yaml] and should be used alongside the onboarding operator's template file you create in this step.
 +
-+ This setup tool will automatically create resources on behalf of the users in their `stage` namespaces. The resources are defined in template files and fed to the tool using the `--template` parameter.
+This setup tool will automatically create resources on behalf of the users in their `stage` namespaces. The resources are defined in template files and fed to the tool using the `--template` parameter.
 +
 Note #1: All resources will be created in the user's `-stage` namespace regardless of whether resources in the template have a namespace set.
 Note #2: Only resources that a user has permissions to create will be successfully created, these are typically namespace-scoped resources limited to only the user's namespaces. If the tool fails to create any resources an error will occur. If these resources are required by the onboarding operator then this should be brought to the attention of the Dev Sandbox team.


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-1028

PR changes:
- created a new README for instructions to run in a dev environment
- moved the list of required tools to its own doc to make it cleaner when following instructions from any of the READMEs
- added a new section to the main readme "Running in a Development Environment"