### PR TITLE
Add test for setting default tier configuration

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -106,7 +106,7 @@ func TestSetDefaultTier(t *testing.T) {
 	// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
 	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
 
-	t.Run(fmt.Sprintf("original default tier"), func(t *testing.T) {
+	t.Run("original default tier", func(t *testing.T) {
 		// Create and approve a new user that should be provisioned to the base tier
 		defaultTierUser, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
 			Username("defaulttier").
@@ -121,7 +121,7 @@ func TestSetDefaultTier(t *testing.T) {
 		VerifyResourcesProvisionedForSignup(t, hostAwait, defaultTierUser, "base", memberAwait)
 	})
 
-	t.Run(fmt.Sprintf("changed default tier configuration"), func(t *testing.T) {
+	t.Run("changed default tier configuration", func(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultTier("advanced"))
 		// Create and approve a new user that should be provisioned to the advanced tier
 		defaultTierUserChanged, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -108,7 +108,7 @@ func TestSetDefaultTier(t *testing.T) {
 
 	t.Run("original default tier", func(t *testing.T) {
 		// Create and approve a new user that should be provisioned to the base tier
-		defaultTierUser, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+		NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
 			Username("defaulttier").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
@@ -116,15 +116,12 @@ func TestSetDefaultTier(t *testing.T) {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().
 			Resources()
-
-		// wait for the user to be provisioned and verify it's provisioned to the base tier
-		VerifyResourcesProvisionedForSignup(t, hostAwait, defaultTierUser, "base", memberAwait)
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultTier("advanced"))
 		// Create and approve a new user that should be provisioned to the advanced tier
-		defaultTierUserChanged, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+		NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
 			Username("defaulttierchanged").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
@@ -132,9 +129,6 @@ func TestSetDefaultTier(t *testing.T) {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().
 			Resources()
-
-		// wait for the user to be provisioned and verify it's provisioned to the advanced tier
-		VerifyResourcesProvisionedForSignup(t, hostAwait, defaultTierUserChanged, "advanced", memberAwait)
 	})
 }
 

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -231,7 +231,11 @@ func (r *signupRequest) Execute() SignupRequest {
 			members = append(members, r.member2Await)
 		}
 
-		VerifyResourcesProvisionedForSignup(r.t, r.hostAwait, userSignup, "base", members...)
+		expectedTier := "base"
+		if r.hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier != nil {
+			expectedTier = *r.hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier
+		}
+		VerifyResourcesProvisionedForSignup(r.t, r.hostAwait, userSignup, expectedTier, members...)
 		mur, err := r.hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 		require.NoError(r.t, err)
 		r.mur = mur


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/503

Tests configuring defaultTier in ToolchainConfig and ensuring the UserSignups are created to the right tier.