### PR TITLE
fix: GetMasterUserRecord returns err when not found (without diff print)

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -138,10 +138,10 @@ func TestE2EFlow(t *testing.T) {
 	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "base")
 	VerifyResourcesProvisionedForSignup(t, awaitilities, originalSubJohnSignup, "base")
 
-	johnsmithMur, err := hostAwait.GetMasterUserRecord(wait.WithMurName(johnsmithName))
+	johnsmithMur, err := hostAwait.GetMasterUserRecord(johnsmithName)
 	require.NoError(t, err)
 
-	targetedJohnMur, err := hostAwait.GetMasterUserRecord(wait.WithMurName(targetedJohnName))
+	targetedJohnMur, err := hostAwait.GetMasterUserRecord(targetedJohnName)
 	require.NoError(t, err)
 
 	t.Run("try to break UserAccount", func(t *testing.T) {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -83,7 +83,7 @@ func TestProxyFlow(t *testing.T) {
 			user.token = req.GetToken()
 
 			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "appstudio")
-			_, err := hostAwait.GetMasterUserRecord(wait.WithMurName(user.username))
+			_, err := hostAwait.GetMasterUserRecord(user.username)
 			require.NoError(t, err)
 
 			t.Run("use proxy to create a configmap in the user appstudio namespace via proxy API and use websocket to watch it created", func(t *testing.T) {

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -425,9 +425,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 
 		// Confirm that the user is banned
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueBanned, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
-		mur, err := hostAwait.GetMasterUserRecord(wait.WithMurName("testuser" + id))
-		require.NoError(s.T(), err)
-		assert.Nil(s.T(), mur)
+		err = hostAwait.WaitUntilMasterUserRecordDeleted("testuser" + id)
 		require.NoError(s.T(), err)
 
 	})

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -162,19 +162,12 @@ func (a *HostAwaitility) WaitForMasterUserRecord(name string, criteria ...Master
 	return mur, err
 }
 
-func (a *HostAwaitility) GetMasterUserRecord(criteria ...MasterUserRecordWaitCriterion) (*toolchainv1alpha1.MasterUserRecord, error) {
-	murList := &toolchainv1alpha1.MasterUserRecordList{}
-	if err := a.Client.List(context.TODO(), murList, client.InNamespace(a.Namespace)); err != nil {
+func (a *HostAwaitility) GetMasterUserRecord(name string) (*toolchainv1alpha1.MasterUserRecord, error) {
+	mur := &toolchainv1alpha1.MasterUserRecord{}
+	if err := a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, name), mur); err != nil {
 		return nil, err
 	}
-	for _, mur := range murList.Items {
-		if matchMasterUserRecordWaitCriterion(&mur, criteria...) {
-			return &mur, nil
-		}
-	}
-	// no match found, print the diffs
-	a.printMasterUserRecordWaitCriterionDiffs(&toolchainv1alpha1.MasterUserRecord{}, criteria...)
-	return nil, nil
+	return mur, nil
 }
 
 // UpdateMasterUserRecordSpec tries to update the Spec of the given MasterUserRecord

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -135,7 +135,7 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitCriterion {
 	return UserAccountWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.UserAccount) bool {
-			mur, err := hostAwaitility.GetMasterUserRecord(WithMurName(actual.Name))
+			mur, err := hostAwaitility.GetMasterUserRecord(actual.Name)
 			if err != nil {
 				return false
 			}
@@ -144,7 +144,7 @@ func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitC
 				reflect.DeepEqual(actual.Spec.UserAccountSpecBase, mur.Spec.UserAccounts[0].Spec.UserAccountSpecBase)
 		},
 		Diff: func(actual *toolchainv1alpha1.UserAccount) string {
-			mur, err := hostAwaitility.GetMasterUserRecord(WithMurName(actual.Name))
+			mur, err := hostAwaitility.GetMasterUserRecord(actual.Name)
 			if err != nil {
 				return fmt.Sprintf("could not find mur for user account '%s'", actual.Name)
 			}


### PR DESCRIPTION
GetMasterUserRecord:
* returns an error when the MUR is not found
* accepts only name (as this is the only case when it's being used)
* it doesn't print any diff as it's not needed