### PR TITLE
Update operator versions

### DIFF
--- a/setup/cmd/root.go
+++ b/setup/cmd/root.go
@@ -21,6 +21,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultHostNS   = "toolchain-host-operator"
+	defaultMemberNS = "toolchain-member-operator"
+)
+
 var (
 	usernamePrefix          = "zippy"
 	kubeconfig              string
@@ -52,14 +57,6 @@ func Execute() {
 		Args:          cobra.NoArgs,
 		Run:           setup,
 	}
-
-	quayNS, found := os.LookupEnv("QUAY_NAMESPACE")
-	if !found || len(quayNS) == 0 {
-		fmt.Println("QUAY_NAMESPACE env var is not set, ensure the prerequisite setup steps are followed")
-		os.Exit(1)
-	}
-	defaultHostNS := fmt.Sprintf("%s-host-operator", quayNS)
-	defaultMemberNS := fmt.Sprintf("%s-member-operator", quayNS)
 
 	cmd.Flags().StringVar(&usernamePrefix, "username", usernamePrefix, "the prefix used for usersignup names")
 	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")

--- a/setup/operators/installtemplates/kiali.yaml
+++ b/setup/operators/installtemplates/kiali.yaml
@@ -14,7 +14,7 @@ objects:
       name: kiali-ossm
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: kiali-operator.v1.24.5
+      startingCSV: kiali-operator.v1.24.8
 parameters:
   - name: KIALI_NAMESPACE
     value: openshift-operators

--- a/setup/operators/installtemplates/rhoas.yaml
+++ b/setup/operators/installtemplates/rhoas.yaml
@@ -23,7 +23,7 @@ objects:
     name: rhoas-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: rhoas-operator.0.7.2
+    startingCSV: rhoas-operator.0.7.6
 parameters:
 - name: RHOAS_NAMESPACE
   value: rhoas-operator

--- a/setup/operators/installtemplates/sbo.yaml
+++ b/setup/operators/installtemplates/sbo.yaml
@@ -23,7 +23,7 @@ objects:
       name: rh-service-binding-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: service-binding-operator.v0.7.0
+      startingCSV: service-binding-operator.v0.9.1
       config:
         resources:
           requests:

--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -3,6 +3,7 @@ package operators
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/codeready-toolchain/toolchain-e2e/setup/templates"
@@ -38,9 +39,9 @@ func VerifySandboxOperatorsInstalled(cl client.Client) error {
 	foundHost := false
 	foundMember := false
 	for _, sub := range subs.Items {
-		if sub.Name == hostSubscriptionName {
+		if strings.HasPrefix(sub.Name, hostSubscriptionName) {
 			foundHost = true
-		} else if sub.Name == memberSubscriptionName {
+		} else if strings.HasPrefix(sub.Name, memberSubscriptionName) {
 			foundMember = true
 		}
 	}


### PR DESCRIPTION
SBO and other operators take a long time to install using the setup tool because it's trying to install from older versions. It can also cause problems when just retrying the setup tool so just update to the newer versions.