### PR TITLE
e2e tests for proxy

### DIFF
--- a/test/e2e/appstudio_test.go
+++ b/test/e2e/appstudio_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
@@ -46,141 +45,151 @@ func TestAppStudioFlow(t *testing.T) {
 	users := []appstudioUsers{
 		{
 			expectedMemberCluster: memberAwait,
-			username:              "asm1",
+			username:              "appstudiomember1",
 		},
 		{
 			expectedMemberCluster: memberAwait2,
-			username:              "asm2",
+			username:              "appstudiomember2",
 		},
 	}
 
-	for _, user := range users {
-		// Create and approve signup
-		req := NewSignupRequest(t, awaitilities).
-			Username(user.username).
-			ManuallyApprove().
-			TargetCluster(user.expectedMemberCluster).
-			EnsureMUR().
-			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute()
+	for index, user := range users {
+		t.Run(user.username, func(t *testing.T) {
+			// Create and approve signup
+			req := NewSignupRequest(t, awaitilities).
+				Username(user.username).
+				ManuallyApprove().
+				TargetCluster(user.expectedMemberCluster).
+				EnsureMUR().
+				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+				Execute()
 
-		user.signup, _ = req.Resources()
-		user.token = req.GetToken()
+			user.signup, _ = req.Resources()
+			user.token = req.GetToken()
 
-		VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "base")
-		_, err = hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
-		require.NoError(t, err)
-
-		// since the registration service always provisions users to the default tier users need to be
-		// promoted to the appstudio tier in order to test appstudio scenarios
-		t.Run("promote to appstudio tier", func(t *testing.T) {
-			// given
-			promotionTier := "appstudio"
-
-			changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, user.signup.Status.CompliantUsername, promotionTier)
-
-			// when
-			err = hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
-
-			// then
+			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "base")
+			_, err = hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
 			require.NoError(t, err)
-			_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
-			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, promotionTier)
 
-			// then - wait until ChangeTierRequest is deleted by our automatic GC
-			err = hostAwait.WaitUntilChangeTierRequestDeleted(changeTierRequest.Name)
-			assert.NoError(t, err)
-		})
+			// since the registration service always provisions users to the default tier users need to be
+			// promoted to the appstudio tier in order to test appstudio scenarios
+			t.Run("promote to appstudio tier", func(t *testing.T) {
+				// given
+				promotionTier := "appstudio"
 
-		t.Run("use proxy to create a configmap in each user appstudio namespace via proxy API", func(t *testing.T) {
-			cmName := "appstudio-test-cm"
-			expectedCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cmName,
-					Namespace: user.username,
-				},
-				Data: map[string]string{
-					"planet": "venus",
-				},
+				changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, user.signup.Status.CompliantUsername, promotionTier)
+
+				// when
+				err = hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
+
+				// then
+				require.NoError(t, err)
+				_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
+				require.NoError(t, err)
+				VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, promotionTier)
+
+				// then - wait until ChangeTierRequest is deleted by our automatic GC
+				err = hostAwait.WaitUntilChangeTierRequestDeleted(changeTierRequest.Name)
+				assert.NoError(t, err)
+			})
+
+			t.Run("use proxy to create a configmap in each user appstudio namespace via proxy API", func(t *testing.T) {
+				cmName := fmt.Sprintf("%s-test-cm", user.username)
+				expectedCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmName,
+						Namespace: user.username,
+					},
+					Data: map[string]string{
+						"planet": "venus",
+					},
+				}
+
+				proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+				err := proxyCl.Create(context.TODO(), expectedCM)
+				require.NoError(t, err)
+
+				createdCM := &corev1.ConfigMap{}
+				err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
+				require.NoError(t, err)
+
+				require.NoError(t, err)
+				require.NotEmpty(t, createdCM)
+				require.Equal(t, "venus", createdCM.Data["planet"])
+			})
+
+			t.Run("try to create a resource in an unauthorized namespace", func(t *testing.T) {
+				cmName := fmt.Sprintf("%s-appstudio-test-cm", user.username)
+				expectedCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmName,
+						Namespace: hostAwait.Namespace, // user should not be allowed to create a resource in the host operator namespace
+					},
+					Data: map[string]string{
+						"planet": "venus",
+					},
+				}
+
+				proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+				err := proxyCl.Create(context.TODO(), expectedCM)
+				require.EqualError(t, err, fmt.Sprintf(`configmaps is forbidden: User "system:serviceaccount:%[1]s:appstudio-%[1]s" cannot create resource "configmaps" in API group "" in the namespace "%[2]s"`, user.username, hostAwait.Namespace))
+			})
+
+			if index == 1 { // only for the second user
+				t.Run("try to create a resource in the other users namespace", func(t *testing.T) {
+					cmName := fmt.Sprintf("%s-appstudio-test-cm", users[0].username)
+					expectedCM := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      cmName,
+							Namespace: users[0].expectedMemberCluster.Namespace, // user should not be allowed to create a resource in the first user's namespace
+						},
+						Data: map[string]string{
+							"planet": "venus",
+						},
+					}
+
+					proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+					err := proxyCl.Create(context.TODO(), expectedCM)
+					require.EqualError(t, err, fmt.Sprintf(`configmaps is forbidden: User "system:serviceaccount:%[1]s:appstudio-%[1]s" cannot create resource "configmaps" in API group "" in the namespace "%[2]s"`, user.username, users[0].expectedMemberCluster.Namespace))
+				})
 			}
 
-			proxyCl := hostAwait.CreateAPIProxyClient(user.token)
-			err := proxyCl.Create(context.TODO(), expectedCM)
-			require.NoError(t, err)
+			t.Run("delete usersignup and expect all resources to be deleted", func(t *testing.T) {
+				// given
+				signup, err := hostAwait.WaitForUserSignup(user.signup.Name)
+				require.NoError(t, err)
 
-			createdCM := &corev1.ConfigMap{}
-			err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
-			require.NoError(t, err)
+				// when
+				err = hostAwait.Client.Delete(context.TODO(), user.signup)
 
-			require.NoError(t, err)
-			require.NotEmpty(t, createdCM)
-			require.Equal(t, "venus", createdCM.Data["planet"])
-		})
+				// then
+				require.NoError(t, err)
+				t.Logf("usersignup '%s' deleted (resource name='%s')", user.username, signup.Name)
 
-		t.Run("try to create a resource in an unauthorized namespace", func(t *testing.T) {
-			cmName := fmt.Sprintf("%s-appstudio-test-cm", user.username)
-			expectedCM := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cmName,
-					Namespace: hostAwait.Namespace, // user should not be allowed to create a resource in the host operator namespace
-				},
-				Data: map[string]string{
-					"planet": "venus",
-				},
-			}
+				err = hostAwait.WaitUntilMasterUserRecordDeleted(user.username)
+				assert.NoError(t, err, "MasterUserRecord is not deleted")
 
-			proxyCl := hostAwait.CreateAPIProxyClient(user.token)
-			err := proxyCl.Create(context.TODO(), expectedCM)
-			require.NoError(t, err)
+				err = memberAwait.WaitUntilUserAccountDeleted(user.username)
+				assert.NoError(t, err, "UserAccount is not deleted")
 
-			t.Log("sleeping for 1 minute...")
-			time.Sleep(1 * time.Minute)
+				err = memberAwait.WaitUntilUserDeleted(user.username)
+				assert.NoError(t, err, "User is not deleted")
 
-			createdCM := &corev1.ConfigMap{}
-			err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
-			require.NoError(t, err)
+				err = memberAwait.WaitUntilIdentityDeleted(user.username)
+				assert.NoError(t, err, "Identity is not deleted")
 
-			require.NoError(t, err)
-			require.NotEmpty(t, createdCM)
-			require.Equal(t, "venus", createdCM.Data["planet"])
-		})
+				err = memberAwait.WaitUntilNSTemplateSetDeleted(user.username)
+				assert.NoError(t, err, "NSTemplateSet id not deleted")
 
-		t.Run("delete usersignup and expect all resources to be deleted", func(t *testing.T) {
-			// given
-			signup, err := hostAwait.WaitForUserSignup(user.signup.Name)
-			require.NoError(t, err)
+				err = memberAwait.WaitUntilClusterResourceQuotasDeleted(user.username)
+				assert.NoError(t, err, "ClusterResourceQuotas were not deleted")
 
-			// when
-			err = hostAwait.Client.Delete(context.TODO(), user.signup)
+				err = memberAwait.WaitUntilNamespaceDeleted(user.username, "dev")
+				assert.NoError(t, err, "johnsmith-dev namespace is not deleted")
 
-			// then
-			require.NoError(t, err)
-			t.Logf("usersignup '%s' deleted (resource name='%s')", user.username, signup.Name)
-
-			err = hostAwait.WaitUntilMasterUserRecordDeleted(user.username)
-			assert.NoError(t, err, "MasterUserRecord is not deleted")
-
-			err = memberAwait.WaitUntilUserAccountDeleted(user.username)
-			assert.NoError(t, err, "UserAccount is not deleted")
-
-			err = memberAwait.WaitUntilUserDeleted(user.username)
-			assert.NoError(t, err, "User is not deleted")
-
-			err = memberAwait.WaitUntilIdentityDeleted(user.username)
-			assert.NoError(t, err, "Identity is not deleted")
-
-			err = memberAwait.WaitUntilNSTemplateSetDeleted(user.username)
-			assert.NoError(t, err, "NSTemplateSet id not deleted")
-
-			err = memberAwait.WaitUntilClusterResourceQuotasDeleted(user.username)
-			assert.NoError(t, err, "ClusterResourceQuotas were not deleted")
-
-			err = memberAwait.WaitUntilNamespaceDeleted(user.username, "dev")
-			assert.NoError(t, err, "johnsmith-dev namespace is not deleted")
-
-			err = memberAwait.WaitUntilNamespaceDeleted(user.username, "stage")
-			assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
+				err = memberAwait.WaitUntilNamespaceDeleted(user.username, "stage")
+				assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
+			})
 		})
 	} // end users loop
 

--- a/test/e2e/appstudio_test.go
+++ b/test/e2e/appstudio_test.go
@@ -1,0 +1,187 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type appstudioUsers struct {
+	expectedMemberCluster *wait.MemberAwaitility
+	username              string
+	token                 string
+	signup                *toolchainv1alpha1.UserSignup
+}
+
+func TestAppStudioFlow(t *testing.T) {
+	// full flow from usersignup with approval down to namespaces creation and cleanup
+	// given
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member1()
+	memberAwait2 := awaitilities.Member2()
+
+	// check that the tier exists, and all its namespace other cluster-scoped resource revisions
+	// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
+	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
+
+	originalToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(
+		ToolchainStatusReadyAndUnreadyNotificationNotCreated()...))
+	require.NoError(t, err, "failed while waiting for ToolchainStatus")
+	originalMursPerDomainCount := originalToolchainStatus.Status.Metrics[toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey]
+	t.Logf("the original MasterUserRecord count: %v", originalMursPerDomainCount)
+
+	users := []appstudioUsers{
+		{
+			expectedMemberCluster: memberAwait,
+			username:              "asm1",
+		},
+		{
+			expectedMemberCluster: memberAwait2,
+			username:              "asm2",
+		},
+	}
+
+	for _, user := range users {
+		// Create and approve signup
+		req := NewSignupRequest(t, awaitilities).
+			Username(user.username).
+			ManuallyApprove().
+			TargetCluster(user.expectedMemberCluster).
+			EnsureMUR().
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute()
+
+		user.signup, _ = req.Resources()
+		user.token = req.GetToken()
+
+		VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "base")
+		_, err = hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
+		require.NoError(t, err)
+
+		// since the registration service always provisions users to the default tier users need to be
+		// promoted to the appstudio tier in order to test appstudio scenarios
+		t.Run("promote to appstudio tier", func(t *testing.T) {
+			// given
+			promotionTier := "appstudio"
+
+			changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, user.signup.Status.CompliantUsername, promotionTier)
+
+			// when
+			err = hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
+
+			// then
+			require.NoError(t, err)
+			_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
+			require.NoError(t, err)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, promotionTier)
+
+			// then - wait until ChangeTierRequest is deleted by our automatic GC
+			err = hostAwait.WaitUntilChangeTierRequestDeleted(changeTierRequest.Name)
+			assert.NoError(t, err)
+		})
+
+		t.Run("use proxy to create a configmap in each user appstudio namespace via proxy API", func(t *testing.T) {
+			cmName := "appstudio-test-cm"
+			expectedCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: user.username,
+				},
+				Data: map[string]string{
+					"planet": "venus",
+				},
+			}
+
+			proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+			err := proxyCl.Create(context.TODO(), expectedCM)
+			require.NoError(t, err)
+
+			createdCM := &corev1.ConfigMap{}
+			err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
+			require.NoError(t, err)
+
+			require.NoError(t, err)
+			require.NotEmpty(t, createdCM)
+			require.Equal(t, "venus", createdCM.Data["planet"])
+		})
+
+		t.Run("try to create a resource in an unauthorized namespace", func(t *testing.T) {
+			cmName := fmt.Sprintf("%s-appstudio-test-cm", user.username)
+			expectedCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cmName,
+					Namespace: hostAwait.Namespace, // user should not be allowed to create a resource in the host operator namespace
+				},
+				Data: map[string]string{
+					"planet": "venus",
+				},
+			}
+
+			proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+			err := proxyCl.Create(context.TODO(), expectedCM)
+			require.NoError(t, err)
+
+			t.Log("sleeping for 1 minute...")
+			time.Sleep(1 * time.Minute)
+
+			createdCM := &corev1.ConfigMap{}
+			err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
+			require.NoError(t, err)
+
+			require.NoError(t, err)
+			require.NotEmpty(t, createdCM)
+			require.Equal(t, "venus", createdCM.Data["planet"])
+		})
+
+		t.Run("delete usersignup and expect all resources to be deleted", func(t *testing.T) {
+			// given
+			signup, err := hostAwait.WaitForUserSignup(user.signup.Name)
+			require.NoError(t, err)
+
+			// when
+			err = hostAwait.Client.Delete(context.TODO(), user.signup)
+
+			// then
+			require.NoError(t, err)
+			t.Logf("usersignup '%s' deleted (resource name='%s')", user.username, signup.Name)
+
+			err = hostAwait.WaitUntilMasterUserRecordDeleted(user.username)
+			assert.NoError(t, err, "MasterUserRecord is not deleted")
+
+			err = memberAwait.WaitUntilUserAccountDeleted(user.username)
+			assert.NoError(t, err, "UserAccount is not deleted")
+
+			err = memberAwait.WaitUntilUserDeleted(user.username)
+			assert.NoError(t, err, "User is not deleted")
+
+			err = memberAwait.WaitUntilIdentityDeleted(user.username)
+			assert.NoError(t, err, "Identity is not deleted")
+
+			err = memberAwait.WaitUntilNSTemplateSetDeleted(user.username)
+			assert.NoError(t, err, "NSTemplateSet id not deleted")
+
+			err = memberAwait.WaitUntilClusterResourceQuotasDeleted(user.username)
+			assert.NoError(t, err, "ClusterResourceQuotas were not deleted")
+
+			err = memberAwait.WaitUntilNamespaceDeleted(user.username, "dev")
+			assert.NoError(t, err, "johnsmith-dev namespace is not deleted")
+
+			err = memberAwait.WaitUntilNamespaceDeleted(user.username, "stage")
+			assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
+		})
+	} // end users loop
+
+}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type appstudioUsers struct {
+type proxyUsers struct {
 	expectedMemberCluster *wait.MemberAwaitility
 	username              string
 	token                 string
@@ -25,7 +25,7 @@ type appstudioUsers struct {
 }
 
 // full flow from usersignup with approval down to namespaces creation and cleanup
-func TestAppStudioFlow(t *testing.T) {
+func TestProxyFlow(t *testing.T) {
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
@@ -42,14 +42,14 @@ func TestAppStudioFlow(t *testing.T) {
 	originalMursPerDomainCount := originalToolchainStatus.Status.Metrics[toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey]
 	t.Logf("the original MasterUserRecord count: %v", originalMursPerDomainCount)
 
-	users := []appstudioUsers{
+	users := []proxyUsers{
 		{
 			expectedMemberCluster: memberAwait,
-			username:              "appstudiomember1",
+			username:              "proxymember1",
 		},
 		{
 			expectedMemberCluster: memberAwait2,
-			username:              "appstudiomember2",
+			username:              "proxymember2",
 		},
 	}
 	promotionTier := "appstudio"
@@ -73,7 +73,7 @@ func TestAppStudioFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// since the registration service always provisions users to the default tier users need to be
-			// promoted to the appstudio tier in order to test appstudio scenarios
+			// promoted to the appstudio tier in order to test proxy scenarios
 			t.Run("promote to appstudio tier", func(t *testing.T) {
 				// given
 				changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, user.signup.Status.CompliantUsername, promotionTier)
@@ -120,7 +120,7 @@ func TestAppStudioFlow(t *testing.T) {
 
 			t.Run("try to create a resource in an unauthorized namespace", func(t *testing.T) {
 				// given
-				cmName := fmt.Sprintf("%s-appstudio-test-cm", user.username)
+				cmName := fmt.Sprintf("%s-proxy-test-cm", user.username)
 				expectedCM := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      cmName,
@@ -142,7 +142,7 @@ func TestAppStudioFlow(t *testing.T) {
 			if index == 1 { // only for the second user
 				t.Run("try to create a resource in the other users namespace", func(t *testing.T) {
 					// given
-					cmName := fmt.Sprintf("%s-appstudio-test-cm", users[0].username)
+					cmName := fmt.Sprintf("%s-proxy-test-cm", users[0].username)
 					expectedCM := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      cmName,

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -136,6 +136,11 @@ func TestProxyFlow(t *testing.T) {
 			if index == 1 { // only for the second user
 				t.Run("try to create a resource in the other users namespace", func(t *testing.T) {
 					// given
+					// verify first user's namespace still exists
+					ns := &corev1.Namespace{}
+					err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{Name: users[0].username}, ns)
+					require.NoError(t, err, "failed to verify the first user's namespace still exists")
+
 					cmName := fmt.Sprintf("%s-proxy-test-cm", users[0].username)
 					expectedCM := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +154,7 @@ func TestProxyFlow(t *testing.T) {
 
 					// when
 					proxyCl := hostAwait.CreateAPIProxyClient(user.token)
-					err := proxyCl.Create(context.TODO(), expectedCM)
+					err = proxyCl.Create(context.TODO(), expectedCM)
 
 					// then
 					require.EqualError(t, err, fmt.Sprintf(`configmaps is forbidden: User "system:serviceaccount:%[1]s:appstudio-%[1]s" cannot create resource "configmaps" in API group "" in the namespace "%[2]s"`, user.username, users[0].expectedMemberCluster.Namespace))

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -155,43 +155,6 @@ func TestProxyFlow(t *testing.T) {
 					require.EqualError(t, err, fmt.Sprintf(`configmaps is forbidden: User "system:serviceaccount:%[1]s:appstudio-%[1]s" cannot create resource "configmaps" in API group "" in the namespace "%[2]s"`, user.username, users[0].expectedMemberCluster.Namespace))
 				})
 			}
-
-			t.Run("delete usersignup and expect all resources to be deleted", func(t *testing.T) {
-				// given
-				signup, err := hostAwait.WaitForUserSignup(user.signup.Name)
-				require.NoError(t, err)
-
-				// when
-				err = hostAwait.Client.Delete(context.TODO(), user.signup)
-
-				// then
-				require.NoError(t, err)
-				t.Logf("usersignup '%s' deleted (resource name='%s')", user.username, signup.Name)
-
-				err = hostAwait.WaitUntilMasterUserRecordDeleted(user.username)
-				assert.NoError(t, err, "MasterUserRecord is not deleted")
-
-				err = memberAwait.WaitUntilUserAccountDeleted(user.username)
-				assert.NoError(t, err, "UserAccount is not deleted")
-
-				err = memberAwait.WaitUntilUserDeleted(user.username)
-				assert.NoError(t, err, "User is not deleted")
-
-				err = memberAwait.WaitUntilIdentityDeleted(user.username)
-				assert.NoError(t, err, "Identity is not deleted")
-
-				err = memberAwait.WaitUntilNSTemplateSetDeleted(user.username)
-				assert.NoError(t, err, "NSTemplateSet id not deleted")
-
-				err = memberAwait.WaitUntilClusterResourceQuotasDeleted(user.username)
-				assert.NoError(t, err, "ClusterResourceQuotas were not deleted")
-
-				err = memberAwait.WaitUntilNamespaceDeleted(user.username, "dev")
-				assert.NoError(t, err, "johnsmith-dev namespace is not deleted")
-
-				err = memberAwait.WaitUntilNamespaceDeleted(user.username, "stage")
-				assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
-			})
 		})
 	} // end users loop
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -36,12 +36,6 @@ func TestProxyFlow(t *testing.T) {
 	// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
 	WaitUntilBaseNSTemplateTierIsUpdated(t, hostAwait)
 
-	originalToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(
-		ToolchainStatusReadyAndUnreadyNotificationNotCreated()...))
-	require.NoError(t, err, "failed while waiting for ToolchainStatus")
-	originalMursPerDomainCount := originalToolchainStatus.Status.Metrics[toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey]
-	t.Logf("the original MasterUserRecord count: %v", originalMursPerDomainCount)
-
 	users := []proxyUsers{
 		{
 			expectedMemberCluster: memberAwait,
@@ -69,7 +63,7 @@ func TestProxyFlow(t *testing.T) {
 			user.token = req.GetToken()
 
 			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "base")
-			_, err = hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
+			_, err := hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
 			require.NoError(t, err)
 
 			// since the registration service always provisions users to the default tier users need to be

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -106,7 +106,7 @@ func TestProxyFlow(t *testing.T) {
 
 				// then
 				createdCM := &corev1.ConfigMap{}
-				err = proxyCl.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
+				err = user.expectedMemberCluster.Client.Get(context.TODO(), types.NamespacedName{Namespace: user.username, Name: cmName}, createdCM)
 				require.NoError(t, err)
 				require.NotEmpty(t, createdCM)
 				require.Equal(t, "venus", createdCM.Data["planet"])

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -1,6 +1,7 @@
 package testsupport
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -63,7 +64,10 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 	hostAwait.RegistrationServiceURL = registrationServiceURL
 
 	// set api proxy values
-	hostAwait.APIProxyURL = hostAwait.GetAPIProxyURL()
+	// hostAwait.APIProxyURL = hostAwait.GetAPIProxyURL()
+	apiRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
+	require.NoError(t, err)
+	hostAwait.APIProxyURL = fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path)
 
 	// wait for member operators to be ready
 	memberAwait := getMemberAwaitility(t, cl, hostAwait, memberNs)

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -52,14 +52,18 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 	// wait for registration service to be ready
 	hostAwait.WaitForDeploymentToGetReady("registration-service", 2)
 
+	// set registration service values
 	registrationServiceRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "registration-service", "/")
-	require.NoError(t, err, "failed while waiting for registration service deployment")
+	require.NoError(t, err, "failed while waiting for registration service route")
 
 	registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host
 	if registrationServiceRoute.Spec.TLS != nil {
 		registrationServiceURL = "https://" + registrationServiceRoute.Spec.Host
 	}
 	hostAwait.RegistrationServiceURL = registrationServiceURL
+
+	// set api proxy values
+	hostAwait.APIProxyURL = hostAwait.GetAPIProxyURL()
 
 	// wait for member operators to be ready
 	memberAwait := getMemberAwaitility(t, cl, hostAwait, memberNs)

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -43,6 +43,9 @@ type SignupRequest interface {
 	// once, and must be called after all other functions EXCEPT for Resources()
 	Execute() SignupRequest
 
+	// GetToken may be called only after a call to Execute(). It returns the token that was generated for the request
+	GetToken() string
+
 	// ManuallyApprove if called will set the "approved" state to true after the UserSignup has been created
 	ManuallyApprove() SignupRequest
 
@@ -100,6 +103,7 @@ type signupRequest struct {
 	conditions           []toolchainv1alpha1.Condition
 	userSignup           *toolchainv1alpha1.UserSignup
 	mur                  *toolchainv1alpha1.MasterUserRecord
+	token                string
 }
 
 func (r *signupRequest) IdentityID(id uuid.UUID) SignupRequest {
@@ -125,6 +129,10 @@ func (r *signupRequest) Resources() (*toolchainv1alpha1.UserSignup, *toolchainv1
 func (r *signupRequest) EnsureMUR() SignupRequest {
 	r.ensureMUR = true
 	return r
+}
+
+func (r *signupRequest) GetToken() string {
+	return r.token
 }
 
 func (r *signupRequest) ManuallyApprove() SignupRequest {
@@ -172,6 +180,7 @@ func (r *signupRequest) Execute() SignupRequest {
 	emailClaim0 := authsupport.WithEmailClaim(r.email)
 	token0, err := authsupport.GenerateSignedE2ETestToken(*userIdentity, emailClaim0)
 	require.NoError(r.t, err)
+	r.token = token0
 
 	// Call the signup endpoint
 	invokeEndpoint(r.t, "POST", hostAwait.RegistrationServiceURL+"/api/v1/signup",

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1304,8 +1304,8 @@ func (a *HostAwaitility) GetAPIProxyURL() string {
 	return fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
 }
 
-// GetAPIProxyURL retrieves the api proxy route and returns its URL
-func (a *HostAwaitility) CreateAPIProxyClient(token string) client.Client {
+// CreateAPIProxyClient creates a client to the appstudio api proxy using the given user token
+func (a *HostAwaitility) CreateAPIProxyClient(usertoken string) client.Client {
 	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	require.NoError(a.T, err)
 	defaultConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
@@ -1318,7 +1318,7 @@ func (a *HostAwaitility) CreateAPIProxyClient(token string) client.Client {
 	proxyKubeConfig := &rest.Config{
 		Host:            a.APIProxyURL,
 		TLSClientConfig: defaultConfig.TLSClientConfig,
-		BearerToken:     token,
+		BearerToken:     usertoken,
 	}
 	proxyCl, err := client.New(proxyKubeConfig, client.Options{
 		Scheme: s,

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -13,7 +13,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
-	routev1 "github.com/openshift/api/route/v1"
 
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
@@ -1304,16 +1303,6 @@ func (a *HostAwaitility) GetHostOperatorPod() (corev1.Pod, error) {
 		return corev1.Pod{}, fmt.Errorf("unexpected number of pods with label 'control-plane=controller-manager' in namespace '%s': %d ", a.Namespace, len(pods.Items))
 	}
 	return pods.Items[0], nil
-}
-
-// GetAPIProxyURL retrieves the api proxy route and returns its URL
-func (a *HostAwaitility) GetAPIProxyURL() string {
-	route := &routev1.Route{}
-	namespacedName := types.NamespacedName{Namespace: a.Namespace, Name: "api"}
-	err := a.Client.Get(context.TODO(), namespacedName, route)
-	require.NoError(a.T, err)
-
-	return fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
 }
 
 // CreateAPIProxyClient creates a client to the appstudio api proxy using the given user token

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1308,15 +1308,18 @@ func (a *HostAwaitility) GetAPIProxyURL() string {
 func (a *HostAwaitility) CreateAPIProxyClient(token string) client.Client {
 	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	require.NoError(a.T, err)
-	proxyKubeConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	defaultConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
 	require.NoError(a.T, err)
 
 	s := scheme.Scheme
 	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme)
 	require.NoError(a.T, builder.AddToScheme(s))
 
-	proxyKubeConfig.APIPath = a.APIProxyURL
-	proxyKubeConfig.BearerToken = token
+	proxyKubeConfig := &rest.Config{
+		Host:            a.APIProxyURL,
+		TLSClientConfig: defaultConfig.TLSClientConfig,
+		BearerToken:     token,
+	}
 	proxyCl, err := client.New(proxyKubeConfig, client.Options{
 		Scheme: s,
 	})


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-1274

Related PR: https://github.com/codeready-toolchain/registration-service/pull/228

Add a test to provision users to the appstudio tier and verify that the proxy API can be used with the user namespaces.