### PR TITLE
fix: improve cleanup messaging

### DIFF
--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -509,6 +509,7 @@ func (a *Awaitility) Cleanup(objects ...runtime.Object) {
 			}
 
 			// wait until deletion is done
+			a.T.Logf("waiting until %s: %s is completely deleted", kind, metaAccess.GetName())
 			require.NoError(a.T, wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 				if err := a.Client.Get(context.TODO(), test.NamespacedName(metaAccess.GetNamespace(), metaAccess.GetName()), objToClean); err != nil {
 					if errors.IsNotFound(err) {
@@ -522,7 +523,7 @@ func (a *Awaitility) Cleanup(objects ...runtime.Object) {
 					a.T.Logf("problem with getting the related %s '%s': %s", kind, metaAccess.GetName(), err)
 					return false, err
 				}
-				a.T.Logf("waiting until %s: %s is completely deleted", kind, metaAccess.GetName())
+				fmt.Print(".")
 				return false, nil
 			}))
 		}
@@ -559,7 +560,7 @@ func (a *Awaitility) verifyMurDeleted(isUserSignup bool, userSignup *toolchainv1
 			a.T.Logf("waiting until MasterUserRecord: %s is completely deleted", userSignup.Status.CompliantUsername)
 			return false, nil
 		}
-		a.T.Logf("the UserSignup doesn't have CompliantUsername set: %+v", userSignup)
+		a.T.Logf("the UserSignup doesn't have CompliantUsername set")
 		return true, nil
 	}
 	return true, nil


### PR DESCRIPTION
The cleanup sometimes takes a long time to finish and there is a lot of messaging around that. Originally, I wanted to clean it in parallel, but when I tried it the client failed with:
```
fatal error: concurrent map writes
fatal error: concurrent map writes

goroutine 2056 [running]:
runtime.throw(0x166d513, 0x15)
	/home/mjobanek/go/go/src/runtime/panic.go:1117 +0x72 fp=0xc0009d6ee0 sp=0xc0009d6eb0 pc=0x43a2b2
runtime.mapassign(0x14ce6e0, 0xc00031d3b0, 0xc000b4e8a0, 0xc000495320)
	/home/mjobanek/go/go/src/runtime/map.go:676 +0x591 fp=0xc0009d6f60 sp=0xc0009d6ee0 pc=0x411f51
reflect.mapassign(0x14ce6e0, 0xc00031d3b0, 0xc000b4e8a0, 0xc000b4e8b0)
	/home/mjobanek/go/go/src/runtime/map.go:1328 +0x3f fp=0xc0009d6f90 sp=0xc0009d6f60 pc=0x46d0ff
github.com/modern-go/reflect2.(*UnsafeMapType).UnsafeSetIndex(...)
	/home/mjobanek/go-workspace/pkg/mod/github.com/modern-go/reflect2@v1.0.1/unsafe_map.go:76
github.com/json-iterator/go.(*mapDecoder).Decode(0xc000db42d0, 0xc000185778, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_map.go:180 +0x1a5 fp=0xc0009d7010 sp=0xc0009d6f90 pc=0x819a65
github.com/json-iterator/go.(*placeholderDecoder).Decode(0xc0005aa9a0, 0xc000185778, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect.go:324 +0x47 fp=0xc0009d7038 sp=0xc0009d7010 pc=0x812587
github.com/json-iterator/go.(*structFieldDecoder).Decode(0xc00047bda0, 0xc0001856e0, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_struct_decoder.go:1054 +0x78 fp=0xc0009d70c0 sp=0xc0009d7038 pc=0x82a938
github.com/json-iterator/go.(*generalStructDecoder).decodeOneField(0xc00047bec0, 0xc0001856e0, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_struct_decoder.go:552 +0x24c fp=0xc0009d7150 sp=0xc0009d70c0 pc=0x827ecc
github.com/json-iterator/go.(*generalStructDecoder).Decode(0xc00047bec0, 0xc0001856e0, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_struct_decoder.go:508 +0x85 fp=0xc0009d71c0 sp=0xc0009d7150 pc=0x827985
github.com/json-iterator/go.(*structFieldDecoder).Decode(0xc0005a7c60, 0xc0001856c0, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_struct_decoder.go:1054 +0x78 fp=0xc0009d7248 sp=0xc0009d71c0 pc=0x82a938
github.com/json-iterator/go.(*fiveFieldsStructDecoder).Decode(0xc00033aa20, 0xc0001856c0, 0xc000495320)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect_struct_decoder.go:737 +0x337 fp=0xc0009d72b0 sp=0xc0009d7248 pc=0x8291f7
github.com/json-iterator/go.(*Iterator).ReadVal(0xc000495320, 0x1626ce0, 0xc0001856c0)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/reflect.go:79 +0xc2 fp=0xc0009d7320 sp=0xc0009d72b0 pc=0x8103c2
github.com/json-iterator/go.(*frozenConfig).Unmarshal(0xc0001b3400, 0xc000bc6400, 0xb48, 0xc00, 0x1626ce0, 0xc0001856c0, 0x0, 0x0)
	/home/mjobanek/go-workspace/pkg/mod/github.com/json-iterator/go@v1.1.10/config.go:348 +0xb7 fp=0xc0009d7380 sp=0xc0009d7320 pc=0x806137
k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode(0xc000554050, 0xc000bc6400, 0xb48, 0xc00, 0x0, 0x1819ee8, 0xc0001856c0, 0xc0009d75c0, 0xc4f706, 0x0, ...)
	/home/mjobanek/go-workspace/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/runtime/serializer/json/json.go:263 +0x5be fp=0xc0009d7650 sp=0xc0009d7380 pc=0xc334fe
k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode(0x18119a0, 0xc000554050, 0xc000bc6400, 0xb48, 0xc00, 0x0, 0x1819ee8, 0xc0001856c0, 0xc0005a87b0, 0xc000faa2a0, ...)
	/home/mjobanek/go-workspace/pkg/mod/k8s.io/apimachinery@v0.18.3/pkg/runtime/helper.go:252 +0x97 fp=0xc0009d76e8 sp=0xc0009d7650 pc=0x883c77
k8s.io/apimachinery/pkg/runtime.(*WithoutVersionDecoder).Decode(0xc000b4e870, 0xc000bc6400, 0xb48, 0xc00, 0x0, 0x1819ee8, 0xc0001856c0, 0xc0009d77b0, 0x0, 0x0, ...)
	<autogenerated>:1 +0x9f fp=0xc0009d7760 sp=0xc0009d76e8 pc=0x8904df
k8s.io/client-go/rest.Result.Into(0xc000bc6400, 0xb48, 0xc00, 0xc000dc1380, 0x10, 0x0, 0x0, 0xc8, 0x1812980, 0xc000b4e870, ...)
	/home/mjobanek/go-workspace/pkg/mod/k8s.io/client-go@v0.18.3/rest/request.go:1233 +0xb4 fp=0xc0009d7828 sp=0xc0009d7760 pc=0xc51db4
sigs.k8s.io/controller-runtime/pkg/client.(*typedClient).Get(0xc00025c480, 0x1840970, 0xc000126018, 0xc0004068c0, 0x1b, 0xc00029cb70, 0x24, 0x1819ee8, 0xc0001856c0, 0xc00004f320, ...)
	/home/mjobanek/go-workspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/client/typed_client.go:139 +0x1b2 fp=0xc0009d7908 sp=0xc0009d7828 pc=0x1208732
sigs.k8s.io/controller-runtime/pkg/client.(*client).Get(0xc00025c480, 0x1840970, 0xc000126018, 0xc0004068c0, 0x1b, 0xc00029cb70, 0x24, 0x1819ee8, 0xc0001856c0, 0x0, ...)
	/home/mjobanek/go-workspace/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/client/client.go:165 +0x145 fp=0xc0009d7970 sp=0xc0009d7908 pc=0x1204725
github.com/codeready-toolchain/toolchain-e2e/testsupport/wait.(*Awaitility).Cleanup.func1.1(0xc0009d7c3c, 0x2, 0x2)
```
so I decided not to do that and just improve the messaging. 
Instead of having many the same lines in a row:
```
awaitility.go:512: waiting until UserSignup: a9c42fbb-75a8-43ec-a0a7-d80db76fe8de is completely deleted
awaitility.go:512: waiting until UserSignup: a9c42fbb-75a8-43ec-a0a7-d80db76fe8de is completely deleted
awaitility.go:512: waiting until UserSignup: a9c42fbb-75a8-43ec-a0a7-d80db76fe8de is completely deleted
awaitility.go:512: waiting until UserSignup: a9c42fbb-75a8-43ec-a0a7-d80db76fe8de is completely deleted
awaitility.go:543: the related MasterUserRecord: crt-redhat-paul is deleted as well
```
we will have:
```
awaitility.go:512: waiting until UserSignup: a9c42fbb-75a8-43ec-a0a7-d80db76fe8de is completely deleted
..................................................    awaitility.go:543: the related MasterUserRecord: crt-redhat-paul is deleted as well
```