### PR TITLE
fix: add better logging to fix UserAccount in updating state

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -235,7 +235,13 @@ func verifyResourceUpdates(t *testing.T, hostAwait *HostAwaitility, memberAwaiti
 			UntilUserAccountHasConditions(Provisioned()),
 			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Name, tier.Name, templateRefs)),
 			UntilUserAccountMatchesMur(hostAwait))
-		require.NoError(t, err, "Failing \nUserSignup: %+v \nUserAccount: %+v", usersignup, userAccount)
+		if err != nil {
+			nsTemplateSet, err := memberAwaitility.WaitForNSTmplSet(usersignup.Status.CompliantUsername)
+			if err != nil {
+				t.Logf("getting NSTemplateSet '%s' failed with: %s", usersignup.Status.CompliantUsername, err)
+			}
+			require.NoError(t, err, "Failing \nUserSignup: %+v \nUserAccount: %+v \nNSTemplateSet: %+v", usersignup, userAccount, nsTemplateSet)
+		}
 		mur, err := hostAwait.WaitForMasterUserRecord(usersignup.Status.CompliantUsername,
 			UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
 			UntilMasterUserRecordHasNotSyncIndex(syncIndex),

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -157,8 +157,8 @@ func UntilUserAccountIsBeingDeleted() UserAccountWaitCriterion {
 func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccountWaitCriterion) (*toolchainv1alpha1.UserAccount, error) {
 	var userAccount *toolchainv1alpha1.UserAccount
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		obj := &toolchainv1alpha1.UserAccount{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, obj); err != nil {
+		userAccount = &toolchainv1alpha1.UserAccount{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, userAccount); err != nil {
 			if errors.IsNotFound(err) {
 				a.T.Logf("waiting for availability of useraccount '%s' in namespace '%s'", name, a.Namespace)
 				return false, nil
@@ -166,12 +166,11 @@ func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccou
 			return false, err
 		}
 		for _, match := range criteria {
-			if !match(a, obj) {
+			if !match(a, userAccount) {
 				return false, nil
 			}
 		}
 		a.T.Logf("found UserAccount '%s'", name)
-		userAccount = obj
 		return true, nil
 	})
 	return userAccount, err


### PR DESCRIPTION
When waiting fails, then print also the content of the UserAccount as well as the NSTempalteSet

is paired with: https://github.com/codeready-toolchain/member-operator/pull/292