### PR TITLE
Cleanup VerificationRequired migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20210506074002-34828c94ab5d
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210507200711-5dd7ad1085b4
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/codeready-toolchain/api v0.0.0-20210413031854-81652586fd90/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/api v0.0.0-20210506074002-34828c94ab5d h1:BH64hZwQ1umajVoh5bBNC2HxiC7UiOk5OMVQK9yXmjo=
 github.com/codeready-toolchain/api v0.0.0-20210506074002-34828c94ab5d/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226 h1:6h2fTykSczXgHeLqFoFWxd8Ih26B2Xfr6e+Un6zPMvg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210507200711-5dd7ad1085b4 h1:Z5GdgredSGEjDEaZ4CHtuJmSgkxU2Wi40RmpGQrDqy4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210507200711-5dd7ad1085b4/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	"testing"
 	"time"
 
@@ -321,7 +322,7 @@ func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAsser
 	userSignup.Spec.Approved = true
 
 	// Set verification required
-	userSignup.Spec.VerificationRequired = true
+	states.SetVerificationRequired(userSignup, true)
 
 	err := s.hostAwait.FrameworkClient.Create(context.TODO(), userSignup, CleanupOptions(s.ctx))
 	require.NoError(s.T(), err)


### PR DESCRIPTION
This PR refactors the e2e tests to use the new states property instead of the VerificationRequired boolean property.