### PR TITLE
build: use 'MEMBER_NS_2' env var when it's defined

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -12,7 +12,7 @@ MEMBER_NS ?= toolchain-member-${DATE_SUFFIX}
 SECOND_MEMBER_MODE = true
 
 ifeq ($(SECOND_MEMBER_MODE),true)
-MEMBER_NS_2 = toolchain-member2-${DATE_SUFFIX}
+MEMBER_NS_2 ?= toolchain-member2-${DATE_SUFFIX}
 endif
 
 REGISTRATION_SERVICE_NS := $(HOST_NS)


### PR DESCRIPTION
only use the `toolchain-member2-${DATE_SUFFIX}` when the
env var is not already defined.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
