### PR TITLE
fix: don't reuse connections

### DIFF
--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -266,6 +266,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("content-type", "application/json")
+	req.Close = true
 	resp, err := httpClient.Do(req)
 
 	require.NoError(t, err, "error posting signup request.\nmethod : %s\npath : %s\nauthToken : %s\nbody : %s", method, path, authToken, requestBody)


### PR DESCRIPTION
IIRC http.Transport reuses connections by default in go, so it could have happened that it reused some old connection that was closed by the server. In that case, the client could get the EOF error. 
by setting `req.Close = true` we should prevent from reusing the connection.