### PR TITLE
fix usersignup setup

### DIFF
--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -138,8 +138,7 @@ func NewUserSignup(t *testing.T, hostAwait *wait.HostAwaitility, username string
 			Name:      name,
 			Namespace: hostAwait.Namespace,
 			Annotations: map[string]string{
-				toolchainv1alpha1.UserSignupUserEmailAnnotationKey:         email,
-				toolchainv1alpha1.UserSignupActivationCounterAnnotationKey: "1", // normally set by registration service during first signup of a user (ie, when creating the UserSignup resource)
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: email,
 			},
 			Labels: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: md5.CalcMd5(email),


### PR DESCRIPTION
avoids starting the test with a user having 2 activations, and some
weird effects on the metrics, such as
```
$ oc get toolchainstatus/toolchain-status -o jsonpath='{.status.metrics} | jq -r
{
  "usersPerActivation": {
    "1": -1
    "2": 1
  }
}

$ curl -X GET https://$(oc get route/host-operator-metrics -o json | jq -r '.status.ingress[0].host')/metrics -k -s | grep sandbox_users_per_activations"
sandbox_users_per_activations{activations="1"} -1
sandbox_users_per_activations{activations="2"} 1
```

Existing tests themselves are not affected, since they measure a delta
between the initial metrics/counters and their value after something
changed (user deactivation/reactivation, etc.)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
