### PR TITLE
Fix malformed yaml template for network policies

### DIFF
--- a/make/resources/default-network-policies.yaml
+++ b/make/resources/default-network-policies.yaml
@@ -3,16 +3,16 @@ kind: Template
 metadata:
   name: default-network-policies
 objects:
-  apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    namespace: ${NAMESPACE}
-    name: allow-all-ingress
-  spec:
-    podSelector: {}
-    ingress:
-    - {}
-    policyTypes:
-    - Ingress
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      namespace: ${NAMESPACE}
+      name: allow-all-ingress
+    spec:
+      podSelector: {}
+      ingress:
+      - {}
+      policyTypes:
+      - Ingress
 parameters:
 - name: NAMESPACE


### PR DESCRIPTION
While using `make dev-deploy-e2e`, I noticed the error message
```
Already on project "toolchain-host-operator" on server "https://api.dwo-2021-09-24.devcluster.openshift.com:6443".
namespace/toolchain-host-operator labeled
adding network policies in toolchain-host-operator namespace
error: failed to read input object (not a Template?): unable to decode "/home/amisevsk/git/toolchain-e2e/make/resources/default-network-policies.yaml": v1.Template.Objects: []runtime.RawExtension: decode slice: expect [ or n, but found {, error found in #10 byte of ...|objects":{"apiVersio|..., bigger context ...|a":{"name":"default-network-policies"},"objects":{"apiVersion":"networking.k8s.io/v1","kind":"Networ|...
error: no objects passed to apply
make[2]: [make/test.mk:224: create-project] Error 1 (ignored)
make[2]: Leaving directory '/home/amisevsk/git/toolchain-e2e'
```

This PR fixes the malformed yaml (`objects` is a list, not an object)