### PR TITLE
Confirm notification won't be created when user has no email address

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -101,7 +101,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		s.T().Logf("user signup '%s' set to deactivated", userSignup.Name)
 
 		_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
-			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), DeactivatedNotificationFailed())...))
+			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), UserSignupMissingEmailAnnotation())...))
 		require.NoError(t, err)
 	})
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -100,7 +100,9 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 		s.T().Logf("user signup '%s' set to deactivated", userSignup.Name)
 
-		s.hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), DeactivatedNotificationFailed())...))
+		_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), DeactivatedNotificationFailed())...))
+		require.NoError(t, err)
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -269,6 +269,16 @@ func Deactivated() []toolchainv1alpha1.Condition {
 	}
 }
 
+func DeactivatedNotificationFailed() []toolchainv1alpha1.Condition {
+	return []toolchainv1alpha1.Condition{
+		{
+			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
+			Status: corev1.ConditionFalse,
+			Reason: "Failed to create user deactivation notification",
+		},
+	}
+}
+
 func Running() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,

--- a/testsupport/conditions.go
+++ b/testsupport/conditions.go
@@ -269,12 +269,23 @@ func Deactivated() []toolchainv1alpha1.Condition {
 	}
 }
 
-func DeactivatedNotificationFailed() []toolchainv1alpha1.Condition {
+func UserSignupMissingEmailAnnotation() []toolchainv1alpha1.Condition {
 	return []toolchainv1alpha1.Condition{
+		{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupMissingUserEmailAnnotationReason,
+			Message: "missing annotation at usersignup",
+		},
 		{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
 			Status: corev1.ConditionFalse,
-			Reason: "Failed to create user deactivation notification",
+			Reason: toolchainv1alpha1.UserSignupDeactivatedNotificationUserIsActiveReason,
+		},
+		{
+			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
+			Status: corev1.ConditionFalse,
+			Reason: toolchainv1alpha1.UserSignupDeactivatingNotificationUserNotInPreDeactivationReason,
 		},
 	}
 }


### PR DESCRIPTION
Tests for https://github.com/codeready-toolchain/host-operator/pull/504

Fixes https://issues.redhat.com/browse/CRT-1219