### PR TITLE
fix(flaky): user can be provisioned to any member with automatic approval

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -350,7 +350,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
-			VerifyResourcesProvisionedForSignup(t, s.hostAwait, userSignup, "base", s.memberAwait)
+			VerifyResourcesProvisionedForSignup(t, s.hostAwait, userSignup, "base", s.memberAwait, s.member2Await)
 
 			s.T().Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back


### PR DESCRIPTION
user can be provided to any member when automatic approval is enabled and no target cluster is required
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/codeready-toolchain_member-operator/270/pull-ci-codeready-toolchain-member-operator-master-e2e/1407954437116268544/build-log.txt