### PR TITLE
Quick fix for a couple flaky tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -233,6 +233,7 @@ func TestE2EFlow(t *testing.T) {
 			Email("laracroft@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
+			TargetCluster(memberAwait).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
 

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -39,6 +39,7 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 		Email("test-idler@redhat.com").
 		ManuallyApprove().
 		EnsureMUR().
+		TargetCluster(s.memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
 		Execute()
 

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -40,7 +40,7 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(s.memberAwait).
-		RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
+		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute()
 
 	idler, err := s.memberAwait.WaitForIdler("test-idler-dev", wait.IdlerConditions(Running()))

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -33,7 +33,7 @@ func (s *userWorkloadsTestSuite) SetupSuite() {
 
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	// Provision a user to idle with a short idling timeout
-	s.hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
+	s.hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	s.newSignupRequest().
 		Username("test-idler").
 		Email("test-idler@redhat.com").

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -120,10 +120,10 @@ func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitC
 func UntilUserAccountHasConditions(conditions ...toolchainv1alpha1.Condition) UserAccountWaitCriterion {
 	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
 		if test.ConditionsMatch(ua.Status.Conditions, conditions...) {
-			a.T.Logf("status conditions match in UserAccount '%s`", ua.Name)
+			a.T.Logf("status conditions match in UserAccount '%s' in namespace '%s'", ua.Name, ua.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for status condition of UserSignup '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Status.Conditions, conditions)
+		a.T.Logf("waiting for status condition of UserSignup '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Namespace, ua.Status.Conditions, conditions)
 		return false
 	}
 }
@@ -133,10 +133,10 @@ func UntilUserAccountHasConditions(conditions ...toolchainv1alpha1.Condition) Us
 func UntilUserAccountContainsCondition(condition toolchainv1alpha1.Condition) UserAccountWaitCriterion {
 	return func(a *MemberAwaitility, ua *toolchainv1alpha1.UserAccount) bool {
 		if test.ContainsCondition(ua.Status.Conditions, condition) {
-			a.T.Logf("status conditions found in UserAccount '%s`", ua.Name)
+			a.T.Logf("status conditions found in UserAccount '%s' in namespace '%s'", ua.Name, ua.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for status condition of UserAccount '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Status.Conditions, condition)
+		a.T.Logf("waiting for status condition of UserAccount '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Namespace, ua.Status.Conditions, condition)
 		return false
 	}
 }
@@ -185,10 +185,10 @@ type NSTemplateSetWaitCriterion func(a *MemberAwaitility, ua *toolchainv1alpha1.
 func UntilNSTemplateSetHasConditions(conditions ...toolchainv1alpha1.Condition) NSTemplateSetWaitCriterion {
 	return func(a *MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet) bool {
 		if test.ConditionsMatch(nsTmplSet.Status.Conditions, conditions...) {
-			a.T.Logf("status conditions match in NSTemplateSet '%s`", nsTmplSet.Name)
+			a.T.Logf("status conditions match in NSTemplateSet '%s' in namespace '%s'", nsTmplSet.Name, nsTmplSet.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for status condition of NSTemplateSet '%s'. Actual: '%+v'; Expected: '%+v'", nsTmplSet.Name, nsTmplSet.Status.Conditions, conditions)
+		a.T.Logf("waiting for status condition of NSTemplateSet '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", nsTmplSet.Name, nsTmplSet.Namespace, nsTmplSet.Status.Conditions, conditions)
 		return false
 	}
 }
@@ -210,10 +210,10 @@ func UntilNSTemplateSetIsBeingDeleted() NSTemplateSetWaitCriterion {
 func UntilNSTemplateSetContainsCondition(condition toolchainv1alpha1.Condition) NSTemplateSetWaitCriterion {
 	return func(a *MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet) bool {
 		if test.ContainsCondition(nsTmplSet.Status.Conditions, condition) {
-			a.T.Logf("status conditions match in NSTemplateSet '%s`", nsTmplSet.Name)
+			a.T.Logf("status conditions match in NSTemplateSet '%s' in namespace '%s'", nsTmplSet.Name, nsTmplSet.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for status condition of NSTemplateSet '%s'. Actual: '%+v'; Expected: '%+v'", nsTmplSet.Name, nsTmplSet.Status.Conditions, condition)
+		a.T.Logf("waiting for status condition of NSTemplateSet '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", nsTmplSet.Name, nsTmplSet.Namespace, nsTmplSet.Status.Conditions, condition)
 		return false
 	}
 }

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -222,10 +222,10 @@ func UntilNSTemplateSetContainsCondition(condition toolchainv1alpha1.Condition) 
 func UntilNSTemplateSetHasTier(tier string) NSTemplateSetWaitCriterion {
 	return func(a *MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet) bool {
 		if nsTmplSet.Spec.TierName == tier {
-			a.T.Logf("tierName in NSTemplateSet '%s` matches the expected tier", nsTmplSet.Name)
+			a.T.Logf("tierName in NSTemplateSet '%s' in namespace '%s' matches the expected tier", nsTmplSet.Name, nsTmplSet.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for NSTemplateSet '%s' having the expected tierName. Actual: '%s'; Expected: '%s'", nsTmplSet.Name, nsTmplSet.Spec.TierName, tier)
+		a.T.Logf("waiting for NSTemplateSet '%s' in namespace '%s' having the expected tierName. Actual: '%s'; Expected: '%s'", nsTmplSet.Name, nsTmplSet.Namespace, nsTmplSet.Spec.TierName, tier)
 		return false
 	}
 }
@@ -237,7 +237,7 @@ func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateS
 		obj := &toolchainv1alpha1.NSTemplateSet{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, obj); err != nil {
 			if errors.IsNotFound(err) {
-				a.T.Logf("waiting for availability of NSTemplateSet '%s'", name)
+				a.T.Logf("waiting for availability of NSTemplateSet '%s' in namespace '%s'", name, a.Namespace)
 				return false, nil
 			}
 			return false, err
@@ -247,7 +247,7 @@ func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateS
 				return false, nil
 			}
 		}
-		a.T.Logf("found NSTemplateSet '%s'", name)
+		a.T.Logf("found NSTemplateSet '%s' in namespace '%s'", name, a.Namespace)
 		nsTmplSet = obj
 		return true, nil
 	})

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -123,7 +123,7 @@ func UntilUserAccountHasConditions(conditions ...toolchainv1alpha1.Condition) Us
 			a.T.Logf("status conditions match in UserAccount '%s' in namespace '%s'", ua.Name, ua.Namespace)
 			return true
 		}
-		a.T.Logf("waiting for status condition of UserSignup '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Namespace, ua.Status.Conditions, conditions)
+		a.T.Logf("waiting for status condition of UserAccount '%s' in namespace '%s'. Actual: '%+v'; Expected: '%+v'", ua.Name, ua.Namespace, ua.Status.Conditions, conditions)
 		return false
 	}
 }


### PR DESCRIPTION
A couple of the tests don't specify a target cluster when creating a new UserSignup so the UserAccount and other member cluster resources could be on member1 or member2 but the tests only perform assertions on a particular member cluster which leads to test flakiness.

This PR sets the target cluster to the cluster used for the assertions but we can probably make this a little more intuitive and reduce/eliminate future test flakiness related to this type of problem.