### PR TITLE
fix: use default health check period

### DIFF
--- a/deploy/host-operator/e2e-tests/toolchainconfig.yaml
+++ b/deploy/host-operator/e2e-tests/toolchainconfig.yaml
@@ -11,5 +11,3 @@ spec:
         bufferReplicas: 2
       memberStatus:
         refreshPeriod: "1s"
-      toolchainCluster:
-        healthCheckPeriod: "5s"


### PR DESCRIPTION
The go routine that checks the health of host cluster is created when the operator is started: https://github.com/codeready-toolchain/toolchain-common/blob/master/controllers/toolchaincluster/healthchecker.go#L33-L35 - at that time it uses the default value (which is 10s) because the MemberOperatorConfig is still not propagated from host (5s). 
let's drop the shorter period and use only the default one