### PR TITLE
feat: add print-local-debug-info target

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -8,6 +8,9 @@ DEV_ENVIRONMENT := dev
 ## Deploy the resources with one member operator instance
 dev-deploy-e2e: deploy-e2e-to-dev-namespaces print-reg-service-link
 
+.PHONY: dev-deploy-e2e-and-print-local-debug
+dev-deploy-e2e-and-print-local-debug: dev-deploy-e2e print-local-debug-info
+
 .PHONY: dev-deploy-e2e-two-members
 ## Deploy the resources with two instances of member operator
 dev-deploy-e2e-two-members: deploy-e2e-to-dev-namespaces-two-members print-reg-service-link


### PR DESCRIPTION
Have ever been struggling with figuring out what was going on with your e2e test? Have you ever wanted to run it from your IDE or debug the test code? 
This should make it easier. The target prints out a set of `os.Setenv(...,...)` calls - if you copy it and paste it at the very beginning of your test/suite, then you should be able to run/debug the test directly from the IDE.