### PR TITLE
Use awaitility Cleanup() instead

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -396,8 +396,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 				// Trigger a reconciliation of the deactivation controller by updating the MUR
 				// - The SyncIndex property of the UserAccount is intended for the express purpose of triggering
 				//   a reconciliation, so we set it to some new unique value here
-				mur.Spec.UserAccounts[0].SyncIndex = uuid.Must(uuid.NewV4()).String()
-				require.NoError(t, s.hostAwait.Client.Update(context.TODO(), mur))
+				syncIndex := uuid.Must(uuid.NewV4()).String()
+				mur, err := s.hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Spec.UserAccounts[0].SyncIndex = syncIndex
+				})
+				require.NoError(t, err)
 
 				// The user should now be set to deactivated
 				userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name,

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -1,7 +1,6 @@
 package testsupport
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,11 +8,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
@@ -218,20 +212,7 @@ func (r *signupRequest) Execute() SignupRequest {
 	}
 
 	// We also need to ensure that the UserSignup is deleted at the end of the test (if the test itself doesn't delete it)
-	r.t.Cleanup(func() {
-		propagationPolicy := metav1.DeletePropagationForeground
-		opts := client.DeleteOption(&client.DeleteOptions{
-			PropagationPolicy: &propagationPolicy,
-		})
-
-		// Delete the UserSignup
-		if err := r.hostAwait.Client.Delete(context.TODO(), r.userSignup, opts); err != nil && !errors.IsNotFound(err) {
-			require.NoError(r.t, err)
-		}
-
-		// Ensure the UserSignup has been deleted
-		require.NoError(r.t, r.hostAwait.WaitUntilUserSignupDeleted(r.userSignup.Name))
-	})
+	r.hostAwait.Cleanup(r.userSignup)
 
 	return r
 }


### PR DESCRIPTION
Minor fix to modify `SignupRequest` to use the awaitility `Cleanup()` function.