### PR TITLE
feat: add SHOW_CLEAN_COMMAND var

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -4,6 +4,8 @@ DEV_HOST_NS := toolchain-host-operator
 DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 
+SHOW_CLEAN_COMMAND="make clean-dev-resources"
+
 .PHONY: dev-deploy-e2e
 ## Deploy the resources with one member operator instance
 dev-deploy-e2e: deploy-e2e-to-dev-namespaces print-reg-service-link
@@ -53,7 +55,7 @@ print-reg-service-link:
 	done
 	@echo ""
 	@echo Access the Landing Page here: https://$$(oc get routes registration-service -n ${DEV_REGISTRATION_SERVICE_NS} -o=jsonpath='{.spec.host}')
-	@echo "To clean the cluster run 'make clean-e2e-resources'"
+	@echo "To clean the cluster run '${SHOW_CLEAN_COMMAND}'"
 	@echo ""
 
 .PHONY: dev-deploy-e2e-member-local


### PR DESCRIPTION
our makefile targets will be executed from https://github.com/redhat-appstudio/infra-deployments and since the targets print clean command at the end of the execution, it would be good to customize it to avoid any confusion.
The usage:
```
make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-e2e-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup"
```