### PR TITLE
feat: drop codecov to make the PR reviews easier

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -40,16 +40,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     
-    - name: Unit Tests with Coverage
+    - name: Unit Tests
       run: |
-        make test-with-coverage
-
-    - name: Upload code coverage
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./build/_output/coverage/coverage.txt
-        flags: unittests # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
-
-
+        make test

--- a/make/test.mk
+++ b/make/test.mk
@@ -242,16 +242,7 @@ display-eval:
 #
 ###########################################################
 
-# Output directory for coverage information
-COV_DIR = $(OUT_DIR)/coverage
-
 .PHONY: test
 ## Run the unit tests in the 'testsupport/...' packages
 test:
 	@go test github.com/codeready-toolchain/toolchain-e2e/testsupport/... -failfast
-
-.PHONY: test-with-coverage
-## Run the unit tests in the 'testsupport/...' packages (with coverage)
-test-with-coverage:
-	@-mkdir -p $(COV_DIR)
-	@go test -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic github.com/codeready-toolchain/toolchain-e2e/testsupport/...


### PR DESCRIPTION
There is no point in having the code-coverage for e2e tests and the CodeCov "warning" comments in the PR reviews are really annoying and make the review harder.