### PR TITLE
test: add label on OLM namespace

### DIFF
--- a/make/resources/default-network-policies.yaml
+++ b/make/resources/default-network-policies.yaml
@@ -1,0 +1,66 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: default-network-policies
+objects:
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      provider: sandbox-sre
+    name: allow-from-same-namespace
+    namespace: ${NAMESPACE}
+  spec:
+    ingress:
+    - from:
+      - podSelector: {}
+    podSelector: null
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      provider: sandbox-sre
+    name: allow-from-ingress-namespace
+    namespace: ${NAMESPACE}
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: null
+- kind: NetworkPolicy
+  apiVersion: networking.k8s.io/v1
+  metadata:
+    labels:
+      provider: sandbox-sre
+    name: allow-from-openshift-customer-monitoring-namespace
+    namespace: ${NAMESPACE}
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: openshift-customer-monitoring
+    policyTypes:
+    - Ingress
+- kind: NetworkPolicy
+  apiVersion: networking.k8s.io/v1
+  metadata:
+    labels:
+      provider: sandbox-sre
+    name: allow-from-openshift-operator-lifecycle-manager-namespace
+    namespace: ${NAMESPACE}
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            name: openshift-operator-lifecycle-manager
+    policyTypes:
+    - Ingress
+parameters:
+- name: NAMESPACE
+  required: true

--- a/make/resources/default-network-policies.yaml
+++ b/make/resources/default-network-policies.yaml
@@ -3,64 +3,16 @@ kind: Template
 metadata:
   name: default-network-policies
 objects:
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    labels:
-      provider: sandbox-sre
-    name: allow-from-same-namespace
-    namespace: ${NAMESPACE}
-  spec:
-    ingress:
-    - from:
-      - podSelector: {}
-    podSelector: null
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    labels:
-      provider: sandbox-sre
-    name: allow-from-ingress-namespace
-    namespace: ${NAMESPACE}
-  spec:
-    ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            network.openshift.io/policy-group: ingress
-    podSelector: null
-- kind: NetworkPolicy
   apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
   metadata:
-    labels:
-      provider: sandbox-sre
-    name: allow-from-openshift-customer-monitoring-namespace
     namespace: ${NAMESPACE}
+    name: allow-all-ingress
   spec:
     podSelector: {}
     ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            name: openshift-customer-monitoring
-    policyTypes:
-    - Ingress
-- kind: NetworkPolicy
-  apiVersion: networking.k8s.io/v1
-  metadata:
-    labels:
-      provider: sandbox-sre
-    name: allow-from-openshift-operator-lifecycle-manager-namespace
-    namespace: ${NAMESPACE}
-  spec:
-    podSelector: {}
-    ingress:
-    - from:
-      - namespaceSelector:
-          matchLabels:
-            name: openshift-operator-lifecycle-manager
+    - {}
     policyTypes:
     - Ingress
 parameters:
 - name: NAMESPACE
-  required: true

--- a/make/test.mk
+++ b/make/test.mk
@@ -37,7 +37,7 @@ test-e2e: deploy-e2e e2e-run
 deploy-e2e: INSTALL_OPERATOR=true
 deploy-e2e: build clean-e2e-files label-olm-ns deploy-host deploy-members e2e-service-account setup-toolchainclusters
 
-label-olm-ns:
+label-olm-ns: create-host-project create-member1 create-member2
 # adds a label on the oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
 # so that deployment also works when network policies were configured with `sandbox-cli`
 	@-oc label --overwrite=true ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager

--- a/make/test.mk
+++ b/make/test.mk
@@ -37,17 +37,11 @@ test-e2e: deploy-e2e e2e-run
 deploy-e2e: INSTALL_OPERATOR=true
 deploy-e2e: build clean-e2e-files label-olm-ns deploy-host deploy-members e2e-service-account setup-toolchainclusters
 
-label-olm-ns: create-host-project create-member1 create-member2
+label-olm-ns:
 # adds a label on the oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
 # so that deployment also works when network policies were configured with `sandbox-cli`
 	@-oc label --overwrite=true ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
-	@echo "adding network policies in $(HOST_NS) namespace"
-	@-oc process -p NAMESPACE=$(HOST_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
-	@echo "adding network policies in $(MEMBER_NS) namespace"
-	@-oc process -p NAMESPACE=$(MEMBER_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
-	@echo "adding network policies in $(MEMBER_NS_2) namespace"
-	@-oc process -p NAMESPACE=$(MEMBER_NS_2) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
-
+	
 .PHONY: test-e2e-local
 ## Run the e2e tests with the local 'host', 'member', and 'registration-service' repositories
 test-e2e-local:
@@ -223,9 +217,12 @@ endif
 
 .PHONY: create-project
 create-project:
-	-oc new-project ${PROJECT_NAME} 1>/dev/null
-	-oc project ${PROJECT_NAME}
-	-oc label ns --overwrite=true ${PROJECT_NAME} toolchain.dev.openshift.com/provider=codeready-toolchain
+	@-oc new-project ${PROJECT_NAME} 1>/dev/null
+	@-oc project ${PROJECT_NAME}
+	@-oc label ns --overwrite=true ${PROJECT_NAME} toolchain.dev.openshift.com/provider=codeready-toolchain
+	@echo "adding network policies in $(HOST_NS) namespace"
+	@-oc process -p NAMESPACE=$(HOST_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
+	
 
 .PHONY: display-eval
 display-eval:

--- a/make/test.mk
+++ b/make/test.mk
@@ -40,8 +40,14 @@ deploy-e2e: build clean-e2e-files label-olm-ns deploy-host deploy-members e2e-se
 label-olm-ns:
 # adds a label on the oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
 # so that deployment also works when network policies were configured with `sandbox-cli`
-	@-oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
-	
+	@-oc label --overwrite=true ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
+	@echo "adding network policies in $(HOST_NS) namespace"
+	@-oc process -p NAMESPACE=$(HOST_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
+	@echo "adding network policies in $(MEMBER_NS) namespace"
+	@-oc process -p NAMESPACE=$(MEMBER_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
+	@echo "adding network policies in $(MEMBER_NS_2) namespace"
+	@-oc process -p NAMESPACE=$(MEMBER_NS_2) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
+
 .PHONY: test-e2e-local
 ## Run the e2e tests with the local 'host', 'member', and 'registration-service' repositories
 test-e2e-local:

--- a/make/test.mk
+++ b/make/test.mk
@@ -183,14 +183,14 @@ deploy-members: create-member1 create-member2 get-and-publish-member-operator
 create-member1:
 	@echo "Deploying member operator to $(MEMBER_NS)..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS}
-	-oc label ns ${MEMBER_NS} app=member-operator
+	-oc label ns --overwrite=true ${MEMBER_NS} app=member-operator
 
 .PHONY: create-member2
 create-member2:
 ifeq ($(SECOND_MEMBER_MODE),true)
 	@echo "Deploying second member operator to ${MEMBER_NS_2}..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS_2}
-	-oc label ns ${MEMBER_NS_2} app=member-operator
+	-oc label ns --overwrite=true ${MEMBER_NS_2} app=member-operator
 endif
 
 .PHONY: deploy-host
@@ -200,7 +200,7 @@ deploy-host: create-host-project get-and-publish-host-operator create-host-resou
 create-host-project:
 	@echo "Deploying host operator to ${HOST_NS}..."
 	$(MAKE) create-project PROJECT_NAME=${HOST_NS}
-	-oc label ns ${HOST_NS} app=host-operator
+	-oc label ns --overwrite=true ${HOST_NS} app=host-operator
 
 .PHONY: create-host-resources
 create-host-resources:
@@ -225,7 +225,7 @@ endif
 create-project:
 	-oc new-project ${PROJECT_NAME} 1>/dev/null
 	-oc project ${PROJECT_NAME}
-	-oc label ns ${PROJECT_NAME} toolchain.dev.openshift.com/provider=codeready-toolchain
+	-oc label ns --overwrite=true ${PROJECT_NAME} toolchain.dev.openshift.com/provider=codeready-toolchain
 
 .PHONY: display-eval
 display-eval:

--- a/make/test.mk
+++ b/make/test.mk
@@ -220,8 +220,8 @@ create-project:
 	@-oc new-project ${PROJECT_NAME} 1>/dev/null
 	@-oc project ${PROJECT_NAME}
 	@-oc label ns --overwrite=true ${PROJECT_NAME} toolchain.dev.openshift.com/provider=codeready-toolchain
-	@echo "adding network policies in $(HOST_NS) namespace"
-	@-oc process -p NAMESPACE=$(HOST_NS) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
+	@echo "adding network policies in $(PROJECT_NAME) namespace"
+	@-oc process -p NAMESPACE=$(PROJECT_NAME) -f ${PWD}/make/resources/default-network-policies.yaml | oc apply -f -
 	
 
 .PHONY: display-eval

--- a/make/test.mk
+++ b/make/test.mk
@@ -35,8 +35,13 @@ test-e2e: deploy-e2e e2e-run
 
 .PHONY: deploy-e2e
 deploy-e2e: INSTALL_OPERATOR=true
-deploy-e2e: build clean-e2e-files deploy-host deploy-members e2e-service-account setup-toolchainclusters
+deploy-e2e: build clean-e2e-files label-olm-ns deploy-host deploy-members e2e-service-account setup-toolchainclusters
 
+label-olm-ns:
+# adds a label on the oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
+# so that deployment also works when network policies were configured with `sandbox-cli`
+	@-oc label ns/openshift-operator-lifecycle-manager name=openshift-operator-lifecycle-manager
+	
 .PHONY: test-e2e-local
 ## Run the e2e tests with the local 'host', 'member', and 'registration-service' repositories
 test-e2e-local:


### PR DESCRIPTION
this is only needed if the cluster in use was configured
with the `sandbox-cli setup` command. In this case, the
`name=openshift-openshift-operator-lifecycle-manager` label
is needed to successfully deploy the operators.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
