### PR TITLE
chore: update api with new format & kubebuilder version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210520133910-ab0d90c32c0b
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210520134909-6a918dd11401
+	github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
@@ -43,10 +43,6 @@ require (
 	k8s.io/metrics v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20210521080611-9ec9bdeaa4e4
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v0.4.0
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/gosuri/uiprogress v0.0.1
@@ -43,10 +43,16 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	github.com/go-logr/logr => github.com/go-logr/logr v0.1.0
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
+	k8s.io/klog/v2 => k8s.io/klog/v2 v2.0.0
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,10 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126 h1:ctRxZ3qcUNtaYoZqc3PUAedQChPpl0iZvyJXF5M6ySE=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02 h1:ptdMQgbc3kCQQ0Zndb4gUwOOJv4+xGPsnlzBQ7ETXgY=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210525074434-b7d36013dc02/go.mod h1:Ah8JSVbGqo58xTlghhCIFBzUZhbBdoFlmAX7P7gqIWA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -660,10 +664,6 @@ github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEX
 github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff h1:YfHt1MpDDqdovcvxgXZh/FglkRwX10BwFlARE7wyTro=
-github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
-github.com/matousjobanek/toolchain-common v0.0.0-20210521080611-9ec9bdeaa4e4 h1:zAgG1epyRt40jLw9bxUKuBE8xeszXxphi8Z2mOP+w2Q=
-github.com/matousjobanek/toolchain-common v0.0.0-20210521080611-9ec9bdeaa4e4/go.mod h1:Pr6I+qFRtVeRFkQM/jYT2DnuCKC1Cqe3OvGj5pCgHXY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1496,6 +1496,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac h1:sAvhNk5RRuc6FNYGqe7Ygz3PSo/2wGWbulskmzRX8Vs=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1537,6 +1538,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99 h1:wdt455ji+MywIGDGQVUQUEGHa8WiRy0sfr5YFn00HbA=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=

--- a/go.sum
+++ b/go.sum
@@ -169,11 +169,6 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210413031854-81652586fd90/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210518063911-913eaf4719b7 h1:b1TIADY79iqmUKJEVlxX64r3yfvr8YtQxO9aXe6TYik=
-github.com/codeready-toolchain/api v0.0.0-20210518063911-913eaf4719b7/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226 h1:6h2fTykSczXgHeLqFoFWxd8Ih26B2Xfr6e+Un6zPMvg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210507092551-8dd100435226/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -665,6 +660,10 @@ github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEX
 github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP5g=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043 h1:FrCL5fGboLnw/8pzb+2tl5rOGmocaQnlVw+ZVbXirgY=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91 h1:ErTmzG5H1oa/Eas5PAwCJZzPTzqUZn+9B6JEcf5SLXI=
+github.com/matousjobanek/toolchain-common v0.0.0-20210520100350-fca58f9efe91/go.mod h1:QjU7LhHgonkPxMQMgXmoyR9o7//i8caVIFrMaO9qKvM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1308,6 +1307,7 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
@@ -1496,6 +1496,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1536,6 +1537,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99 h1:wdt455ji+MywIGDGQVUQUEGHa8WiRy0sfr5YFn00HbA=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/setup/configuration/configuration.go
+++ b/setup/configuration/configuration.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
 
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -53,7 +53,7 @@ func NewClient(term terminal.Terminal, kubeconfigPath string) (client.Client, *r
 // NewScheme returns the scheme configured with all the needed types
 func NewScheme() (*runtime.Scheme, error) {
 	s := scheme.Scheme
-	builder := append(apis.AddToSchemes, quotav1.Install, operatorsv1alpha1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
 	err := builder.AddToScheme(s)
 	return s, err
 }

--- a/setup/configuration/configuration.go
+++ b/setup/configuration/configuration.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
 
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -53,7 +53,7 @@ func NewClient(term terminal.Terminal, kubeconfigPath string) (client.Client, *r
 // NewScheme returns the scheme configured with all the needed types
 func NewScheme() (*runtime.Scheme, error) {
 	s := scheme.Scheme
-	builder := append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
 	err := builder.AddToScheme(s)
 	return s, err
 }

--- a/setup/idlers/update_idler.go
+++ b/setup/idlers/update_idler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	cfg "github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"

--- a/setup/test/fakeclient.go
+++ b/setup/test/fakeclient.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -15,7 +15,7 @@ import (
 
 func NewFakeClient(t commontest.T, initObjs ...runtime.Object) *commontest.FakeClient {
 	s := scheme.Scheme
-	builder := append(apis.AddToSchemes, quotav1.Install, operatorsv1alpha1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
 	err := builder.AddToScheme(s)
 	require.NoError(t, err)
 	cl := fake.NewFakeClientWithScheme(s, initObjs...)

--- a/setup/test/fakeclient.go
+++ b/setup/test/fakeclient.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -15,7 +15,7 @@ import (
 
 func NewFakeClient(t commontest.T, initObjs ...runtime.Object) *commontest.FakeClient {
 	s := scheme.Scheme
-	builder := append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme, quotav1.Install, operatorsv1alpha1.AddToScheme)
 	err := builder.AddToScheme(s)
 	require.NoError(t, err)
 	cl := fake.NewFakeClientWithScheme(s, initObjs...)

--- a/setup/users/create_users.go
+++ b/setup/users/create_users.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/setup/users/create_users_test.go
+++ b/setup/users/create_users_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -33,7 +33,7 @@ type baseUserIntegrationTest struct {
 //
 // The method then waits until the UserSignup contains the given set of conditions and the corresponding MUR is created
 func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, username string, email string, targetCluster *wait.MemberAwaitility,
-	conditions ...v1alpha1.Condition) (*v1alpha1.UserSignup, *v1alpha1.MasterUserRecord) {
+	conditions ...toolchainv1alpha1.Condition) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.MasterUserRecord) {
 
 	userSignup := s.createAndCheckUserSignupNoMUR(specApproved, username, email, targetCluster, conditions...)
 
@@ -53,7 +53,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignup(specApproved bool, us
 //
 // The method then waits until the UserSignup contains the given set of conditions
 func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved bool, username string, email string, targetCluster *wait.MemberAwaitility,
-	conditions ...v1alpha1.Condition) *v1alpha1.UserSignup {
+	conditions ...toolchainv1alpha1.Condition) *toolchainv1alpha1.UserSignup {
 
 	WaitUntilBaseNSTemplateTierIsUpdated(s.T(), s.hostAwait)
 	// Create a new UserSignup with the given approved flag
@@ -73,7 +73,7 @@ func (s *baseUserIntegrationTest) createAndCheckUserSignupNoMUR(specApproved boo
 	return userSignup
 }
 
-func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *v1alpha1.BannedUser {
+func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *toolchainv1alpha1.BannedUser {
 	// Create the BannedUser
 	bannedUser := newBannedUser(s.hostAwait, email)
 	err := s.hostAwait.FrameworkClient.Create(context.TODO(), bannedUser, CleanupOptions(s.ctx))
@@ -83,23 +83,23 @@ func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *v1alph
 	return bannedUser
 }
 
-func newBannedUser(host *wait.HostAwaitility, email string) *v1alpha1.BannedUser {
-	return &v1alpha1.BannedUser{
+func newBannedUser(host *wait.HostAwaitility, email string) *toolchainv1alpha1.BannedUser {
+	return &toolchainv1alpha1.BannedUser{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      uuid.NewV4().String(),
 			Namespace: host.Namespace,
 			Labels: map[string]string{
-				v1alpha1.BannedUserEmailHashLabelKey: md5.CalcMd5(email),
+				toolchainv1alpha1.BannedUserEmailHashLabelKey: md5.CalcMd5(email),
 			},
 		},
-		Spec: v1alpha1.BannedUserSpec{
+		Spec: toolchainv1alpha1.BannedUserSpec{
 			Email: email,
 		},
 	}
 }
 
-func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *v1alpha1.UserSignup, mur *v1alpha1.MasterUserRecord) {
-	userSignup, err := s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
+	userSignup, err := s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 		states.SetDeactivated(us, true)
 	})
 	require.NoError(s.T(), err)
@@ -109,7 +109,7 @@ func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *v1alpha1.Us
 	require.NoError(s.T(), err)
 
 	// "deactivated"
-	notifications, err := s.hostAwait.WaitForNotifications(userSignup.Status.CompliantUsername, v1alpha1.NotificationTypeDeactivated, 1, wait.UntilNotificationHasConditions(Sent()))
+	notifications, err := s.hostAwait.WaitForNotifications(userSignup.Status.CompliantUsername, toolchainv1alpha1.NotificationTypeDeactivated, 1, wait.UntilNotificationHasConditions(Sent()))
 	require.NoError(s.T(), err)
 	require.NotEmpty(s.T(), notifications)
 	require.Len(s.T(), notifications, 1)
@@ -119,24 +119,24 @@ func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *v1alpha1.Us
 	assert.Equal(s.T(), "userdeactivated", notification.Spec.Template)
 	assert.Equal(s.T(), userSignup.Name, notification.Spec.UserID)
 
-	err = s.hostAwait.WaitUntilNotificationsDeleted(userSignup.Status.CompliantUsername, v1alpha1.NotificationTypeDeactivated)
+	err = s.hostAwait.WaitUntilNotificationsDeleted(userSignup.Status.CompliantUsername, toolchainv1alpha1.NotificationTypeDeactivated)
 	require.NoError(s.T(), err)
 
 	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 		wait.UntilUserSignupHasConditions(DeactivatedWithoutPreDeactivation()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueDeactivated))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
 	require.NoError(s.T(), err)
 	require.True(s.T(), states.Deactivated(userSignup), "usersignup should be deactivated")
 }
 
-func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *v1alpha1.UserSignup, mur *v1alpha1.MasterUserRecord) {
+func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
 	err := s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{
 		Namespace: userSignup.Namespace,
 		Name:      userSignup.Name,
 	}, userSignup)
 	require.NoError(s.T(), err)
 
-	userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+	userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 		states.SetDeactivating(us, false)
 		states.SetDeactivated(us, false)
 	})
@@ -148,7 +148,7 @@ func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *v1alpha1.Us
 
 	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 		wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 	require.NoError(s.T(), err)
 	require.False(s.T(), states.Deactivated(userSignup), "usersignup should not be deactivated")
 }

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -47,7 +47,7 @@ type registrationServiceTestSuite struct {
 }
 
 func (s *registrationServiceTestSuite) SetupSuite() {
-	userSignupList := &v1alpha1.UserSignupList{}
+	userSignupList := &toolchainv1alpha1.UserSignupList{}
 	s.ctx, s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T(), userSignupList)
 	s.namespace = s.hostAwait.RegistrationServiceNs
 	s.route = s.hostAwait.RegistrationServiceURL
@@ -294,16 +294,16 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 
 func (s *registrationServiceTestSuite) TestSignupOK() {
 
-	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *v1alpha1.UserSignup {
+	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
 		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
 
 		// Wait for the UserSignup to be created
 		userSignup, err := s.hostAwait.WaitForUserSignup(userSignupName,
 			wait.UntilUserSignupHasConditions(PendingApproval()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValuePending))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
 		require.NoError(s.T(), err)
-		emailAnnotation := userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
+		emailAnnotation := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
 		assert.Equal(s.T(), email, emailAnnotation)
 
 		// Call get signup endpoint with a valid token and make sure it's pending approval
@@ -343,13 +343,13 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		userSignup := signupUser(t, emailValue, identity.ID.String(), identity)
 
 		// Deactivate the usersignup
-		userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *v1alpha1.UserSignup) {
+		userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
 		require.NoError(s.T(), err)
 		_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 			wait.UntilUserSignupHasConditions(DeactivatedWithoutPreDeactivation()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueDeactivated))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
 		require.NoError(s.T(), err)
 
 		// Now check that the reg-service treats the deactivated usersignup as nonexistent and returns 404
@@ -405,9 +405,9 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	// Wait for the UserSignup to be created
 	userSignup, err := s.hostAwait.WaitForUserSignup(identity0.ID.String(),
 		wait.UntilUserSignupHasConditions(VerificationRequired()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueNotReady))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
-	emailAnnotation := userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
+	emailAnnotation := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
 	assert.Equal(s.T(), emailValue, emailAnnotation)
 
 	// Call get signup endpoint with a valid token and make sure verificationRequired is true
@@ -422,11 +422,11 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	// Confirm the status of the UserSignup is correct
 	_, err = s.hostAwait.WaitForUserSignup(identity0.ID.String(),
 		wait.UntilUserSignupHasConditions(VerificationRequired()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueNotReady))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
 
 	// Confirm that a MUR hasn't been created
-	obj := &v1alpha1.MasterUserRecord{}
+	obj := &toolchainv1alpha1.MasterUserRecord{}
 	err = s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: s.hostAwait.Namespace, Name: identity0.Username}, obj)
 	require.Error(s.T(), err)
 	require.True(s.T(), errors.IsNotFound(err))
@@ -440,11 +440,11 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Confirm there is a verification code annotation value, and store it in a variable
-	verificationCode := userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]
+	verificationCode := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
 	require.NotEmpty(s.T(), verificationCode)
 
 	// Confirm the expiry time has been set
-	require.NotEmpty(s.T(), userSignup.Annotations[v1alpha1.UserVerificationExpiryAnnotationKey])
+	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
 
 	// Attempt to verify with an incorrect verification code
 	invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
@@ -454,27 +454,27 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Check attempts has been incremented
-	require.NotEmpty(s.T(), userSignup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey])
+	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
 
 	// Confirm the verification code has not changed
-	require.Equal(s.T(), verificationCode, userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Equal(s.T(), verificationCode, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Verify with the correct code
 	invokeEndpoint(s.T(), "GET", s.route+fmt.Sprintf("/api/v1/signup/verification/%s",
-		userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey]), token0, "", http.StatusOK)
+		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]), token0, "", http.StatusOK)
 
 	// Retrieve the updated UserSignup
 	userSignup, err = s.hostAwait.WaitForUserSignup(identity0.ID.String(),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValuePending))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
 	require.NoError(s.T(), err)
 
 	// Confirm all unrequired verification-related annotations have been removed
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserVerificationExpiryAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserVerificationAttemptsAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationTimestampAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationCounterAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[v1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationTimestampAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey])
+	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
 	mp, mpStatus = parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
@@ -513,9 +513,9 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	// Wait for the UserSignup to be created
 	otherUserSignup, err := s.hostAwait.WaitForUserSignup(otherIdentity.ID.String(),
 		wait.UntilUserSignupHasConditions(VerificationRequired()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueNotReady))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
-	otherEmailAnnotation := otherUserSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey]
+	otherEmailAnnotation := otherUserSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
 	assert.Equal(s.T(), otherEmailValue, otherEmailAnnotation)
 
 	// Initiate the verification process using the same phone number as previously
@@ -534,7 +534,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Confirm there is no verification code annotation value
-	require.Empty(s.T(), otherUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(s.T(), otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Retrieve the current UserSignup
 	err = s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: s.hostAwait.Namespace, Name: userSignup.Name}, userSignup)
@@ -556,7 +556,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.NoError(s.T(), err)
 
 	// Confirm there is now a verification code annotation value
-	require.NotEmpty(s.T(), otherUserSignup.Annotations[v1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(s.T(), otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestToolchainClusterE2E(t *testing.T) {
-	toolchainClusterList := &v1alpha1.ToolchainClusterList{}
+	toolchainClusterList := &toolchainv1alpha1.ToolchainClusterList{}
 	ctx, hostAwait, memberAwait, _ := WaitForDeployments(t, toolchainClusterList)
 	defer ctx.Cleanup()
 
@@ -86,8 +86,8 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		err := await.Client.Create(context.TODO(), toolchainCluster)
 		// then the ToolchainCluster should be offline
 		require.NoError(t, err)
-		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, &v1alpha1.ToolchainClusterCondition{
-			Type:   v1alpha1.ToolchainClusterOffline,
+		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, &toolchainv1alpha1.ToolchainClusterCondition{
+			Type:   toolchainv1alpha1.ToolchainClusterOffline,
 			Status: corev1.ConditionTrue,
 		})
 		require.NoError(t, err)
@@ -99,10 +99,10 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 	})
 }
 
-func newToolchainCluster(namespace, name string, options ...clusterOption) *v1alpha1.ToolchainCluster {
-	toolchainCluster := &v1alpha1.ToolchainCluster{
-		Spec: v1alpha1.ToolchainClusterSpec{
-			SecretRef: v1alpha1.LocalSecretReference{
+func newToolchainCluster(namespace, name string, options ...clusterOption) *toolchainv1alpha1.ToolchainCluster {
+	toolchainCluster := &toolchainv1alpha1.ToolchainCluster{
+		Spec: toolchainv1alpha1.ToolchainClusterSpec{
+			SecretRef: toolchainv1alpha1.LocalSecretReference{
 				Name: "", // default
 			},
 			APIEndpoint: "", // default
@@ -124,38 +124,38 @@ func newToolchainCluster(namespace, name string, options ...clusterOption) *v1al
 }
 
 // clusterOption an option to configure the cluster to use in the tests
-type clusterOption func(*v1alpha1.ToolchainCluster)
+type clusterOption func(*toolchainv1alpha1.ToolchainCluster)
 
 // capacityExhausted an option to state that the cluster capacity has exhausted
-var capacityExhausted clusterOption = func(c *v1alpha1.ToolchainCluster) {
+var capacityExhausted clusterOption = func(c *toolchainv1alpha1.ToolchainCluster) {
 	c.Labels["toolchain.dev.openshift.com/capacity-exhausted"] = strconv.FormatBool(true)
 }
 
 // Type sets the label which defines the type of cluster
 func clusterType(t cluster.Type) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
 		c.Labels["type"] = string(t)
 	}
 }
 
 // Owner sets the 'ownerClusterName' label
 func owner(name string) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
 		c.Labels["ownerClusterName"] = name
 	}
 }
 
 // Namespace sets the 'namespace' label
 func namespace(name string) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
 		c.Labels["namespace"] = name
 	}
 }
 
 // SecretRef sets the SecretRef in the cluster's Spec
 func secretRef(ref string) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
-		c.Spec.SecretRef = v1alpha1.LocalSecretReference{
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
+		c.Spec.SecretRef = toolchainv1alpha1.LocalSecretReference{
 			Name: ref,
 		}
 	}
@@ -163,14 +163,14 @@ func secretRef(ref string) clusterOption {
 
 // APIEndpoint sets the APIEndpoint in the cluster's Spec
 func apiEndpoint(url string) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
 		c.Spec.APIEndpoint = url
 	}
 }
 
 // CABundle sets the CABundle in the cluster's Spec
 func caBundle(bundle string) clusterOption {
-	return func(c *v1alpha1.ToolchainCluster) {
+	return func(c *toolchainv1alpha1.ToolchainCluster) {
 		c.Spec.CABundle = bundle
 	}
 }

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
@@ -38,7 +37,7 @@ type userManagementTestSuite struct {
 }
 
 func (s *userManagementTestSuite) SetupSuite() {
-	userSignupList := &v1alpha1.UserSignupList{}
+	userSignupList := &toolchainv1alpha1.UserSignupList{}
 	s.ctx, s.hostAwait, s.memberAwait, s.member2Await = WaitForDeployments(s.T(), userSignupList)
 }
 
@@ -131,7 +130,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		manyManyDaysAgo := 999999999999999
 		durationDelta := time.Duration(manyManyDaysAgo) * time.Hour * 24
 		updatedProvisionedTime := &metav1.Time{Time: time.Now().Add(-durationDelta)}
-		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *v1alpha1.MasterUserRecord) {
+		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = updatedProvisionedTime
 		})
 		require.NoError(s.T(), err)
@@ -171,14 +170,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
 		// time should test the behaviour of the deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *v1alpha1.MasterUserRecord) {
+		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
 		require.NoError(s.T(), err)
 		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name, murMember1.Status.ProvisionedTime.String())
 
 		// Use the same method above to change the provisioned time for the excluded user
-		excludedMurMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(excludedMurMember1.Name, func(mur *v1alpha1.MasterUserRecord) {
+		excludedMurMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(excludedMurMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
 		require.NoError(s.T(), err)
@@ -189,7 +188,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 		userSignupMember1, err = s.hostAwait.WaitForUserSignup(userSignupMember1.Name,
 			wait.UntilUserSignupHasConditions(Deactivated()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueDeactivated))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
 		require.NoError(s.T(), err)
 		require.True(t, states.Deactivated(userSignupMember1), "usersignup should be deactivated")
 
@@ -198,7 +197,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 		deactivationExcludedUserSignupMember1, err = s.hostAwait.WaitForUserSignup(deactivationExcludedUserSignupMember1.Name,
 			wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 		require.NoError(s.T(), err)
 		require.False(t, states.Deactivated(deactivationExcludedUserSignupMember1), "deactivationExcludedUserSignup should not be deactivated")
 
@@ -235,7 +234,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// period from the current time and setting this as the provisioned time should test the behaviour of the
 		// deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *v1alpha1.MasterUserRecord) {
+		murMember1, err = s.hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
 		require.NoError(s.T(), err)
@@ -268,7 +267,7 @@ func (s *userManagementTestSuite) TestUserReactivationsMetric() {
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
-			_, err := s.hostAwait.UpdateUserSignupSpec(usersignups[username].Name, func(usersignup *v1alpha1.UserSignup) {
+			_, err := s.hostAwait.UpdateUserSignupSpec(usersignups[username].Name, func(usersignup *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(usersignup, true)
 			})
 			require.NoError(s.T(), err)
@@ -346,7 +345,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 			"banprovisioned@test.com", s.memberAwait, ApprovedAutomatically()...)
 
 		// Create the BannedUser
-		s.createAndCheckBannedUser(userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
+		s.createAndCheckBannedUser(userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
@@ -359,7 +358,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		// confirm usersignup
 		_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 			wait.UntilUserSignupHasConditions(ApprovedAutomaticallyAndBanned()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueBanned))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
 		require.NoError(s.T(), err)
 
 		t.Run("verify metrics are correct after user banned", func(t *testing.T) {
@@ -381,7 +380,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Check that no MUR created
 		userSignup := s.createAndCheckUserSignupNoMUR(false, "testuser"+id, email, s.memberAwait, Banned()...)
-		assert.Equal(t, v1alpha1.UserSignupStateLabelValueBanned, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueBanned, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		mur, err := s.hostAwait.GetMasterUserRecord(wait.WithMurName("testuser" + id))
 		require.NoError(s.T(), err)
 		assert.Nil(s.T(), mur)
@@ -442,7 +441,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		userSignup, mur := s.createAndCheckUserSignup(false, "banandunban", "banandunban@test.com", s.memberAwait, ApprovedAutomatically()...)
 
 		// Create the BannedUser
-		bannedUser := s.createAndCheckBannedUser(userSignup.Annotations[v1alpha1.UserSignupUserEmailAnnotationKey])
+		bannedUser := s.createAndCheckBannedUser(userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 		// Confirm the user is banned
 		_, err := s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
@@ -455,7 +454,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		// confirm usersignup
 		userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 			wait.UntilUserSignupHasConditions(ApprovedAutomaticallyAndBanned()...),
-			wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueBanned))
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
 		require.NoError(s.T(), err)
 
 		t.Run("unban the banned user", func(t *testing.T) {
@@ -470,7 +469,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 			// Confirm the user is provisioned
 			userSignup, err = s.hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
-				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
 			// Confirm the MUR is created
@@ -493,7 +492,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	require.NoError(s.T(), err)
 
 	// Disable MUR
-	mur, err = s.hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *v1alpha1.MasterUserRecord) {
+	mur, err = s.hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 		mur.Spec.Disabled = true
 	})
 	require.NoError(s.T(), err)
@@ -525,7 +524,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	s.Run("re-enabled mur", func() {
 		// Re-enable MUR
-		mur, err = s.hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *v1alpha1.MasterUserRecord) {
+		mur, err = s.hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Spec.Disabled = false
 		})
 		require.NoError(s.T(), err)

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -29,7 +29,7 @@ type userWorkloadsTestSuite struct {
 }
 
 func (s *userWorkloadsTestSuite) SetupSuite() {
-	s.ctx, s.hostAwait, s.memberAwait, s.member2Await = WaitForDeployments(s.T(), &v1alpha1.UserSignupList{})
+	s.ctx, s.hostAwait, s.memberAwait, s.member2Await = WaitForDeployments(s.T(), &toolchainv1alpha1.UserSignupList{})
 }
 
 func (s *userWorkloadsTestSuite) TearDownTest() {

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -26,7 +26,7 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 }
 
 func (s *userSignupIntegrationTest) SetupSuite() {
-	userSignupList := &v1alpha1.UserSignupList{}
+	userSignupList := &toolchainv1alpha1.UserSignupList{}
 	s.ctx, s.hostAwait, s.memberAwait, s.member2Await = WaitForDeployments(s.T(), userSignupList)
 }
 
@@ -58,7 +58,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 			// then
 			userSignup, err := s.hostAwait.WaitForUserSignup(userSignup.Name,
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
-				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
 		})
@@ -88,7 +88,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 			// then
 			userSignup, err := s.hostAwait.WaitForUserSignup(userSignup1.Name,
 				wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
-				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
 			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
@@ -101,7 +101,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				// then
 				userSignup, err := s.hostAwait.WaitForUserSignup(userSignup2.Name,
 					wait.UntilUserSignupHasConditions(ApprovedAutomatically()...),
-					wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
 				VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
@@ -144,11 +144,11 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 	})
 }
 
-func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *v1alpha1.UserSignup) {
+func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *toolchainv1alpha1.UserSignup) {
 	s.hostAwait.CheckMasterUserRecordIsDeleted(userSignup.Spec.Username)
 	currentUserSignup, err := s.hostAwait.WaitForUserSignup(userSignup.Name)
 	require.NoError(t, err)
-	assert.Equal(t, v1alpha1.UserSignupStateLabelValuePending, currentUserSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValuePending, currentUserSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 }
 
 func (s *userSignupIntegrationTest) TestManualApproval() {
@@ -159,7 +159,7 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
 			userSignup, _ := s.createAndCheckUserSignup(true, "manual1", "manual1@redhat.com", nil, ApprovedByAdmin()...)
-			assert.Equal(t, v1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
@@ -196,7 +196,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			// then
 			userSignup, err := s.hostAwait.WaitForUserSignup(userSignup.Name,
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
-				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
 		})
@@ -219,7 +219,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			// then
 			userSignup, err := s.hostAwait.WaitForUserSignup(userSignup.Name,
 				wait.UntilUserSignupHasConditions(ApprovedByAdmin()...),
-				wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved))
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
 		})
@@ -231,7 +231,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 
 		// when & then
 		userSignup, _ := s.createAndCheckUserSignup(true, "withtargetcluster", "withtargetcluster@redhat.com", s.memberAwait, ApprovedByAdmin()...)
-		assert.Equal(t, v1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
 }
 
@@ -311,7 +311,7 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 	}
 }
 
-func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *v1alpha1.UserSignup {
+func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *toolchainv1alpha1.UserSignup {
 	// Create a new UserSignup
 	username := "testuser" + uuid.NewV4().String()
 	email := username + "@test.com"
@@ -331,7 +331,7 @@ func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAsser
 	// Check the UserSignup is pending approval now
 	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
 		wait.UntilUserSignupHasConditions(VerificationRequired()...),
-		wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueNotReady))
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
 
 	// Confirm the CompliantUsername has NOT been set

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -1,7 +1,7 @@
 package testsupport
 
 import (
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
@@ -116,7 +116,7 @@ func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.H
 }
 
 func newSchemeBuilder() runtime.SchemeBuilder {
-	return append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme,
+	return append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme,
 		userv1.Install,
 		templatev1.Install,
 		routev1.Install,

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
@@ -116,7 +116,7 @@ func getMemberAwaitility(t *testing.T, f *framework.Framework, hostAwait *wait.H
 }
 
 func newSchemeBuilder() runtime.SchemeBuilder {
-	return append(apis.AddToSchemes,
+	return append(runtime.SchemeBuilder{}, v1alpha1.AddToScheme,
 		userv1.Install,
 		templatev1.Install,
 		routev1.Install,

--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint: golint
 
 	"github.com/operator-framework/operator-sdk/pkg/test"

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	quotav1 "github.com/openshift/api/quota/v1"

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	quotav1 "github.com/openshift/api/quota/v1"
@@ -554,7 +554,7 @@ func idlers(namespaceTypes ...string) clusterObjectsCheckCreator {
 			}
 
 			// Make sure there is no unexpected idlers
-			idlers := &v1alpha1.IdlerList{}
+			idlers := &toolchainv1alpha1.IdlerList{}
 			err := memberAwait.Client.List(context.TODO(), idlers,
 				client.MatchingLabels(map[string]string{
 					"toolchain.dev.openshift.com/provider": "codeready-toolchain",

--- a/testsupport/tiers/nstemplateset.go
+++ b/testsupport/tiers/nstemplateset.go
@@ -3,7 +3,7 @@ package tiers
 import (
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	"github.com/stretchr/testify/assert"

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -1,7 +1,7 @@
 package tiers
 
 import (
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
 )

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/assert"
 

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/assert"
 
@@ -29,7 +29,7 @@ func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility, memberA
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }
 
-func VerifyIncreaseOfUserAccountCount(t *testing.T, previous, current *v1alpha1.ToolchainStatus, memberClusterName string, increase int) {
+func VerifyIncreaseOfUserAccountCount(t *testing.T, previous, current *toolchainv1alpha1.ToolchainStatus, memberClusterName string, increase int) {
 	found := false
 CurrentMembers:
 	for _, currentMemberStatus := range current.Status.Members {

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -3,8 +3,8 @@ package testsupport
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -3,7 +3,6 @@ package testsupport
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
@@ -22,7 +21,7 @@ func VerifyMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, signups
 func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwaitility, signup *toolchainv1alpha1.UserSignup, tier string, members ...*wait.MemberAwaitility) {
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
 	// Get the latest signup version, wait for usersignup to have the approved label and wait for the complete status to ensure the compliantusername is available
-	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(v1alpha1.UserSignupStateLabelValueApproved), wait.ContainsCondition(Complete()))
+	userSignup, err := hostAwait.WaitForUserSignup(signup.Name, wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved), wait.ContainsCondition(Complete()))
 	require.NoError(t, err)
 
 	// First, wait for the MasterUserRecord to exist, no matter what status
@@ -69,7 +68,7 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, hostAwait *wait.HostAwait
 	assert.NoError(t, err)
 }
 
-func ExpectedUserAccount(userID string, tier string, templateRefs tiers.TemplateRefs) v1alpha1.UserAccountSpec {
+func ExpectedUserAccount(userID string, tier string, templateRefs tiers.TemplateRefs) toolchainv1alpha1.UserAccountSpec {
 	namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, 0, len(templateRefs.Namespaces))
 	for _, ref := range templateRefs.Namespaces {
 		namespaces = append(namespaces, toolchainv1alpha1.NSTemplateSetNamespace{
@@ -83,7 +82,7 @@ func ExpectedUserAccount(userID string, tier string, templateRefs tiers.Template
 			TemplateRef: tier + "-" + "clusterresources" + "-" + *templateRefs.ClusterResources,
 		}
 	}
-	return v1alpha1.UserAccountSpec{
+	return toolchainv1alpha1.UserAccountSpec{
 		UserID:   userID,
 		Disabled: false,
 		UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	routev1 "github.com/openshift/api/route/v1"

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -49,8 +49,8 @@ type Awaitility struct {
 }
 
 // ReadyToolchainCluster is a ClusterCondition that represents cluster that is ready
-var ReadyToolchainCluster = &v1alpha1.ToolchainClusterCondition{
-	Type:   v1alpha1.ToolchainClusterReady,
+var ReadyToolchainCluster = &toolchainv1alpha1.ToolchainClusterCondition{
+	Type:   toolchainv1alpha1.ToolchainClusterReady,
 	Status: v1.ConditionTrue,
 }
 
@@ -121,12 +121,12 @@ func (a *Awaitility) WaitForMetricsService(name string) (corev1.Service, error) 
 // WaitForToolchainClusterWithCondition waits until there is a ToolchainCluster representing a operator of the given type
 // and running in the given expected namespace. If the given condition is not nil, then it also checks
 // if the CR has the ClusterCondition
-func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Type, namespace string, condition *v1alpha1.ToolchainClusterCondition) (v1alpha1.ToolchainCluster, error) {
+func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
 	timeout := a.Timeout
 	if condition != nil {
 		timeout = ToolchainClusterConditionTimeout
 	}
-	var c v1alpha1.ToolchainCluster
+	var c toolchainv1alpha1.ToolchainCluster
 	err := wait.Poll(a.RetryInterval, timeout, func() (done bool, err error) {
 		var ready bool
 		if c, ready, err = a.GetToolchainCluster(clusterType, namespace, condition); ready {
@@ -140,14 +140,14 @@ func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Ty
 
 // WaitForNamedToolchainClusterWithCondition waits until there is a ToolchainCluster with the given name
 // and with the given ClusterCondition (if it the condition is nil, then it skips this check)
-func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(name string, condition *v1alpha1.ToolchainClusterCondition) (v1alpha1.ToolchainCluster, error) {
+func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(name string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
 	timeout := a.Timeout
 	if condition != nil {
 		timeout = ToolchainClusterConditionTimeout
 	}
-	c := v1alpha1.ToolchainCluster{}
+	c := toolchainv1alpha1.ToolchainCluster{}
 	err := wait.Poll(a.RetryInterval, timeout, func() (done bool, err error) {
-		c = v1alpha1.ToolchainCluster{}
+		c = toolchainv1alpha1.ToolchainCluster{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, &c); err != nil {
 			return false, err
 		}
@@ -164,13 +164,13 @@ func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(name string, cond
 // GetToolchainCluster retrieves and returns a ToolchainCluster representing a operator of the given type
 // and running in the given expected namespace. If the given condition is not nil, then it also checks
 // if the CR has the ClusterCondition
-func (a *Awaitility) GetToolchainCluster(clusterType cluster.Type, namespace string, condition *v1alpha1.ToolchainClusterCondition) (v1alpha1.ToolchainCluster, bool, error) {
-	clusters := &v1alpha1.ToolchainClusterList{}
+func (a *Awaitility) GetToolchainCluster(clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, bool, error) {
+	clusters := &toolchainv1alpha1.ToolchainClusterList{}
 	if err := a.Client.List(context.TODO(), clusters, client.InNamespace(a.Namespace), client.MatchingLabels{
 		"namespace": namespace,
 		"type":      string(clusterType),
 	}); err != nil {
-		return v1alpha1.ToolchainCluster{}, false, err
+		return toolchainv1alpha1.ToolchainCluster{}, false, err
 	}
 	if len(clusters.Items) == 0 {
 		a.T.Logf("no toolchaincluster resource with expected labels: namespace='%s', type='%s'", namespace, string(clusterType))
@@ -184,10 +184,10 @@ func (a *Awaitility) GetToolchainCluster(clusterType cluster.Type, namespace str
 		a.T.Logf("found %s ToolchainCluster running in namespace '%s' but with insufficient conditions: %+v", clusterType, namespace, cl.Status.Conditions)
 
 	}
-	return v1alpha1.ToolchainCluster{}, false, nil
+	return toolchainv1alpha1.ToolchainCluster{}, false, nil
 }
 
-func containsClusterCondition(conditions []v1alpha1.ToolchainClusterCondition, contains *v1alpha1.ToolchainClusterCondition) bool {
+func containsClusterCondition(conditions []toolchainv1alpha1.ToolchainClusterCondition, contains *toolchainv1alpha1.ToolchainClusterCondition) bool {
 	if contains == nil {
 		return true
 	}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 


### PR DESCRIPTION
result of codeready-toolchain/api#237

* small changes in go.mod so we can use the new controller-tools 0.4.1 together with client-go 0.18.3
* update all imports to api repo/types

related PRs, but NOT paired:
https://github.com/codeready-toolchain/member-operator/pull/254
https://github.com/codeready-toolchain/host-operator/pull/441
https://github.com/codeready-toolchain/registration-service/pull/191