### PR TITLE
Test promotion resets deactivating state

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -211,7 +211,7 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tierName, nameFmt st
 	// let's promote to users the new tier and retain the SyncIndexes (indexes by usersignup.Name)
 	syncIndexes := make(map[string]string, len(users))
 	for i, user := range users {
-		mur := MoveUserToTier(t, hostAwait, fmt.Sprintf(nameFmt, i), *tier)
+		mur := MoveUserToTier(t, hostAwait, fmt.Sprintf(nameFmt, i), tier.Name)
 		syncIndexes[user.Name] = mur.Spec.UserAccounts[0].SyncIndex
 		t.Logf("initial syncIndex for %s: '%s'", mur.Name, syncIndexes[user.Name])
 	}

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -363,32 +363,6 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			})
 		})
 	})
-
-	s.T().Run("test reset deactivating state when promoting user", func(t *testing.T) {
-		userSignup, _ := s.newSignupRequest().
-			Username("promoteuser").
-			Email("promoteuser@redhat.com").
-			EnsureMUR().
-			ManuallyApprove().
-			TargetCluster(s.Member1()).
-			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
-
-		// Set the deactivating state on the UserSignup
-		updatedUserSignup, err := hostAwait.UpdateUserSignupSpec(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivating(us, true)
-		})
-		require.NoError(s.T(), err)
-
-		// Move the user to the new tier
-		_ = MoveUserToTier(t, hostAwait, updatedUserSignup.Spec.Username, "advanced")
-
-		// Ensure the deactivating state is reset after promotion
-		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
-		require.NoError(t, err)
-		require.False(t, states.Deactivating(promotedUserSignup), "usersignup should not be deactivating")
-		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, promotedUserSignup, "advanced")
-	})
 }
 
 func (s *userManagementTestSuite) TestUserBanning() {

--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -98,11 +98,11 @@ func createNewTierTemplate(t *testing.T, hostAwait *HostAwaitility, tierName, or
 	return newTierTemplate.Name
 }
 
-func MoveUserToTier(t *testing.T, hostAwait *HostAwaitility, username string, tier toolchainv1alpha1.NSTemplateTier) *toolchainv1alpha1.MasterUserRecord {
+func MoveUserToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) *toolchainv1alpha1.MasterUserRecord {
 	mur, err := hostAwait.WaitForMasterUserRecord(username,
 		UntilMasterUserRecordHasCondition(Provisioned())) // ignore other conditions, such as notification sent, etc.
 	require.NoError(t, err)
-	changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, username, tier.Name)
+	changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, username, tierName)
 	err = hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
 	require.NoError(t, err)
 	_, err = hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -448,7 +448,7 @@ func ContainsCondition(expected toolchainv1alpha1.Condition) UserSignupWaitCrite
 }
 
 // UntilUserSignupHasStateLabel returns a `UserAccountWaitCriterion` which checks that the given
-// USerAccount has toolchain.dev.openshift.com/state equal to the given value
+// UserAccount has toolchain.dev.openshift.com/state equal to the given value
 func UntilUserSignupHasStateLabel(expected string) UserSignupWaitCriterion {
 	return UserSignupWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.UserSignup) bool {


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1222

Related PRs:
https://github.com/codeready-toolchain/host-operator/pull/524

Verifies that the deactivating state is reset after promoting a user to a new tier.