### PR TITLE
Lookup subscription using prefix

### DIFF
--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/codeready-toolchain/toolchain-e2e/setup/templates"
@@ -38,9 +39,9 @@ func VerifySandboxOperatorsInstalled(cl client.Client) error {
 	foundHost := false
 	foundMember := false
 	for _, sub := range subs.Items {
-		if sub.Name == hostSubscriptionName {
+		if strings.HasPrefix(sub.Name, hostSubscriptionName) {
 			foundHost = true
-		} else if sub.Name == memberSubscriptionName {
+		} else if strings.HasPrefix(sub.Name, memberSubscriptionName) {
 			foundMember = true
 		}
 	}


### PR DESCRIPTION
It looks like the subscriptions now have an identifier appended so the setup tool needs to update to look for a prefix instead of an exact match