### PR TITLE
check proxyURL is populated in signup response

### DIFF
--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -578,6 +578,7 @@ func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username
 	require.NoError(s.T(), err)
 	require.True(s.T(), found)
 	assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
+	assert.Equal(s.T(), hostAwait.APIProxyURL, mp["proxyURL"])
 }
 
 func (s *registrationServiceTestSuite) assertGetSignupStatusPendingApproval(username, bearerToken string) {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -3,6 +3,7 @@ package testsupport
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +69,9 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 	apiRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
 	require.NoError(t, err)
 	hostAwait.APIProxyURL = fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path)
+	if strings.HasSuffix(hostAwait.APIProxyURL, "/") {
+		hostAwait.APIProxyURL = hostAwait.APIProxyURL[:len(hostAwait.APIProxyURL)-1]
+	}
 
 	// wait for member operators to be ready
 	memberAwait := getMemberAwaitility(t, cl, hostAwait, memberNs)


### PR DESCRIPTION
e2e test for https://issues.redhat.com/browse/CRT-1396
related PR: https://github.com/codeready-toolchain/registration-service/pull/242