### PR TITLE
Reduce risk of flakiness when dealing with member clusters

### DIFF
--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -19,15 +19,15 @@ import (
 
 type baseUserIntegrationTest struct {
 	suite.Suite
-	awaitilities wait.Awaitilities
+	wait.Awaitilities
 }
 
 func (s *baseUserIntegrationTest) newSignupRequest() SignupRequest {
-	return NewSignupRequest(s.T(), s.awaitilities)
+	return NewSignupRequest(s.T(), s.Awaitilities)
 }
 
 func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *toolchainv1alpha1.BannedUser {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	// Create the BannedUser
 	bannedUser := newBannedUser(hostAwait, email)
 	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
@@ -53,7 +53,7 @@ func newBannedUser(host *wait.HostAwaitility, email string) *toolchainv1alpha1.B
 }
 
 func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	userSignup, err := hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 		states.SetDeactivated(us, true)
 	})
@@ -87,7 +87,7 @@ func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *toolchainv1
 }
 
 func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{
 		Namespace: userSignup.Namespace,
 		Name:      userSignup.Name,

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -27,7 +27,7 @@ func (s *baseUserIntegrationTest) newSignupRequest() SignupRequest {
 }
 
 func (s *baseUserIntegrationTest) createAndCheckBannedUser(email string) *toolchainv1alpha1.BannedUser {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	// Create the BannedUser
 	bannedUser := newBannedUser(hostAwait, email)
 	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
@@ -53,7 +53,7 @@ func newBannedUser(host *wait.HostAwaitility, email string) *toolchainv1alpha1.B
 }
 
 func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	userSignup, err := hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 		states.SetDeactivated(us, true)
 	})
@@ -87,7 +87,7 @@ func (s *baseUserIntegrationTest) deactivateAndCheckUser(userSignup *toolchainv1
 }
 
 func (s *baseUserIntegrationTest) reactivateAndCheckUser(userSignup *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{
 		Namespace: userSignup.Namespace,
 		Name:      userSignup.Name,

--- a/test/e2e/base_user_test.go
+++ b/test/e2e/base_user_test.go
@@ -19,7 +19,7 @@ import (
 
 type baseUserIntegrationTest struct {
 	suite.Suite
-	awaitilities Awaitilities
+	awaitilities wait.Awaitilities
 }
 
 func (s *baseUserIntegrationTest) newSignupRequest() SignupRequest {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,9 +24,9 @@ func TestE2EFlow(t *testing.T) {
 	// given
 	// full flow from usersignup with approval down to namespaces creation
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
-	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
+	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
 
 	consoleURL := memberAwait.GetConsoleURL()
 	// host and member cluster statuses should be available at this point
@@ -89,7 +89,7 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
-	signups := CreateMultipleSignups(t, awaitilities, awaitilities.Member(t), 5)
+	signups := CreateMultipleSignups(t, awaitilities, awaitilities.Member(), 5)
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,7 +23,10 @@ import (
 func TestE2EFlow(t *testing.T) {
 	// given
 	// full flow from usersignup with approval down to namespaces creation
-	hostAwait, memberAwait, memberAwait2 := WaitForDeployments(t)
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host(t)
+	memberAwait := awaitilities.Member(t)
+	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
 
 	consoleURL := memberAwait.GetConsoleURL()
 	// host and member cluster statuses should be available at this point
@@ -86,11 +89,11 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
-	signups := CreateMultipleSignups(t, hostAwait, memberAwait, 5)
+	signups := CreateMultipleSignups(t, awaitilities, awaitilities.Member(t), 5)
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+	johnSignup, _ := NewSignupRequest(t, awaitilities).
 		Username(johnsmithName).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
@@ -99,7 +102,7 @@ func TestE2EFlow(t *testing.T) {
 		Execute().Resources()
 
 	extrajohnName := "extrajohn"
-	johnExtraSignup, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+	johnExtraSignup, _ := NewSignupRequest(t, awaitilities).
 		Username(extrajohnName).
 		ManuallyApprove().
 		EnsureMUR().
@@ -108,7 +111,7 @@ func TestE2EFlow(t *testing.T) {
 		Execute().Resources()
 
 	targetedJohnName := "targetedjohn"
-	targetedJohnSignup, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+	targetedJohnSignup, _ := NewSignupRequest(t, awaitilities).
 		Username(targetedJohnName).
 		ManuallyApprove().
 		EnsureMUR().
@@ -116,9 +119,9 @@ func TestE2EFlow(t *testing.T) {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().Resources()
 
-	VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-	VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
-	VerifyResourcesProvisionedForSignup(t, hostAwait, targetedJohnSignup, "base", memberAwait2)
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "base")
 
 	johnsmithMur, err := hostAwait.GetMasterUserRecord(wait.WithMurName(johnsmithName))
 	require.NoError(t, err)
@@ -139,8 +142,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
@@ -154,8 +157,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -170,8 +173,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
@@ -186,8 +189,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
@@ -211,8 +214,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := memberAwait.WaitForNamespace(johnSignup.Spec.Username, ref)
 				require.NoError(t, err)
 			}
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 		})
 
 		t.Run("delete useraccount and expect recreation", func(t *testing.T) {
@@ -231,13 +234,13 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, hostAwait, johnSignup, "base", memberAwait)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
 		})
 	})
 
 	t.Run("multiple MasterUserRecord resources provisioned", func(t *testing.T) {
 		// Now when the main flow has been tested we can verify the signups we created in the very beginning
-		VerifyMultipleSignups(t, hostAwait, signups, memberAwait)
+		VerifyMultipleSignups(t, awaitilities, signups)
 
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(
@@ -248,7 +251,7 @@ func TestE2EFlow(t *testing.T) {
 	})
 
 	t.Run("verify userAccount is not deleted if namespace is not deleted", func(t *testing.T) {
-		laraSignUp, _ := NewSignupRequest(t, hostAwait, memberAwait, memberAwait2).
+		laraSignUp, _ := NewSignupRequest(t, awaitilities).
 			Username("laracroft").
 			Email("laracroft@redhat.com").
 			ManuallyApprove().
@@ -381,7 +384,7 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		VerifyResourcesProvisionedForSignup(t, hostAwait, johnExtraSignup, "base", memberAwait)
+		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
 
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,8 +25,8 @@ func TestE2EFlow(t *testing.T) {
 	// full flow from usersignup with approval down to namespaces creation
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
-	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
 
 	consoleURL := memberAwait.GetConsoleURL()
 	// host and member cluster statuses should be available at this point
@@ -89,7 +89,7 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create multiple accounts and let them get provisioned while we are executing the main flow for "johnsmith" and "extrajohn"
 	// We will verify them in the end of the test
-	signups := CreateMultipleSignups(t, awaitilities, awaitilities.Member(), 5)
+	signups := CreateMultipleSignups(t, awaitilities, awaitilities.Member1(), 5)
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -32,14 +32,14 @@ const (
 func TestNSTemplateTiers(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
+	hostAwait := awaitilities.Host()
 
 	// Create and approve "testingtiers" signups
 	testingTiersName := "testingtiers"
 	testingtiers, _ := NewSignupRequest(t, awaitilities).
 		Username(testingTiersName).
 		ManuallyApprove().
-		TargetCluster(awaitilities.Member(t)).
+		TargetCluster(awaitilities.Member()).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().
@@ -102,8 +102,8 @@ func TestNSTemplateTiers(t *testing.T) {
 func TestSetDefaultTier(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 
 	// check that the tier exists, and all its namespace other cluster-scoped resource revisions
 	// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
@@ -143,8 +143,8 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	count := 2*MaxPoolSize + 1
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 
 	// first group of users: the "cheesecake lovers"
 	cheesecakeSyncIndexes := setupAccounts(t, awaitilities, "cheesecake", "cheesecakelover%02d", memberAwait, count)
@@ -189,7 +189,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 // returns the tier, users and their "syncIndexes"
 func setupAccounts(t *testing.T, awaitilities Awaitilities, tierName, nameFmt string, targetCluster *MemberAwaitility, count int) map[string]string {
 	// first, let's create the a new NSTemplateTier (to avoid messing with other tiers)
-	hostAwait := awaitilities.Host(t)
+	hostAwait := awaitilities.Host()
 	tier := CreateNSTemplateTier(t, hostAwait, tierName)
 
 	// let's create a few users (more than `maxPoolSize`)
@@ -313,7 +313,7 @@ func verifyResourceUpdates(t *testing.T, hostAwait *HostAwaitility, memberAwaiti
 func TestTierTemplates(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
+	hostAwait := awaitilities.Host()
 	// when the tiers are created during the startup then we can verify them
 	allTiers := &toolchainv1alpha1.TierTemplateList{}
 	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -39,7 +39,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	testingtiers, _ := NewSignupRequest(t, awaitilities).
 		Username(testingTiersName).
 		ManuallyApprove().
-		TargetCluster(awaitilities.Member()).
+		TargetCluster(awaitilities.Member1()).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().
@@ -103,7 +103,7 @@ func TestSetDefaultTier(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 
 	// check that the tier exists, and all its namespace other cluster-scoped resource revisions
 	// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
@@ -144,7 +144,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	count := 2*MaxPoolSize + 1
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 
 	// first group of users: the "cheesecake lovers"
 	cheesecakeSyncIndexes := setupAccounts(t, awaitilities, "cheesecake", "cheesecakelover%02d", memberAwait, count)

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -37,14 +37,14 @@ func TestRegistrationService(t *testing.T) {
 
 type registrationServiceTestSuite struct {
 	suite.Suite
-	namespace    string
-	route        string
-	awaitilities wait.Awaitilities
+	wait.Awaitilities
+	namespace string
+	route     string
 }
 
 func (s *registrationServiceTestSuite) SetupSuite() {
-	s.awaitilities = WaitForDeployments(s.T())
-	hostAwait := s.awaitilities.Host()
+	s.Awaitilities = WaitForDeployments(s.T())
+	hostAwait := s.Host()
 	s.namespace = hostAwait.RegistrationServiceNs
 	s.route = hostAwait.RegistrationServiceURL
 }
@@ -281,7 +281,7 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 		require.Equal(s.T(), "error creating UserSignup resource", response["details"])
 		require.Equal(s.T(), float64(403), response["code"])
 
-		hostAwait := s.awaitilities.Host()
+		hostAwait := s.Host()
 		userSignup, err := hostAwait.WaitForUserSignup(identity.ID.String())
 		require.Nil(s.T(), userSignup)
 		require.Error(s.T(), err)
@@ -291,8 +291,8 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 
 func (s *registrationServiceTestSuite) TestSignupOK() {
 
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
 		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
@@ -321,7 +321,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		require.NoError(s.T(), err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		s.assertGetSignupStatusProvisioned(identity.Username, token)
@@ -391,7 +391,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 }
 
 func (s *registrationServiceTestSuite) TestPhoneVerification() {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	// Create a token and identity to sign up with
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.Must(uuid.NewV4()).String() + "@some.domain"
@@ -565,8 +565,8 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
 	assert.Equal(s.T(), username, mp["compliantUsername"])
 	assert.Equal(s.T(), username, mp["username"])

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -44,7 +44,7 @@ type registrationServiceTestSuite struct {
 
 func (s *registrationServiceTestSuite) SetupSuite() {
 	s.awaitilities = WaitForDeployments(s.T())
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	s.namespace = hostAwait.RegistrationServiceNs
 	s.route = hostAwait.RegistrationServiceURL
 }
@@ -281,7 +281,7 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 		require.Equal(s.T(), "error creating UserSignup resource", response["details"])
 		require.Equal(s.T(), float64(403), response["code"])
 
-		hostAwait := s.awaitilities.Host(s.T())
+		hostAwait := s.awaitilities.Host()
 		userSignup, err := hostAwait.WaitForUserSignup(identity.ID.String())
 		require.Nil(s.T(), userSignup)
 		require.Error(s.T(), err)
@@ -291,8 +291,8 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 
 func (s *registrationServiceTestSuite) TestSignupOK() {
 
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
 		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
@@ -391,7 +391,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 }
 
 func (s *registrationServiceTestSuite) TestPhoneVerification() {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	// Create a token and identity to sign up with
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.Must(uuid.NewV4()).String() + "@some.domain"
@@ -565,8 +565,8 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
 	assert.Equal(s.T(), username, mp["compliantUsername"])
 	assert.Equal(s.T(), username, mp["username"])

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -39,7 +39,7 @@ type registrationServiceTestSuite struct {
 	suite.Suite
 	namespace    string
 	route        string
-	awaitilities Awaitilities
+	awaitilities wait.Awaitilities
 }
 
 func (s *registrationServiceTestSuite) SetupSuite() {

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -292,7 +292,7 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 func (s *registrationServiceTestSuite) TestSignupOK() {
 
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
 		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
@@ -566,7 +566,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
 	assert.Equal(s.T(), username, mp["compliantUsername"])
 	assert.Equal(s.T(), username, mp["username"])

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -37,16 +37,16 @@ func TestRegistrationService(t *testing.T) {
 
 type registrationServiceTestSuite struct {
 	suite.Suite
-	namespace   string
-	route       string
-	hostAwait   *wait.HostAwaitility
-	memberAwait *wait.MemberAwaitility
+	namespace    string
+	route        string
+	awaitilities Awaitilities
 }
 
 func (s *registrationServiceTestSuite) SetupSuite() {
-	s.hostAwait, s.memberAwait, _ = WaitForDeployments(s.T())
-	s.namespace = s.hostAwait.RegistrationServiceNs
-	s.route = s.hostAwait.RegistrationServiceURL
+	s.awaitilities = WaitForDeployments(s.T())
+	hostAwait := s.awaitilities.Host(s.T())
+	s.namespace = hostAwait.RegistrationServiceNs
+	s.route = hostAwait.RegistrationServiceURL
 }
 
 func (s *registrationServiceTestSuite) TestLandingPageReachable() {
@@ -281,7 +281,8 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 		require.Equal(s.T(), "error creating UserSignup resource", response["details"])
 		require.Equal(s.T(), float64(403), response["code"])
 
-		userSignup, err := s.hostAwait.WaitForUserSignup(identity.ID.String())
+		hostAwait := s.awaitilities.Host(s.T())
+		userSignup, err := hostAwait.WaitForUserSignup(identity.ID.String())
 		require.Nil(s.T(), userSignup)
 		require.Error(s.T(), err)
 		require.EqualError(s.T(), err, "timed out waiting for the condition")
@@ -290,12 +291,14 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 
 func (s *registrationServiceTestSuite) TestSignupOK() {
 
+	hostAwait := s.awaitilities.Host(s.T())
+	memberAwait := s.awaitilities.Member(s.T())
 	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
 		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
 
 		// Wait for the UserSignup to be created
-		userSignup, err := s.hostAwait.WaitForUserSignup(userSignupName,
+		userSignup, err := hostAwait.WaitForUserSignup(userSignupName,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), PendingApproval())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
 		require.NoError(s.T(), err)
@@ -313,12 +316,12 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 
 		// Approve usersignup.
 		states.SetApproved(userSignup, true)
-		userSignup.Spec.TargetCluster = s.memberAwait.ClusterName
-		err = s.hostAwait.Client.Update(context.TODO(), userSignup)
+		userSignup.Spec.TargetCluster = memberAwait.ClusterName
+		err = hostAwait.Client.Update(context.TODO(), userSignup)
 		require.NoError(s.T(), err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.hostAwait, userSignup, "base", s.memberAwait)
+		VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		s.assertGetSignupStatusProvisioned(identity.Username, token)
@@ -339,11 +342,11 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		userSignup := signupUser(t, emailValue, identity.ID.String(), identity)
 
 		// Deactivate the usersignup
-		userSignup, err = s.hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		userSignup, err = hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
 		require.NoError(s.T(), err)
-		_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+		_, err = hostAwait.WaitForUserSignup(userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), DeactivatedWithoutPreDeactivation())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
 		require.NoError(s.T(), err)
@@ -388,6 +391,7 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 }
 
 func (s *registrationServiceTestSuite) TestPhoneVerification() {
+	hostAwait := s.awaitilities.Host(s.T())
 	// Create a token and identity to sign up with
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.Must(uuid.NewV4()).String() + "@some.domain"
@@ -399,7 +403,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token0, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
-	userSignup, err := s.hostAwait.WaitForUserSignup(identity0.ID.String(),
+	userSignup, err := hostAwait.WaitForUserSignup(identity0.ID.String(),
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
@@ -416,14 +420,14 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.True(s.T(), mpStatus["verificationRequired"].(bool))
 
 	// Confirm the status of the UserSignup is correct
-	_, err = s.hostAwait.WaitForUserSignup(identity0.ID.String(),
+	_, err = hostAwait.WaitForUserSignup(identity0.ID.String(),
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
 
 	// Confirm that a MUR hasn't been created
 	obj := &toolchainv1alpha1.MasterUserRecord{}
-	err = s.hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: s.hostAwait.Namespace, Name: identity0.Username}, obj)
+	err = hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: hostAwait.Namespace, Name: identity0.Username}, obj)
 	require.Error(s.T(), err)
 	require.True(s.T(), errors.IsNotFound(err))
 
@@ -432,7 +436,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup
-	userSignup, err = s.hostAwait.WaitForUserSignup(identity0.ID.String())
+	userSignup, err = hostAwait.WaitForUserSignup(identity0.ID.String())
 	require.NoError(s.T(), err)
 
 	// Confirm there is a verification code annotation value, and store it in a variable
@@ -446,7 +450,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
 
 	// Retrieve the updated UserSignup
-	userSignup, err = s.hostAwait.WaitForUserSignup(identity0.ID.String())
+	userSignup, err = hostAwait.WaitForUserSignup(identity0.ID.String())
 	require.NoError(s.T(), err)
 
 	// Check attempts has been incremented
@@ -460,7 +464,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]), token0, "", http.StatusOK)
 
 	// Retrieve the updated UserSignup
-	userSignup, err = s.hostAwait.WaitForUserSignup(identity0.ID.String(),
+	userSignup, err = hostAwait.WaitForUserSignup(identity0.ID.String(),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
 	require.NoError(s.T(), err)
 
@@ -484,11 +488,11 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	// Now approve the usersignup.
 	states.SetApproved(userSignup, true)
 
-	err = s.hostAwait.Client.Update(context.TODO(), userSignup)
+	err = hostAwait.Client.Update(context.TODO(), userSignup)
 	require.NoError(s.T(), err)
 
 	// Confirm the MasterUserRecord is provisioned
-	_, err = s.hostAwait.WaitForMasterUserRecord(identity0.Username, wait.UntilMasterUserRecordHasCondition(Provisioned()))
+	_, err = hostAwait.WaitForMasterUserRecord(identity0.Username, wait.UntilMasterUserRecordHasCondition(Provisioned()))
 	require.NoError(s.T(), err)
 
 	// Retrieve the UserSignup from the GET endpoint
@@ -508,7 +512,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", otherToken, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
-	otherUserSignup, err := s.hostAwait.WaitForUserSignup(otherIdentity.ID.String(),
+	otherUserSignup, err := hostAwait.WaitForUserSignup(otherIdentity.ID.String(),
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
 	require.NoError(s.T(), err)
@@ -527,24 +531,24 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 	require.Equal(s.T(), "phone number already in use", responseMap["details"])
 
 	// Retrieve the updated UserSignup
-	otherUserSignup, err = s.hostAwait.WaitForUserSignup(otherIdentity.ID.String())
+	otherUserSignup, err = hostAwait.WaitForUserSignup(otherIdentity.ID.String())
 	require.NoError(s.T(), err)
 
 	// Confirm there is no verification code annotation value
 	require.Empty(s.T(), otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Retrieve the current UserSignup
-	userSignup, err = s.hostAwait.WaitForUserSignup(userSignup.Name)
+	userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name)
 	require.NoError(s.T(), err)
 
 	// Now mark the original UserSignup as deactivated
 	states.SetDeactivated(userSignup, true)
 
-	err = s.hostAwait.Client.Update(context.TODO(), userSignup)
+	err = hostAwait.Client.Update(context.TODO(), userSignup)
 	require.NoError(s.T(), err)
 
 	// Ensure the UserSignup is deactivated
-	_, err = s.hostAwait.WaitForUserSignup(userSignup.Name,
+	_, err = hostAwait.WaitForUserSignup(userSignup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), ManuallyDeactivated())...))
 	require.NoError(s.T(), err)
 
@@ -553,7 +557,7 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup again
-	otherUserSignup, err = s.hostAwait.WaitForUserSignup(otherIdentity.ID.String())
+	otherUserSignup, err = hostAwait.WaitForUserSignup(otherIdentity.ID.String())
 	require.NoError(s.T(), err)
 
 	// Confirm there is now a verification code annotation value
@@ -561,14 +565,16 @@ func (s *registrationServiceTestSuite) TestPhoneVerification() {
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {
+	hostAwait := s.awaitilities.Host(s.T())
+	memberAwait := s.awaitilities.Member(s.T())
 	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
 	assert.Equal(s.T(), username, mp["compliantUsername"])
 	assert.Equal(s.T(), username, mp["username"])
 	require.IsType(s.T(), false, mpStatus["ready"])
 	assert.True(s.T(), mpStatus["ready"].(bool))
 	assert.Equal(s.T(), "Provisioned", mpStatus["reason"])
-	assert.Equal(s.T(), s.memberAwait.GetConsoleURL(), mp["consoleURL"])
-	memberCluster, found, err := s.hostAwait.GetToolchainCluster(cluster.Member, s.memberAwait.Namespace, nil)
+	assert.Equal(s.T(), memberAwait.GetConsoleURL(), mp["consoleURL"])
+	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(s.T(), err)
 	require.True(s.T(), found)
 	assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestToolchainClusterE2E(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 
 	verifyToolchainCluster(t, hostAwait.Awaitility, memberAwait.Awaitility)
 	verifyToolchainCluster(t, memberAwait.Awaitility, hostAwait.Awaitility)

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -18,7 +18,7 @@ import (
 func TestToolchainClusterE2E(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 
 	verifyToolchainCluster(t, hostAwait.Awaitility, memberAwait.Awaitility)
 	verifyToolchainCluster(t, memberAwait.Awaitility, hostAwait.Awaitility)

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func TestToolchainClusterE2E(t *testing.T) {
-	hostAwait, memberAwait, _ := WaitForDeployments(t)
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host(t)
+	memberAwait := awaitilities.Member(t)
 
 	verifyToolchainCluster(t, hostAwait.Awaitility, memberAwait.Awaitility)
 	verifyToolchainCluster(t, memberAwait.Awaitility, hostAwait.Awaitility)

--- a/test/e2e/toolchainstatus_test.go
+++ b/test/e2e/toolchainstatus_test.go
@@ -18,9 +18,9 @@ func TestForceMetricsSynchronization(t *testing.T) {
 
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
-	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
+	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))

--- a/test/e2e/toolchainstatus_test.go
+++ b/test/e2e/toolchainstatus_test.go
@@ -19,8 +19,8 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
-	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))

--- a/test/e2e/toolchainstatus_test.go
+++ b/test/e2e/toolchainstatus_test.go
@@ -17,12 +17,15 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	t.Skip("skipping this test due to flakyness")
 
 	// given
-	hostAwait, memberAwait, member2Await := WaitForDeployments(t)
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host(t)
+	memberAwait := awaitilities.Member(t)
+	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))
 
-	userSignups := CreateMultipleSignups(t, hostAwait, memberAwait, 2)
+	userSignups := CreateMultipleSignups(t, awaitilities, memberAwait, 2)
 
 	// delete the current toolchainstatus/toolchain-status resource and restart the host-operator pod,
 	// so we can start with accurate counters/metrics and not get flaky because of previous tests,
@@ -34,7 +37,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	err = hostAwait.DeletePods(client.InNamespace(hostAwait.Namespace), client.MatchingLabels{"name": "controller-manager"})
 	require.NoError(t, err)
 
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, member2Await.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
 
 	t.Run("tampering activation-counter annotations", func(t *testing.T) {
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -42,8 +42,8 @@ func (s *userManagementTestSuite) SetupSuite() {
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
-	memberAwait2 := s.Member(s.SecondMember)
+	memberAwait := s.Member1()
+	memberAwait2 := s.Member2()
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(false),
 		testconfig.Deactivation().DeactivatingNotificationDays(-1))
@@ -369,7 +369,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
 		hostAwait := s.Host()
-		memberAwait := s.Member()
+		memberAwait := s.Member1()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
@@ -401,7 +401,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 	s.T().Run("manually created usersignup with preexisting banneduser", func(t *testing.T) {
 		hostAwait := s.Host()
-		memberAwait := s.Member()
+		memberAwait := s.Member1()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
@@ -472,7 +472,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
 		hostAwait := s.Host()
-		memberAwait := s.Member()
+		memberAwait := s.Member1()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
@@ -526,7 +526,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 func (s *userManagementTestSuite) TestUserDisabled() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -37,13 +37,13 @@ type userManagementTestSuite struct {
 }
 
 func (s *userManagementTestSuite) SetupSuite() {
-	s.awaitilities = WaitForDeployments(s.T())
+	s.Awaitilities = WaitForDeployments(s.T())
 }
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
-	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
+	hostAwait := s.Host()
+	memberAwait := s.Member()
+	memberAwait2 := s.Member(s.SecondMember)
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(false),
 		testconfig.Deactivation().DeactivatingNotificationDays(-1))
@@ -249,7 +249,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 
 		// Verify resources have been provisioned
-		VerifyResourcesProvisionedForSignup(t, s.awaitilities, userSignupMember1, "base")
+		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base")
 	})
 
 	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
@@ -300,7 +300,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
-			VerifyResourcesProvisionedForSignup(t, s.awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base")
 
 			s.T().Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
@@ -368,8 +368,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 func (s *userManagementTestSuite) TestUserBanning() {
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host()
-		memberAwait := s.awaitilities.Member()
+		hostAwait := s.Host()
+		memberAwait := s.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
@@ -400,8 +400,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("manually created usersignup with preexisting banneduser", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host()
-		memberAwait := s.awaitilities.Member()
+		hostAwait := s.Host()
+		memberAwait := s.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
@@ -432,7 +432,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("register new user with preexisting ban", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host()
+		hostAwait := s.Host()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
@@ -471,8 +471,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host()
-		memberAwait := s.awaitilities.Member()
+		hostAwait := s.Host()
+		memberAwait := s.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
@@ -525,8 +525,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 }
 
 func (s *userManagementTestSuite) TestUserDisabled() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup
@@ -538,7 +538,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().Resources()
 
-	VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 
 	// Disable MUR
 	mur, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
@@ -578,6 +578,6 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 	})
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -41,9 +41,9 @@ func (s *userManagementTestSuite) SetupSuite() {
 }
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
-	memberAwait2 := s.awaitilities.Member(s.T(), s.awaitilities.SecondMember)
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
+	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(false),
 		testconfig.Deactivation().DeactivatingNotificationDays(-1))
@@ -368,8 +368,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 func (s *userManagementTestSuite) TestUserBanning() {
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host(s.T())
-		memberAwait := s.awaitilities.Member(s.T())
+		hostAwait := s.awaitilities.Host()
+		memberAwait := s.awaitilities.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
@@ -400,8 +400,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("manually created usersignup with preexisting banneduser", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host(s.T())
-		memberAwait := s.awaitilities.Member(s.T())
+		hostAwait := s.awaitilities.Host()
+		memberAwait := s.awaitilities.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
@@ -432,7 +432,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("register new user with preexisting ban", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host(s.T())
+		hostAwait := s.awaitilities.Host()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
@@ -471,8 +471,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	})
 
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
-		hostAwait := s.awaitilities.Host(s.T())
-		memberAwait := s.awaitilities.Member(s.T())
+		hostAwait := s.awaitilities.Host()
+		memberAwait := s.awaitilities.Member()
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
@@ -525,8 +525,8 @@ func (s *userManagementTestSuite) TestUserBanning() {
 }
 
 func (s *userManagementTestSuite) TestUserDisabled() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -33,7 +33,7 @@ func (s *userWorkloadsTestSuite) SetupSuite() {
 
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Provision a user to idle with a short idling timeout
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	s.newSignupRequest().
@@ -93,7 +93,7 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 }
 
 func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	s.createStandalonePod(namespace, "idler-test-pod-1")
 	d := s.createDeployment(namespace)
 	n := 1 + int(*d.Spec.Replicas) // total number of created pods
@@ -123,7 +123,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 }
 
 func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Deployment {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Create a Deployment with two pods
 	replicas := int32(3)
 	deployment := &appsv1.Deployment{
@@ -141,7 +141,7 @@ func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Depl
 }
 
 func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.ReplicaSet {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Standalone ReplicaSet
 	replicas := int32(2)
 	rs := &appsv1.ReplicaSet{
@@ -159,7 +159,7 @@ func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.Repl
 }
 
 func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.DaemonSet {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Standalone ReplicaSet
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-daemonset", Namespace: namespace},
@@ -175,7 +175,7 @@ func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.Daemo
 }
 
 func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Job
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-job", Namespace: namespace},
@@ -191,7 +191,7 @@ func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
 }
 
 func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *openshiftappsv1.DeploymentConfig {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Create a Deployment with two pods
 	spec := podTemplateSpec("idler-dc")
 	replicas := int32(2)
@@ -210,7 +210,7 @@ func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *opens
 }
 
 func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *corev1.ReplicationController {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Standalone ReplicationController
 	spec := podTemplateSpec("idler-rc")
 	replicas := int32(2)
@@ -229,7 +229,7 @@ func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *
 }
 
 func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *corev1.Pod {
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Create a Deployment with two pods
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -28,12 +28,12 @@ type userWorkloadsTestSuite struct {
 }
 
 func (s *userWorkloadsTestSuite) SetupSuite() {
-	s.awaitilities = WaitForDeployments(s.T())
+	s.Awaitilities = WaitForDeployments(s.T())
 }
 
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	// Provision a user to idle with a short idling timeout
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	s.newSignupRequest().
@@ -93,7 +93,7 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 }
 
 func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	s.createStandalonePod(namespace, "idler-test-pod-1")
 	d := s.createDeployment(namespace)
 	n := 1 + int(*d.Spec.Replicas) // total number of created pods
@@ -123,7 +123,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 }
 
 func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Deployment {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Create a Deployment with two pods
 	replicas := int32(3)
 	deployment := &appsv1.Deployment{
@@ -141,7 +141,7 @@ func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Depl
 }
 
 func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.ReplicaSet {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Standalone ReplicaSet
 	replicas := int32(2)
 	rs := &appsv1.ReplicaSet{
@@ -159,7 +159,7 @@ func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.Repl
 }
 
 func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.DaemonSet {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Standalone ReplicaSet
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-daemonset", Namespace: namespace},
@@ -175,7 +175,7 @@ func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.Daemo
 }
 
 func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Job
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-job", Namespace: namespace},
@@ -191,7 +191,7 @@ func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
 }
 
 func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *openshiftappsv1.DeploymentConfig {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Create a Deployment with two pods
 	spec := podTemplateSpec("idler-dc")
 	replicas := int32(2)
@@ -210,7 +210,7 @@ func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *opens
 }
 
 func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *corev1.ReplicationController {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Standalone ReplicationController
 	spec := podTemplateSpec("idler-rc")
 	replicas := int32(2)
@@ -229,7 +229,7 @@ func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *
 }
 
 func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *corev1.Pod {
-	memberAwait := s.awaitilities.Member()
+	memberAwait := s.Member()
 	// Create a Deployment with two pods
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -32,8 +32,8 @@ func (s *userWorkloadsTestSuite) SetupSuite() {
 }
 
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	// Provision a user to idle with a short idling timeout
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	s.newSignupRequest().
@@ -93,7 +93,7 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 }
 
 func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	s.createStandalonePod(namespace, "idler-test-pod-1")
 	d := s.createDeployment(namespace)
 	n := 1 + int(*d.Spec.Replicas) // total number of created pods
@@ -123,7 +123,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 }
 
 func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Deployment {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Create a Deployment with two pods
 	replicas := int32(3)
 	deployment := &appsv1.Deployment{
@@ -141,7 +141,7 @@ func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Depl
 }
 
 func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.ReplicaSet {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Standalone ReplicaSet
 	replicas := int32(2)
 	rs := &appsv1.ReplicaSet{
@@ -159,7 +159,7 @@ func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.Repl
 }
 
 func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.DaemonSet {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Standalone ReplicaSet
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-daemonset", Namespace: namespace},
@@ -175,7 +175,7 @@ func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.Daemo
 }
 
 func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Job
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-job", Namespace: namespace},
@@ -191,7 +191,7 @@ func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
 }
 
 func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *openshiftappsv1.DeploymentConfig {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Create a Deployment with two pods
 	spec := podTemplateSpec("idler-dc")
 	replicas := int32(2)
@@ -210,7 +210,7 @@ func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *opens
 }
 
 func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *corev1.ReplicationController {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Standalone ReplicationController
 	spec := podTemplateSpec("idler-rc")
 	replicas := int32(2)
@@ -229,7 +229,7 @@ func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *
 }
 
 func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *corev1.Pod {
-	memberAwait := s.awaitilities.Member(s.T())
+	memberAwait := s.awaitilities.Member()
 	// Create a Deployment with two pods
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -28,26 +28,28 @@ type userWorkloadsTestSuite struct {
 }
 
 func (s *userWorkloadsTestSuite) SetupSuite() {
-	s.hostAwait, s.memberAwait, s.member2Await = WaitForDeployments(s.T())
+	s.awaitilities = WaitForDeployments(s.T())
 }
 
 func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
+	hostAwait := s.awaitilities.Host(s.T())
+	memberAwait := s.awaitilities.Member(s.T())
 	// Provision a user to idle with a short idling timeout
-	s.hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	s.newSignupRequest().
 		Username("test-idler").
 		Email("test-idler@redhat.com").
 		ManuallyApprove().
 		EnsureMUR().
-		TargetCluster(s.memberAwait).
+		TargetCluster(memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute()
 
-	idler, err := s.memberAwait.WaitForIdler("test-idler-dev", wait.IdlerConditions(Running()))
+	idler, err := memberAwait.WaitForIdler("test-idler-dev", wait.IdlerConditions(Running()))
 	require.NoError(s.T(), err)
 
 	// Noise
-	idlerNoise, err := s.memberAwait.WaitForIdler("test-idler-stage", wait.IdlerConditions(Running()))
+	idlerNoise, err := memberAwait.WaitForIdler("test-idler-stage", wait.IdlerConditions(Running()))
 	require.NoError(s.T(), err)
 
 	// Create payloads for both users
@@ -55,42 +57,43 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	podsNoise := s.prepareWorkloads(idlerNoise.Name, wait.WithSandboxPriorityClass())
 
 	// Create another noise pods in non-user namespace
-	s.memberAwait.CreateNamespace("workloads-noise")
+	memberAwait.CreateNamespace("workloads-noise")
 	externalNsPodsNoise := s.prepareWorkloads("workloads-noise", wait.WithOriginalPriorityClass())
 
 	// Set a short timeout for one of the idler to trigger pod idling
 	idler.Spec.TimeoutSeconds = 5
-	idler, err = s.memberAwait.UpdateIdlerSpec(idler) // The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
+	idler, err = memberAwait.UpdateIdlerSpec(idler) // The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
 	require.NoError(s.T(), err)
 
 	// Wait for the pods to be deleted
 	for _, p := range podsToIdle {
-		err := s.memberAwait.WaitUntilPodsDeleted(p.Namespace, wait.WithPodName(p.Name))
+		err := memberAwait.WaitUntilPodsDeleted(p.Namespace, wait.WithPodName(p.Name))
 		require.NoError(s.T(), err)
 	}
 
 	// make sure that "noise" pods are still there
-	_, err = s.memberAwait.WaitForPods(idlerNoise.Name, len(podsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithSandboxPriorityClass())
+	_, err = memberAwait.WaitForPods(idlerNoise.Name, len(podsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithSandboxPriorityClass())
 	require.NoError(s.T(), err)
-	_, err = s.memberAwait.WaitForPods("workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
+	_, err = memberAwait.WaitForPods("workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(s.T(), err)
 
 	// Create another pod and make sure it's deleted.
 	// In the tests above the Idler reconcile was triggered after we changed the Idler resource (to set a short timeout).
 	// Now we want to verify that the idler reconcile is triggered without modifying the Idler resource.
-	pod := s.createStandalonePod(idler.Name, "idler-test-pod-2")      // create just one standalone pod. No need to create all possible pod controllers which may own pods.
-	_, err = s.memberAwait.WaitForPod(idler.Name, "idler-test-pod-2") // pod was created
+	pod := s.createStandalonePod(idler.Name, "idler-test-pod-2")    // create just one standalone pod. No need to create all possible pod controllers which may own pods.
+	_, err = memberAwait.WaitForPod(idler.Name, "idler-test-pod-2") // pod was created
 	require.NoError(s.T(), err)
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
-	err = s.memberAwait.WaitUntilPodDeleted(pod.Namespace, pod.Name)
+	err = memberAwait.WaitUntilPodDeleted(pod.Namespace, pod.Name)
 	require.NoError(s.T(), err)
 
 	// There should not be any pods left in the namespace
-	err = s.memberAwait.WaitUntilPodsDeleted(idler.Name, wait.WithPodLabel("idler", "idler"))
+	err = memberAwait.WaitUntilPodsDeleted(idler.Name, wait.WithPodLabel("idler", "idler"))
 	require.NoError(s.T(), err)
 }
 
 func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
+	memberAwait := s.awaitilities.Member(s.T())
 	s.createStandalonePod(namespace, "idler-test-pod-1")
 	d := s.createDeployment(namespace)
 	n := 1 + int(*d.Spec.Replicas) // total number of created pods
@@ -100,7 +103,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 
 	s.createDaemonSet(namespace)
 	nodes := &corev1.NodeList{}
-	err := s.memberAwait.Client.List(context.TODO(), nodes, client.MatchingLabels(map[string]string{"node-role.kubernetes.io/worker": ""}))
+	err := memberAwait.Client.List(context.TODO(), nodes, client.MatchingLabels(map[string]string{"node-role.kubernetes.io/worker": ""}))
 	require.NoError(s.T(), err)
 	n = n + len(nodes.Items) // DaemonSet creates N pods where N is the number of worker nodes in the cluster
 
@@ -113,13 +116,14 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 	rc := s.createReplicationController(namespace)
 	n = n + int(*rc.Spec.Replicas)
 
-	pods, err := s.memberAwait.WaitForPods(namespace, n, append(additionalPodCriteria, wait.PodRunning(),
+	pods, err := memberAwait.WaitForPods(namespace, n, append(additionalPodCriteria, wait.PodRunning(),
 		wait.WithPodLabel("idler", "idler"))...)
 	require.NoError(s.T(), err)
 	return pods
 }
 
 func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Deployment {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Create a Deployment with two pods
 	replicas := int32(3)
 	deployment := &appsv1.Deployment{
@@ -130,13 +134,14 @@ func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Depl
 			Template: podTemplateSpec("idler-deployment"),
 		},
 	}
-	err := s.memberAwait.Create(deployment)
+	err := memberAwait.Create(deployment)
 	require.NoError(s.T(), err)
 
 	return deployment
 }
 
 func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.ReplicaSet {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Standalone ReplicaSet
 	replicas := int32(2)
 	rs := &appsv1.ReplicaSet{
@@ -147,13 +152,14 @@ func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.Repl
 			Template: podTemplateSpec("idler-rs"),
 		},
 	}
-	err := s.memberAwait.Create(rs)
+	err := memberAwait.Create(rs)
 	require.NoError(s.T(), err)
 
 	return rs
 }
 
 func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.DaemonSet {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Standalone ReplicaSet
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-daemonset", Namespace: namespace},
@@ -162,13 +168,14 @@ func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.Daemo
 			Template: podTemplateSpec("idler-ds"),
 		},
 	}
-	err := s.memberAwait.Create(ds)
+	err := memberAwait.Create(ds)
 	require.NoError(s.T(), err)
 
 	return ds
 }
 
 func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Job
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "idler-test-job", Namespace: namespace},
@@ -177,13 +184,14 @@ func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
 		},
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
-	err := s.memberAwait.Create(job)
+	err := memberAwait.Create(job)
 	require.NoError(s.T(), err)
 
 	return job
 }
 
 func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *openshiftappsv1.DeploymentConfig {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Create a Deployment with two pods
 	spec := podTemplateSpec("idler-dc")
 	replicas := int32(2)
@@ -195,13 +203,14 @@ func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *opens
 			Template: &spec,
 		},
 	}
-	err := s.memberAwait.Create(dc)
+	err := memberAwait.Create(dc)
 	require.NoError(s.T(), err)
 
 	return dc
 }
 
 func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *corev1.ReplicationController {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Standalone ReplicationController
 	spec := podTemplateSpec("idler-rc")
 	replicas := int32(2)
@@ -213,13 +222,14 @@ func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *
 			Template: &spec,
 		},
 	}
-	err := s.memberAwait.Create(rc)
+	err := memberAwait.Create(rc)
 	require.NoError(s.T(), err)
 
 	return rc
 }
 
 func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *corev1.Pod {
+	memberAwait := s.awaitilities.Member(s.T())
 	// Create a Deployment with two pods
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -230,7 +240,7 @@ func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *co
 		Spec: podSpec(),
 	}
 	pod.Spec.PriorityClassName = "system-cluster-critical"
-	err := s.memberAwait.Create(pod)
+	err := memberAwait.Create(pod)
 	require.NoError(s.T(), err)
 	return pod
 }

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -26,13 +26,13 @@ func TestRunUserSignupIntegrationTest(t *testing.T) {
 }
 
 func (s *userSignupIntegrationTest) SetupSuite() {
-	s.awaitilities = WaitForDeployments(s.T())
+	s.Awaitilities = WaitForDeployments(s.T())
 }
 
 func (s *userSignupIntegrationTest) TearDownTest() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
-	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
+	hostAwait := s.Host()
+	memberAwait := s.Member()
+	memberAwait2 := s.Member(s.SecondMember)
 	hostAwait.Clean()
 	memberAwait.Clean()
 	memberAwait2.Clean()
@@ -40,7 +40,7 @@ func (s *userSignupIntegrationTest) TearDownTest() {
 
 func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	// given
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 	// when & then
@@ -74,7 +74,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 		})
 	})
 
@@ -114,7 +114,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
-			VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -127,16 +127,16 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
-				VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 			})
 		})
 	})
 }
 
 func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
-	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
+	hostAwait := s.Host()
+	memberAwait := s.Member()
+	memberAwait2 := s.Member(s.SecondMember)
 	s.T().Run("set per member clusters max number of users for both members and expect that users will be provisioned to the other member when one is full", func(t *testing.T) {
 		// given
 		var memberLimits []testconfig.PerMemberClusterOptionInt
@@ -186,7 +186,7 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 }
 
 func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *toolchainv1alpha1.UserSignup) {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	hostAwait.CheckMasterUserRecordIsDeleted(userSignup.Spec.Username)
 	currentUserSignup, err := hostAwait.WaitForUserSignup(userSignup.Name)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignu
 }
 
 func (s *userSignupIntegrationTest) TestManualApproval() {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	s.T().Run("default approval config - manual", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
@@ -227,8 +227,8 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 }
 
 func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	// given
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -265,7 +265,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 		})
 	})
 
@@ -293,7 +293,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 		})
 	})
 
@@ -319,7 +319,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 }
 
 func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	s.T().Run("automatic approval with verification required", func(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -330,7 +330,7 @@ func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
 }
 
 func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
-	hostAwait := s.awaitilities.Host()
+	hostAwait := s.Host()
 	// Create user signup
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -345,7 +345,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {
@@ -467,8 +467,8 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 }
 
 func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *toolchainv1alpha1.UserSignup {
-	hostAwait := s.awaitilities.Host()
-	memberAwait := s.awaitilities.Member()
+	hostAwait := s.Host()
+	memberAwait := s.Member()
 	// Create a new UserSignup
 	username := "testuser" + uuid.Must(uuid.NewV4()).String()
 	email := username + "@test.com"

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -31,8 +31,8 @@ func (s *userSignupIntegrationTest) SetupSuite() {
 
 func (s *userSignupIntegrationTest) TearDownTest() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
-	memberAwait2 := s.Member(s.SecondMember)
+	memberAwait := s.Member1()
+	memberAwait2 := s.Member2()
 	hostAwait.Clean()
 	memberAwait.Clean()
 	memberAwait2.Clean()
@@ -135,8 +135,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 
 func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
-	memberAwait2 := s.Member(s.SecondMember)
+	memberAwait := s.Member1()
+	memberAwait2 := s.Member2()
 	s.T().Run("set per member clusters max number of users for both members and expect that users will be provisioned to the other member when one is full", func(t *testing.T) {
 		// given
 		var memberLimits []testconfig.PerMemberClusterOptionInt
@@ -228,7 +228,7 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 
 func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// given
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -468,7 +468,7 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 
 func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *toolchainv1alpha1.UserSignup {
 	hostAwait := s.Host()
-	memberAwait := s.Member()
+	memberAwait := s.Member1()
 	// Create a new UserSignup
 	username := "testuser" + uuid.Must(uuid.NewV4()).String()
 	email := username + "@test.com"

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -30,9 +30,9 @@ func (s *userSignupIntegrationTest) SetupSuite() {
 }
 
 func (s *userSignupIntegrationTest) TearDownTest() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
-	memberAwait2 := s.awaitilities.Member(s.T(), s.awaitilities.SecondMember)
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
+	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
 	hostAwait.Clean()
 	memberAwait.Clean()
 	memberAwait2.Clean()
@@ -40,7 +40,7 @@ func (s *userSignupIntegrationTest) TearDownTest() {
 
 func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	// given
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
 
 	// when & then
@@ -134,9 +134,9 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 }
 
 func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
-	memberAwait2 := s.awaitilities.Member(s.T(), s.awaitilities.SecondMember)
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
+	memberAwait2 := s.awaitilities.Member(s.awaitilities.SecondMember)
 	s.T().Run("set per member clusters max number of users for both members and expect that users will be provisioned to the other member when one is full", func(t *testing.T) {
 		// given
 		var memberLimits []testconfig.PerMemberClusterOptionInt
@@ -186,7 +186,7 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 }
 
 func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *toolchainv1alpha1.UserSignup) {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	hostAwait.CheckMasterUserRecordIsDeleted(userSignup.Spec.Username)
 	currentUserSignup, err := hostAwait.WaitForUserSignup(userSignup.Name)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignu
 }
 
 func (s *userSignupIntegrationTest) TestManualApproval() {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	s.T().Run("default approval config - manual", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
@@ -227,8 +227,8 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 }
 
 func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	// given
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -319,7 +319,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 }
 
 func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	s.T().Run("automatic approval with verification required", func(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -330,7 +330,7 @@ func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
 }
 
 func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
-	hostAwait := s.awaitilities.Host(s.T())
+	hostAwait := s.awaitilities.Host()
 	// Create user signup
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
@@ -467,8 +467,8 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 }
 
 func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAssertNotProvisioned() *toolchainv1alpha1.UserSignup {
-	hostAwait := s.awaitilities.Host(s.T())
-	memberAwait := s.awaitilities.Member(s.T())
+	hostAwait := s.awaitilities.Host()
+	memberAwait := s.awaitilities.Member()
 	// Create a new UserSignup
 	username := "testuser" + uuid.Must(uuid.NewV4()).String()
 	email := username + "@test.com"

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -25,9 +25,9 @@ import (
 func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
-	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
+	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -85,8 +85,8 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -163,8 +163,8 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 func TestMetricsWhenUsersDeleted(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -205,9 +205,9 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
-	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
+	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -269,9 +269,9 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 func TestMetricsWhenUserDisabled(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
-	memberAwait2 := awaitilities.Member(t, awaitilities.SecondMember)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
+	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -26,8 +26,8 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
-	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -86,7 +86,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -164,7 +164,7 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
@@ -206,8 +206,8 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
-	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -270,8 +270,8 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
-	memberAwait2 := awaitilities.Member(awaitilities.SecondMember)
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -32,7 +32,9 @@ func TestPerformance(t *testing.T) {
 	logger, out, err := initLogger()
 	require.NoError(t, err)
 	defer out.Close()
-	hostAwait, memberAwait, _ := WaitForDeployments(t)
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host(t)
+	memberAwait := awaitilities.Member(t)
 	hostAwait.Timeout = 5 * time.Minute
 	memberAwait.Timeout = 5 * time.Minute
 

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -34,7 +34,7 @@ func TestPerformance(t *testing.T) {
 	defer out.Close()
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member()
+	memberAwait := awaitilities.Member1()
 	hostAwait.Timeout = 5 * time.Minute
 	memberAwait.Timeout = 5 * time.Minute
 

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -33,8 +33,8 @@ func TestPerformance(t *testing.T) {
 	require.NoError(t, err)
 	defer out.Close()
 	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host(t)
-	memberAwait := awaitilities.Member(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member()
 	hostAwait.Timeout = 5 * time.Minute
 	memberAwait.Timeout = 5 * time.Minute
 

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -89,7 +89,7 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 	require.NoError(t, err)
 
 	t.Log("all operators are ready and in running state")
-	return wait.NewAwaitilities(t, hostAwait, memberAwait, member2Await)
+	return wait.NewAwaitilities(hostAwait, memberAwait, member2Await)
 }
 
 func getMemberAwaitility(t *testing.T, cl client.Client, hostAwait *wait.HostAwaitility, namespace string) *wait.MemberAwaitility {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -24,6 +24,7 @@ import (
 )
 
 type Awaitilities struct {
+	t                  *testing.T
 	hostAwaitility     *wait.HostAwaitility
 	memberAwaitilities []*wait.MemberAwaitility
 }
@@ -96,13 +97,13 @@ func WaitForDeployments(t *testing.T) Awaitilities {
 	t.Log("all operators are ready and in running state")
 	memberAwaitilities := []*wait.MemberAwaitility{memberAwait, member2Await}
 	return Awaitilities{
+		t:                  t,
 		hostAwaitility:     hostAwait,
 		memberAwaitilities: memberAwaitilities,
 	}
 }
 
-func (a Awaitilities) Host(t *testing.T) *wait.HostAwaitility {
-	require.NotNil(t, a.hostAwaitility, "host awaitility is not initialized")
+func (a Awaitilities) Host() *wait.HostAwaitility {
 	return a.hostAwaitility
 }
 
@@ -112,8 +113,8 @@ func (a Awaitilities) SecondMember(m *wait.MemberAwaitility) bool {
 	return m.ClusterName == a.memberAwaitilities[1].ClusterName
 }
 
-func (a Awaitilities) Member(t *testing.T, selectors ...memberSelector) *wait.MemberAwaitility {
-	require.NotEmpty(t, a.memberAwaitilities, "there are no initialized member awaitilities")
+func (a Awaitilities) Member(selectors ...memberSelector) *wait.MemberAwaitility {
+	require.NotEmpty(a.t, a.memberAwaitilities, "there are no initialized member awaitilities")
 	for _, selector := range selectors {
 		for _, m := range a.memberAwaitilities {
 			if selector(m) {

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -75,7 +75,7 @@ type SignupRequest interface {
 	VerificationRequired() SignupRequest
 }
 
-func NewSignupRequest(t *testing.T, awaitilities Awaitilities) SignupRequest {
+func NewSignupRequest(t *testing.T, awaitilities wait.Awaitilities) SignupRequest {
 	defaultUsername := fmt.Sprintf("testuser-%s", uuid.Must(uuid.NewV4()).String())
 	return &signupRequest{
 		t:                  t,
@@ -88,7 +88,7 @@ func NewSignupRequest(t *testing.T, awaitilities Awaitilities) SignupRequest {
 
 type signupRequest struct {
 	t                    *testing.T
-	awaitilities         Awaitilities
+	awaitilities         wait.Awaitilities
 	ensureMUR            bool
 	manuallyApprove      bool
 	verificationRequired bool

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -153,8 +153,8 @@ func (r *signupRequest) RequireHTTPStatus(httpStatus int) SignupRequest {
 }
 
 func (r *signupRequest) Execute() SignupRequest {
-	hostAwait := r.awaitilities.Host(r.t)
-	WaitUntilBaseNSTemplateTierIsUpdated(r.t, r.awaitilities.Host(r.t))
+	hostAwait := r.awaitilities.Host()
+	WaitUntilBaseNSTemplateTierIsUpdated(r.t, r.awaitilities.Host())
 
 	var identityID uuid.UUID
 	if r.identityID != nil {

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -12,16 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func VerifyMultipleSignups(t *testing.T, awaitilities Awaitilities, signups []*toolchainv1alpha1.UserSignup) {
+func VerifyMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, signups []*toolchainv1alpha1.UserSignup) {
 	for _, signup := range signups {
 		VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
 	}
 }
 
-func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities Awaitilities, signup *toolchainv1alpha1.UserSignup,
+func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup,
 	tier string) {
 
-	hostAwait := awaitilities.hostAwaitility
+	hostAwait := awaitilities.Host()
 	templateRefs := tiers.GetTemplateRefs(hostAwait, tier)
 	// Get the latest signup version, wait for usersignup to have the approved label and wait for the complete status to
 	// ensure the compliantusername is available
@@ -102,8 +102,8 @@ func ExpectedUserAccount(userID string, tier string, templateRefs tiers.Template
 	}
 }
 
-func getMurTargetMember(t *testing.T, awaitilities Awaitilities, mur *toolchainv1alpha1.MasterUserRecord) *wait.MemberAwaitility {
-	for _, member := range awaitilities.memberAwaitilities {
+func getMurTargetMember(t *testing.T, awaitilities wait.Awaitilities, mur *toolchainv1alpha1.MasterUserRecord) *wait.MemberAwaitility {
+	for _, member := range awaitilities.AllMembers() {
 		for _, ua := range mur.Spec.UserAccounts {
 			if ua.TargetCluster == member.ClusterName {
 				return member

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func CreateMultipleSignups(t *testing.T, awaitilities Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
 	hostAwait := awaitilities.Host()
 	signups := make([]*toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -18,7 +18,7 @@ import (
 )
 
 func CreateMultipleSignups(t *testing.T, awaitilities Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
-	hostAwait := awaitilities.Host(t)
+	hostAwait := awaitilities.Host()
 	signups := make([]*toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
 		name := fmt.Sprintf("multiple-signup-testuser-%d", i)

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -17,7 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func CreateMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+func CreateMultipleSignups(t *testing.T, awaitilities Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+	hostAwait := awaitilities.Host(t)
 	signups := make([]*toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
 		name := fmt.Sprintf("multiple-signup-testuser-%d", i)
@@ -29,7 +30,7 @@ func CreateMultipleSignups(t *testing.T, hostAwait *wait.HostAwaitility, targetC
 			continue
 		}
 		// Create an approved UserSignup resource
-		signups[i], _ = NewSignupRequest(t, hostAwait, targetCluster, nil).
+		signups[i], _ = NewSignupRequest(t, awaitilities).
 			Username(name).
 			Email(fmt.Sprintf("multiple-signup-testuser-%d@test.com", i)).
 			ManuallyApprove().

--- a/testsupport/wait/awaitilities.go
+++ b/testsupport/wait/awaitilities.go
@@ -1,0 +1,47 @@
+package wait
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func NewAwaitilities(t *testing.T, hostAwait *HostAwaitility, memberAwaitilities ...*MemberAwaitility) Awaitilities {
+	return Awaitilities{
+		t:                  t,
+		hostAwaitility:     hostAwait,
+		memberAwaitilities: memberAwaitilities,
+	}
+}
+
+type Awaitilities struct {
+	t                  *testing.T
+	hostAwaitility     *HostAwaitility
+	memberAwaitilities []*MemberAwaitility
+}
+
+func (a Awaitilities) Host() *HostAwaitility {
+	return a.hostAwaitility
+}
+
+type memberSelector func(*MemberAwaitility) bool
+
+func (a Awaitilities) SecondMember(m *MemberAwaitility) bool {
+	return m.ClusterName == a.memberAwaitilities[1].ClusterName
+}
+
+func (a Awaitilities) Member(selectors ...memberSelector) *MemberAwaitility {
+	require.NotEmpty(a.t, a.memberAwaitilities, "there are no initialized member awaitilities")
+	for _, selector := range selectors {
+		for _, m := range a.memberAwaitilities {
+			if selector(m) {
+				return m
+			}
+		}
+	}
+	return a.memberAwaitilities[0]
+}
+
+func (a Awaitilities) AllMembers() []*MemberAwaitility {
+	return a.memberAwaitilities
+}

--- a/testsupport/wait/awaitilities.go
+++ b/testsupport/wait/awaitilities.go
@@ -1,21 +1,13 @@
 package wait
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
-
-func NewAwaitilities(t *testing.T, hostAwait *HostAwaitility, memberAwaitilities ...*MemberAwaitility) Awaitilities {
+func NewAwaitilities(hostAwait *HostAwaitility, memberAwaitilities ...*MemberAwaitility) Awaitilities {
 	return Awaitilities{
-		t:                  t,
 		hostAwaitility:     hostAwait,
 		memberAwaitilities: memberAwaitilities,
 	}
 }
 
 type Awaitilities struct {
-	t                  *testing.T
 	hostAwaitility     *HostAwaitility
 	memberAwaitilities []*MemberAwaitility
 }
@@ -24,22 +16,12 @@ func (a Awaitilities) Host() *HostAwaitility {
 	return a.hostAwaitility
 }
 
-type memberSelector func(*MemberAwaitility) bool
-
-func (a Awaitilities) SecondMember(m *MemberAwaitility) bool {
-	return m.ClusterName == a.memberAwaitilities[1].ClusterName
+func (a Awaitilities) Member1() *MemberAwaitility {
+	return a.memberAwaitilities[0]
 }
 
-func (a Awaitilities) Member(selectors ...memberSelector) *MemberAwaitility {
-	require.NotEmpty(a.t, a.memberAwaitilities, "there are no initialized member awaitilities")
-	for _, selector := range selectors {
-		for _, m := range a.memberAwaitilities {
-			if selector(m) {
-				return m
-			}
-		}
-	}
-	return a.memberAwaitilities[0]
+func (a Awaitilities) Member2() *MemberAwaitility {
+	return a.memberAwaitilities[1]
 }
 
 func (a Awaitilities) AllMembers() []*MemberAwaitility {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/CRT-1208

### Reason for the changes
This PR tries to reduce the probability of introducing flaky tests related to usersignup provisioning and verification.

#### Current Problems
1. A usersignup can be created without specifying a target member cluster so it can end up targeted to any member cluster (this is valid) but verification functions in e2e tests only accept a specific member cluster to verify against so it can be easy to forget to specify a target cluster when creating the usersignup and then specify a specific member cluster to verify against which leads to flakiness.
2. The second member cluster in the e2e environment is mainly for testing multi-member specific functionality but is returned by the WaitForDeployments func by default increasing the likelihood that someone uses it accidentally

See https://github.com/codeready-toolchain/toolchain-e2e/pull/364 for more details.

### Summary of changes

- Wrap the host awaitility and member awaitilities in a single object so it can be passed to verification functions like VerifyResourcesProvisionedForSignup 
```
type Awaitilities struct {
	t                  *testing.T
	hostAwaitility     *wait.HostAwaitility
	memberAwaitilities []*wait.MemberAwaitility
}
```

- Updated the VerifyResourcesProvisionedForSignup func to automatically determine which member cluster to use based on the provided usersignup. This avoids the test writer having to think about which member cluster to select when calling VerifyResourcesProvisionedForSignup

- Defined a func to retrieve a member cluster that accepts a selector or returns the first member cluster if no selector is provided. So if someone wants to test using the second member cluster, it requires a specific action to get it.
```
type memberSelector func(*wait.MemberAwaitility) bool

func (a Awaitilities) SecondMember(m *wait.MemberAwaitility) bool {
	return m.ClusterName == a.memberAwaitilities[1].ClusterName
}

func (a Awaitilities) Member(selectors ...memberSelector) *wait.MemberAwaitility {
	require.NotEmpty(a.t, a.memberAwaitilities, "there are no initialized member awaitilities")
	for _, selector := range selectors {
		for _, m := range a.memberAwaitilities {
			if selector(m) {
				return m
			}
		}
	}
	return a.memberAwaitilities[0]
}
```