### PR TITLE
feat: clean objects in parallel

### DIFF
--- a/testsupport/cleanup/clean.go
+++ b/testsupport/cleanup/clean.go
@@ -1,0 +1,169 @@
+package cleanup
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultRetryInterval = time.Millisecond * 100 // make it short because a "retry interval" is waited before the first test
+	defaultTimeout       = time.Second * 60
+)
+
+var (
+	propagationPolicy     = metav1.DeletePropagationForeground
+	propagationPolicyOpts = client.DeleteOption(&client.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	})
+)
+
+type cleanManager struct {
+	sync.RWMutex
+	cleanTasks []*cleanTask
+}
+
+var cleaning = &cleanManager{}
+
+// AddCleanTasks adds cleaning tasks for the given objects that will be automatically performed at the end of the test execution
+func AddCleanTasks(t *testing.T, cl client.Client, objects ...client.Object) {
+	cleaning.addCleanTasks(t, cl, objects...)
+}
+
+func (c *cleanManager) addCleanTasks(t *testing.T, cl client.Client, objects ...client.Object) {
+	c.Lock()
+	defer c.Unlock()
+	for _, obj := range objects {
+		if len(c.cleanTasks) == 0 {
+			t.Cleanup(c.clean())
+		}
+		c.cleanTasks = append(c.cleanTasks, newCleanTask(t, cl, obj))
+	}
+}
+
+// ExecuteAllCleanTasks triggers cleanup of all resources that were marked to be cleaned before that
+func ExecuteAllCleanTasks() {
+	cleaning.clean()()
+}
+
+func (c *cleanManager) clean() func() {
+	return func() {
+		c.Lock()
+		defer c.Unlock()
+		var wg sync.WaitGroup
+		for _, task := range c.cleanTasks {
+			wg.Add(1)
+			go func(cleanTask *cleanTask) {
+				defer wg.Done()
+				cleanTask.clean()
+			}(task)
+		}
+		wg.Wait()
+		c.cleanTasks = nil
+	}
+}
+
+type cleanTask struct {
+	sync.Once
+	objToClean client.Object
+	client     client.Client
+	t          *testing.T
+}
+
+func (c *cleanTask) clean() {
+	c.Do(c.cleanObject)
+}
+func newCleanTask(t *testing.T, cl client.Client, obj client.Object) *cleanTask {
+	return &cleanTask{
+		t:          t,
+		client:     cl,
+		objToClean: obj,
+	}
+}
+
+func (c *cleanTask) cleanObject() {
+	if c.objToClean == nil {
+		return
+	}
+	objToClean, ok := c.objToClean.DeepCopyObject().(client.Object)
+	require.True(c.t, ok)
+	userSignup, isUserSignup := c.objToClean.(*toolchainv1alpha1.UserSignup)
+	kind := objToClean.GetObjectKind().GroupVersionKind().Kind
+	if kind == "" {
+		kind = reflect.TypeOf(c.objToClean).Elem().Name()
+	}
+	c.t.Logf("deleting %s: %s ...", kind, objToClean.GetName())
+	if err := c.client.Delete(context.TODO(), objToClean, propagationPolicyOpts); err != nil {
+		if errors.IsNotFound(err) {
+			// if the object was UserSignup, then let's check that the MUR was deleted as well
+			deleted, err := c.verifyMurDeleted(isUserSignup, userSignup, true)
+			require.NoError(c.t, err)
+			// either if it was deleted or if it wasn't UserSignup, then return here
+			if deleted {
+				c.t.Logf("%s: %s was already deleted", kind, objToClean.GetName())
+				return
+			}
+		}
+	}
+
+	// wait until deletion is done
+	c.t.Logf("waiting until %s: %s is completely deleted", kind, objToClean.GetName())
+	require.NoError(c.t, wait.Poll(defaultRetryInterval, defaultTimeout, func() (done bool, err error) {
+		if err := c.client.Get(context.TODO(), test.NamespacedName(objToClean.GetNamespace(), objToClean.GetName()), objToClean); err != nil {
+			if errors.IsNotFound(err) {
+				// if the object was UserSignup, then let's check that the MUR is deleted as well
+				if deleted, err := c.verifyMurDeleted(isUserSignup, userSignup, false); !deleted || err != nil {
+					return false, err
+				}
+				return true, nil
+			}
+			c.t.Logf("problem with getting the related %s '%s': %s", kind, objToClean.GetName(), err)
+			return false, err
+		}
+		return false, nil
+	}))
+}
+
+func (c *cleanTask) verifyMurDeleted(isUserSignup bool, userSignup *toolchainv1alpha1.UserSignup, delete bool) (bool, error) {
+	// only applicable for UserSignups with compliant username set
+	if isUserSignup {
+		if userSignup.Status.CompliantUsername != "" {
+			mur := &toolchainv1alpha1.MasterUserRecord{}
+			if err := c.client.Get(context.TODO(), test.NamespacedName(userSignup.GetNamespace(), userSignup.Status.CompliantUsername), mur); err != nil {
+				// if MUR is not found then we are good
+				if errors.IsNotFound(err) {
+					c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
+					return true, nil
+				}
+				c.t.Logf("problem with getting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)
+				return false, err
+			}
+			if delete {
+				c.t.Logf("deleting also the related MasterUserRecord: %s", userSignup.Status.CompliantUsername)
+				if err := c.client.Delete(context.TODO(), mur, propagationPolicyOpts); err != nil {
+					if errors.IsNotFound(err) {
+						c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
+						return true, nil
+					}
+					c.t.Logf("problem with deleting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)
+					return false, err
+				}
+			}
+			c.t.Logf("waiting until MasterUserRecord: %s is completely deleted", userSignup.Status.CompliantUsername)
+			return false, nil
+		}
+		c.t.Logf("the UserSignup %s doesn't have CompliantUsername set", userSignup.Name)
+		return true, nil
+	}
+	return true, nil
+}

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -12,6 +12,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/require"
@@ -260,7 +261,7 @@ func (r *signupRequest) Execute() SignupRequest {
 	// We also need to ensure that the UserSignup is deleted at the end of the test (if the test itself doesn't delete it)
 	// and if cleanup hasn't been disabled
 	if !r.cleanupDisabled {
-		hostAwait.Cleanup(r.userSignup)
+		cleanup.AddCleanTasks(hostAwait.T, hostAwait.Client, r.userSignup)
 	}
 
 	return r

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,10 +13,10 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/metrics"
 
 	routev1 "github.com/openshift/api/route/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,7 +51,6 @@ type Awaitility struct {
 	RetryInterval time.Duration
 	Timeout       time.Duration
 	MetricsURL    string
-	toClean       []func()
 }
 
 // ReadyToolchainCluster is a ClusterCondition that represents cluster that is ready
@@ -463,121 +461,13 @@ func (a *Awaitility) CreateWithCleanup(ctx context.Context, obj client.Object, o
 	if err := a.Client.Create(ctx, obj, opts...); err != nil {
 		return err
 	}
-	a.Cleanup(obj)
+	cleanup.AddCleanTasks(a.T, a.Client, obj)
 	return nil
-}
-
-var (
-	propagationPolicy     = metav1.DeletePropagationForeground
-	propagationPolicyOpts = client.DeleteOption(&client.DeleteOptions{
-		PropagationPolicy: &propagationPolicy,
-	})
-)
-
-// Cleanup schedules removal of the given objects at the end of the current test
-func (a *Awaitility) Cleanup(objects ...client.Object) {
-	for _, obj := range objects {
-		userSignup, isUserSignup := obj.(*toolchainv1alpha1.UserSignup)
-		objToClean, ok := obj.DeepCopyObject().(client.Object)
-		require.True(a.T, ok)
-		cleanup := func() {
-			kind := objToClean.GetObjectKind().GroupVersionKind().Kind
-			if kind == "" {
-				kind = reflect.TypeOf(obj).Elem().Name()
-			}
-			a.T.Logf("deleting %s: %s ...", kind, objToClean.GetName())
-			if err := a.Client.Delete(context.TODO(), objToClean, propagationPolicyOpts); err != nil {
-				if errors.IsNotFound(err) {
-					// if the object was UserSignup, then let's check that the MUR was deleted as well
-					deleted, err := a.verifyMurDeleted(isUserSignup, userSignup, true)
-					require.NoError(a.T, err)
-					// either if it was deleted or if it wasn't UserSignup, then return here
-					if deleted {
-						a.T.Logf("%s: %s was already deleted", kind, objToClean.GetName())
-						return
-					}
-				}
-			}
-
-			// wait until deletion is done
-			a.T.Logf("waiting until %s: %s is completely deleted", kind, objToClean.GetName())
-			require.NoError(a.T, wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-				if err := a.Client.Get(context.TODO(), test.NamespacedName(objToClean.GetNamespace(), objToClean.GetName()), objToClean); err != nil {
-					if errors.IsNotFound(err) {
-						// if the object was UserSignup, then let's check that the MUR is deleted as well
-						if deleted, err := a.verifyMurDeleted(isUserSignup, userSignup, false); !deleted || err != nil {
-							return false, err
-						}
-						return true, nil
-					}
-					a.T.Logf("problem with getting the related %s '%s': %s", kind, objToClean.GetName(), err)
-					return false, err
-				}
-				fmt.Print(".")
-				return false, nil
-			}))
-		}
-		a.toClean = append(a.toClean, cleanup)
-		a.T.Cleanup(cleanup)
-	}
-}
-
-func (a *Awaitility) verifyMurDeleted(isUserSignup bool, userSignup *toolchainv1alpha1.UserSignup, delete bool) (bool, error) {
-	// only applicable for UserSignups with compliant username set
-	if isUserSignup {
-		if userSignup.Status.CompliantUsername != "" {
-			mur := &toolchainv1alpha1.MasterUserRecord{}
-			if err := a.Client.Get(context.TODO(), test.NamespacedName(userSignup.GetNamespace(), userSignup.Status.CompliantUsername), mur); err != nil {
-				// if MUR is not found then we are good
-				if errors.IsNotFound(err) {
-					a.T.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
-					return true, nil
-				}
-				a.T.Logf("problem with getting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)
-				return false, err
-			}
-			if delete {
-				a.T.Logf("deleting also the related MasterUserRecord: %s", userSignup.Status.CompliantUsername)
-				if err := a.Client.Delete(context.TODO(), mur, propagationPolicyOpts); err != nil {
-					if errors.IsNotFound(err) {
-						a.T.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
-						return true, nil
-					}
-					a.T.Logf("problem with deleting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)
-					return false, err
-				}
-			}
-			a.T.Logf("waiting until MasterUserRecord: %s is completely deleted", userSignup.Status.CompliantUsername)
-			return false, nil
-		}
-		a.T.Logf("the UserSignup doesn't have CompliantUsername set")
-		return true, nil
-	}
-	return true, nil
 }
 
 // Clean triggers cleanup of all resources that were marked to be cleaned before that
 func (a *Awaitility) Clean() {
-	for _, clean := range a.toClean {
-		clean()
-	}
-	if a.Type == cluster.Host {
-		require.NoError(a.T, wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-			murList := &toolchainv1alpha1.MasterUserRecordList{}
-			if err := a.Client.List(context.TODO(), murList, client.InNamespace(a.Namespace)); err != nil {
-				return false, err
-			}
-			for _, mur := range murList.Items {
-				if util.IsBeingDeleted(&mur) {
-					a.T.Logf("there is still at least one MUR that is being deleted, but is not completely gone yet: %s", mur.Name)
-					return false, nil
-				}
-			}
-			a.T.Logf("all MURs are successfully deleted")
-			return true, nil
-		}))
-	}
-	a.toClean = nil
+	cleanup.ExecuteAllCleanTasks()
 }
 
 func (a *Awaitility) listAndPrint(resourceKind, namespace string, list client.ObjectList, additionalOptions ...client.ListOption) {


### PR DESCRIPTION
This PR refactors and improves the cleanup of the resources (that is performed at the end of each test) so it is executed in parallel - this change decreases the overall test execution by a few minutes. 