### PR TITLE
Tests for new baseextendedidling tier

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -37,7 +37,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	testingtiers := CreateAndApproveSignup(t, hostAwait, testingTiersName, memberAwait.ClusterName)
 
 	// all tiers to check - keep the base as the last one, it will verify downgrade back to the default tier at the end of the test
-	tiersToCheck := []string{"advanced", "team", "test", "basedeactivationdisabled", "baseextended", "base"}
+	tiersToCheck := []string{"advanced", "team", "test", "basedeactivationdisabled", "baseextended", "baseextendedidling", "base"}
 
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.NSTemplateTierList{}
@@ -258,7 +258,7 @@ func TestTierTemplates(t *testing.T) {
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
 	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))
-	// verify that we have 18 tier templates (base: 3, baseextended: 3, basedeactivationdisabled 3, advanced: 3, team 3, test 3)
+	// verify that we have 21 tier templates (base: 3, baseextended: 3, baseextendedidling: 3, basedeactivationdisabled: 3, advanced: 3, team: 3, test: 3)
 	require.NoError(t, err)
-	assert.Len(t, allTiers.Items, 18)
+	assert.Len(t, allTiers.Items, 21)
 }


### PR DESCRIPTION
Updates the tests to include the new baseextendedidling tier that has idling timeout set to 24 hours.

Related PR: https://github.com/codeready-toolchain/host-operator/pull/486