### PR TITLE
Remove workaround for webhook deploy

### DIFF
--- a/deploy/member2-operator/dev/member-operator-config-map.yaml
+++ b/deploy/member2-operator/dev/member-operator-config-map.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: member-operator-config
-type: Opaque
-data:
-  deploy.webhook: 'false'

--- a/deploy/member2-operator/e2e-tests/hack.yaml
+++ b/deploy/member2-operator/e2e-tests/hack.yaml
@@ -1,7 +1,0 @@
-apiVersion: toolchain.dev.openshift.com/v1alpha1
-kind: MemberOperatorConfig
-metadata:
-  name: config
-spec:     
-  webhook:
-    deploy: false

--- a/deploy/member2-operator/e2e-tests/member-operator-config-map.yaml
+++ b/deploy/member2-operator/e2e-tests/member-operator-config-map.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: member-operator-config
-type: Opaque
-data:
-  deploy.webhook: 'false'

--- a/make/test.mk
+++ b/make/test.mk
@@ -157,7 +157,7 @@ get-and-publish-host-operator:
 ###########################################################
 
 .PHONY: deploy-members
-deploy-members: create-member1 create-member2 get-and-publish-member-operator create-member-resources
+deploy-members: create-member1 create-member2 get-and-publish-member-operator
 
 .PHONY: create-member1
 create-member1:
@@ -171,15 +171,6 @@ ifeq ($(SECOND_MEMBER_MODE),true)
 	@echo "Deploying second member operator to ${MEMBER_NS_2}..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS_2}
 	-oc label ns ${MEMBER_NS_2} app=member-operator
-endif
-
-.PHONY: create-member-resources
-create-member-resources:
-ifeq ($(MEMBER_REPO_PATH),)
-	$(eval MEMBER_REPO_PATH = /tmp/codeready-toolchain/member-operator)
-endif
-ifeq ($(SECOND_MEMBER_MODE),true)
-	oc apply -f deploy/member2-operator/${ENVIRONMENT}/ -n ${MEMBER_NS_2}
 endif
 
 .PHONY: deploy-host


### PR DESCRIPTION
Removes the previous hack that was in place temporarily until the autoscaler and webhook deployment was moved to the member operator controller.

Related PR: https://github.com/codeready-toolchain/member-operator/pull/281