### PR TITLE
feat: add appstudio-e2e-deploy-latest target

### DIFF
--- a/deploy/host-operator/appstudio-e2e/secrets.yaml
+++ b/deploy/host-operator/appstudio-e2e/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-operator-secret
+type: Opaque
+data:
+  twilio.account.sid: QUM4MWE4MTcwMTQ5NDU2MmQ3OWFjZmRkNzlkNjhkZTg3Yw==
+  twilio.auth.token: NjZlMzllNGUxOTZiMjFlOTM1YzU0OTA4M2RhMGU3NzI=
+  twilio.from_number: KzE1MDA1NTUwMDA2

--- a/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
@@ -1,0 +1,34 @@
+apiVersion: toolchain.dev.openshift.com/v1alpha1
+kind: ToolchainConfig
+metadata:
+  name: config
+spec:
+  host:
+    tiers:
+      defaultTier: 'appstudio'
+      durationBeforeChangeTierRequestDeletion: '5s'
+    automaticApproval:
+      enabled: true
+    deactivation:
+      deactivationDomainsExcluded: '@redhat.com'
+    environment: 'e2e-tests'
+    notifications:
+      durationBeforeNotificationDeletion: '5s'
+    registrationService:
+      environment: 'e2e-tests'
+      verification:
+        enabled: true
+        excludedEmailDomains: 'redhat.com'
+        secret:
+          ref: 'host-operator-secret'
+          twilioAccountSID: 'twilio.account.sid'
+          twilioAuthToken: 'twilio.auth.token'
+          twilioFromNumber: 'twilio.from_number'
+    toolchainStatus:
+      toolchainStatusRefreshTime: '1s'
+  members:
+    default:
+      autoscaler:
+        deploy: false
+      memberStatus:
+        refreshPeriod: "1s"

--- a/make/appstudio.mk
+++ b/make/appstudio.mk
@@ -1,0 +1,10 @@
+.PHONY: appstudio-dev-deploy-latest
+appstudio-dev-deploy-latest: DEV_ENVIRONMENT=appstudio-dev
+appstudio-dev-deploy-latest: dev-deploy-latest
+
+.PHONY: appstudio-e2e-deploy-latest
+appstudio-e2e-deploy-latest: DEV_ENVIRONMENT=appstudio-e2e
+appstudio-e2e-deploy-latest: dev-deploy-latest
+
+.PHONY: appstudio-cleanup
+appstudio-cleanup: clean-dev-resources

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -11,18 +11,40 @@ clean:
 ##    * all usersignups including user namespaces
 clean-users:
 	$(Q)-oc delete usersignups --all --all-namespaces
+	$(Q)-oc delete spaces --all --all-namespaces
 	$(Q)-oc wait --for=delete namespaces -l toolchain.dev.openshift.com/provider=codeready-toolchain
 
-.PHONY: clean-e2e-resources
-## Delete resources in the OpenShift cluster. The deleted resources are:
-##    * all resources created by both host and member operators in all namespaces including user namespaces
-##    * operator namespaces created during both the dev and e2e test setup (for both operators host and member)
-##    * all CatalogSources that were created as part of operator deployment
-clean-e2e-resources: clean-users
-	$(Q)-oc get projects --output=name | grep -E "toolchain-(member|host)(\-operator)?(\-[0-9]+)?" | xargs oc delete
+.PHONY: clean-cluster-wide-config
+## Delete all cluster-wide configuration resources like PriorityClass, MutatingWebhookConfiguration, and ClusterRoleBinding for e2e SA
+clean-cluster-wide-config:
 	$(Q)-oc get ClusterRoleBinding -o name | grep e2e-service-account | xargs oc delete
 	$(Q)-oc delete PriorityClass -l='toolchain.dev.openshift.com/provider=codeready-toolchain'
 	$(Q)-oc delete MutatingWebhookConfiguration -l='toolchain.dev.openshift.com/provider=codeready-toolchain'
+
+.PHONY: clean-toolchain-namespaces-in-e2e
+## Delete e2e namespaces
+clean-toolchain-namespaces-in-e2e:
+	$(Q)-oc get projects --output=name | grep -E "toolchain-(member|host)(\-operator)?(\-[0-9]+)?" | xargs oc delete
+
+.PHONY: clean-e2e-resources
+## Delete resources in the OpenShift cluster. The deleted resources are:
+##    * all user-related resources
+##    * operator namespaces created during both the dev and e2e test setup (for both operators host and member)
+##    * cluster-wide config
+clean-e2e-resources: clean-users clean-toolchain-namespaces-in-e2e clean-cluster-wide-config
+
+.PHONY: clean-toolchain-namespaces-in-dev
+## Delete dev namespaces
+clean-toolchain-namespaces-in-dev:
+	$(Q)oc delete namespace ${DEV_HOST_NS} || true
+	$(Q)oc delete namespace ${DEV_MEMBER_NS} || true
+
+.PHONY: clean-dev-resources
+## Delete resources in the OpenShift cluster. The deleted resources are:
+##    * all user-related resources
+##    * operator namespaces created during both the dev and e2e test setup (for both operators host and member)
+##    * cluster-wide config
+clean-dev-resources: clean-users clean-toolchain-namespaces-in-dev clean-cluster-wide-config
 
 .PHONY: clean-e2e-files
 ## Remove files and directories used during e2e test setup
@@ -30,29 +52,19 @@ clean-e2e-files:
 	rm -f ${WAS_ALREADY_PAIRED_FILE} 2>/dev/null || true
 	rm -rf ${IMAGE_NAMES_DIR} 2>/dev/null || true
 
-.PHONY: clean-toolchain-resources-in-dev
+.PHONY: clean-all-toolchain-resources
 ## Delete resources in the OpenShift cluster. The deleted resources are:
 ##    * all toolchain.dev.openshift.com CRs in both host and member namespaces created during the dev setup
 ##    * all ClusterresourceQuotas with the label toolchain.dev.openshift.com/provider=codeready-toolchain in member namespace
-##    * pods of both operators host and member
-clean-toolchain-resources-in-dev:
-	$(Q)echo "cleaning resources in $(DEV_HOST_NS) and $(DEV_MEMBER_NS)..."
-	$(Q)oc get usersignups -n $(DEV_HOST_NS) -o name | xargs -i oc delete -n $(DEV_HOST_NS) {}
+clean-all-toolchain-resources:
+	$(Q)echo "cleaning resources"
+	$(Q)oc delete usersignups --all --all-namespaces
 	$(Q)for CRD in `oc get crd -o name | grep toolchain`; do \
-		echo "deleting $${CRD} in $(DEV_HOST_NS) and $(DEV_MEMBER_NS)"; \
+		echo "deleting $${CRD}"; \
 		CRD_NAME=`oc get $${CRD} --template '{{.metadata.name}}'`; \
-		oc get $${CRD_NAME} -n $(DEV_HOST_NS) -o name | xargs -i oc delete {}; \
-		oc get $${CRD_NAME} -n $(DEV_MEMBER_NS) -o name | xargs -i oc delete {}; \
+		oc delete $${CRD_NAME} --all --all-namespaces; \
 	done
-	$(Q)oc get clusterresourcequotas -l "toolchain.dev.openshift.com/provider"=codeready-toolchain -o name -n $(DEV_MEMBER_NS) | xargs -i oc delete {}
-	$(Q)oc get pods -n $(DEV_HOST_NS) -l name=host-operator -o name | xargs -i oc delete -n $(DEV_HOST_NS) {}
-	$(Q)oc get pods -n $(DEV_MEMBER_NS) -l name=member-operator -o name | xargs -i oc delete -n $(DEV_MEMBER_NS) {}
-
-.PHONY: clean-toolchain-namespaces-in-dev
-## Delete dev namespaces
-clean-toolchain-namespaces-in-dev:
-	$(Q)oc delete namespace ${DEV_HOST_NS} || true
-	$(Q)oc delete namespace ${DEV_MEMBER_NS} || true
+	$(Q)oc get clusterresourcequotas -l "toolchain.dev.openshift.com/provider"=codeready-toolchain --all --all-namespaces
 
 .PHONY: clean-toolchain-crds
 ## Delete all Toolchain CRDs

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -12,7 +12,7 @@ clean:
 clean-users:
 	$(Q)-oc delete usersignups --all --all-namespaces
 	$(Q)-oc delete spaces --all --all-namespaces
-	$(Q)-oc wait --for=delete namespaces -l toolchain.dev.openshift.com/provider=codeready-toolchain
+	$(Q)-oc wait --for=delete namespaces -l toolchain.dev.openshift.com/type
 
 .PHONY: clean-cluster-wide-config
 ## Delete all cluster-wide configuration resources like PriorityClass, MutatingWebhookConfiguration, and ClusterRoleBinding for e2e SA

--- a/make/test.mk
+++ b/make/test.mk
@@ -229,6 +229,8 @@ create-host-resources:
 		echo "{\"spec\":{\"members\":{\"specificPerMemberCluster\":{\"member-$${TOOLCHAIN_CLUSTER_NAME}2\":{\"webhook\":{\"deploy\":false}}}}}}" > $$PATCH_FILE; \
 		oc patch toolchainconfig config -n $(HOST_NS) --type=merge --patch "$$(cat $$PATCH_FILE)"; \
 	fi;
+	# delete registration-service pods in case they already exist
+	oc delete pods --namespace ${HOST_NS} -l name=registration-service || true
 
 .PHONY: create-project
 create-project:


### PR DESCRIPTION
introduce: 
* appstudio-e2e environment config YAML files
* appstudio-e2e-deploy-latest target that deploys the latest toolchain operators in appstudio-e2e environment
* deletion of registration-service pods after the `ToolchainConfig` CR is created - this is for the case when we would run for example `appstudio-dev-deploy-latest` & `appstudio-e2e-deploy-latest` after each other, without cleaning the namespaces.

refactoring:
* move all appstudio related targets to `appstudio.mk`
* a few changes in the `clean.mk` to make it more flexible and reusable 

Fixes:
* the way we get the registration page URL - the `$(eval ROUTE = $(shell ` is evaluated at the very beginning when the target was called, so if it wasn't available at that time, then the echo would print only `Access the Landing Page here: https://`
* add deletion of the Spaces to the `clean-users` target

