### PR TITLE
feat: run initialization of awaitilities only once

### DIFF
--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,83 +26,93 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	hostAwait    *wait.HostAwaitility
+	memberAwait  *wait.MemberAwaitility
+	member2Await *wait.MemberAwaitility
+	doOnce       sync.Once
+)
+
 // WaitForDeployments initializes test context, registers schemes and waits until both operators (host, member)
 // and corresponding ToolchainCluster CRDs are present, running and ready. Based on the given cluster type
 // that represents the current operator that is the target of the e2e test it retrieves namespace names.
 // Also waits for the registration service to be deployed (with 3 replica)
 // Returns the test context and an instance of Awaitility that contains all necessary information
 func WaitForDeployments(t *testing.T) wait.Awaitilities {
-	memberNs := os.Getenv(wait.MemberNsVar)
-	memberNs2 := os.Getenv(wait.MemberNsVar2)
-	hostNs := os.Getenv(wait.HostNsVar)
-	registrationServiceNs := os.Getenv(wait.RegistrationServiceVar)
+	doOnce.Do(func() {
+		memberNs := os.Getenv(wait.MemberNsVar)
+		memberNs2 := os.Getenv(wait.MemberNsVar2)
+		hostNs := os.Getenv(wait.HostNsVar)
+		registrationServiceNs := os.Getenv(wait.RegistrationServiceVar)
 
-	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-	require.NoError(t, err)
-	kubeconfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
-	require.NoError(t, err)
+		apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+		require.NoError(t, err)
+		kubeconfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+		require.NoError(t, err)
 
-	cl, err := client.New(kubeconfig, client.Options{
-		Scheme: schemeWithAllAPIs(t),
+		cl, err := client.New(kubeconfig, client.Options{
+			Scheme: schemeWithAllAPIs(t),
+		})
+		require.NoError(t, err)
+
+		hostAwait = wait.NewHostAwaitility(t, kubeconfig, cl, hostNs, registrationServiceNs)
+
+		// wait for host operator to be ready
+		hostAwait.WaitForDeploymentToGetReady("host-operator-controller-manager", 1)
+
+		// wait for registration service to be ready
+		hostAwait.WaitForDeploymentToGetReady("registration-service", 2)
+
+		// set registration service values
+		registrationServiceRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "registration-service", "/")
+		require.NoError(t, err, "failed while waiting for registration service route")
+
+		registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host
+		if registrationServiceRoute.Spec.TLS != nil {
+			registrationServiceURL = "https://" + registrationServiceRoute.Spec.Host
+		}
+		hostAwait.RegistrationServiceURL = registrationServiceURL
+
+		// set api proxy values
+		// hostAwait.APIProxyURL = hostAwait.GetAPIProxyURL()
+		apiRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
+		require.NoError(t, err)
+		hostAwait.APIProxyURL = fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path)
+		if strings.HasSuffix(hostAwait.APIProxyURL, "/") {
+			hostAwait.APIProxyURL = hostAwait.APIProxyURL[:len(hostAwait.APIProxyURL)-1]
+		}
+
+		// wait for member operators to be ready
+		memberAwait = getMemberAwaitility(t, cl, hostAwait, memberNs)
+
+		member2Await = getMemberAwaitility(t, cl, hostAwait, memberNs2)
+
+		hostToolchainCluster, err := memberAwait.WaitForToolchainClusterWithCondition("e2e", hostNs, wait.ReadyToolchainCluster)
+		require.NoError(t, err)
+		hostConfig, err := cluster.NewClusterConfig(cl, &hostToolchainCluster, 6*time.Second)
+		require.NoError(t, err)
+		hostAwait.RestConfig = hostConfig.RestConfig
+
+		// setup host metrics route for metrics verification in tests
+		hostMetricsRoute, err := hostAwait.SetupRouteForService("host-operator-metrics-service", "/metrics")
+		require.NoError(t, err)
+		hostAwait.MetricsURL = hostMetricsRoute.Status.Ingress[0].Host
+
+		// setup member metrics route for metrics verification in tests
+		memberMetricsRoute, err := memberAwait.SetupRouteForService("member-operator-metrics-service", "/metrics")
+		require.NoError(t, err, "failed while setting up or waiting for the route to the 'member-operator-metrics' service to be available")
+		memberAwait.MetricsURL = memberMetricsRoute.Status.Ingress[0].Host
+
+		_, err = memberAwait.WaitForToolchainClusterWithCondition(hostAwait.Type, hostAwait.Namespace, wait.ReadyToolchainCluster)
+		require.NoError(t, err)
+
+		_, err = member2Await.WaitForToolchainClusterWithCondition(hostAwait.Type, hostAwait.Namespace, wait.ReadyToolchainCluster)
+		require.NoError(t, err)
+
+		t.Log("all operators are ready and in running state")
 	})
-	require.NoError(t, err)
 
-	hostAwait := wait.NewHostAwaitility(t, kubeconfig, cl, hostNs, registrationServiceNs)
-
-	// wait for host operator to be ready
-	hostAwait.WaitForDeploymentToGetReady("host-operator-controller-manager", 1)
-
-	// wait for registration service to be ready
-	hostAwait.WaitForDeploymentToGetReady("registration-service", 2)
-
-	// set registration service values
-	registrationServiceRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "registration-service", "/")
-	require.NoError(t, err, "failed while waiting for registration service route")
-
-	registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host
-	if registrationServiceRoute.Spec.TLS != nil {
-		registrationServiceURL = "https://" + registrationServiceRoute.Spec.Host
-	}
-	hostAwait.RegistrationServiceURL = registrationServiceURL
-
-	// set api proxy values
-	// hostAwait.APIProxyURL = hostAwait.GetAPIProxyURL()
-	apiRoute, err := hostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
-	require.NoError(t, err)
-	hostAwait.APIProxyURL = fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path)
-	if strings.HasSuffix(hostAwait.APIProxyURL, "/") {
-		hostAwait.APIProxyURL = hostAwait.APIProxyURL[:len(hostAwait.APIProxyURL)-1]
-	}
-
-	// wait for member operators to be ready
-	memberAwait := getMemberAwaitility(t, cl, hostAwait, memberNs)
-
-	member2Await := getMemberAwaitility(t, cl, hostAwait, memberNs2)
-
-	hostToolchainCluster, err := memberAwait.WaitForToolchainClusterWithCondition("e2e", hostNs, wait.ReadyToolchainCluster)
-	require.NoError(t, err)
-	hostConfig, err := cluster.NewClusterConfig(cl, &hostToolchainCluster, 6*time.Second)
-	require.NoError(t, err)
-	hostAwait.RestConfig = hostConfig.RestConfig
-
-	// setup host metrics route for metrics verification in tests
-	hostMetricsRoute, err := hostAwait.SetupRouteForService("host-operator-metrics-service", "/metrics")
-	require.NoError(t, err)
-	hostAwait.MetricsURL = hostMetricsRoute.Status.Ingress[0].Host
-
-	// setup member metrics route for metrics verification in tests
-	memberMetricsRoute, err := memberAwait.SetupRouteForService("member-operator-metrics-service", "/metrics")
-	require.NoError(t, err, "failed while setting up or waiting for the route to the 'member-operator-metrics' service to be available")
-	memberAwait.MetricsURL = memberMetricsRoute.Status.Ingress[0].Host
-
-	_, err = memberAwait.WaitForToolchainClusterWithCondition(hostAwait.Type, hostAwait.Namespace, wait.ReadyToolchainCluster)
-	require.NoError(t, err)
-
-	_, err = member2Await.WaitForToolchainClusterWithCondition(hostAwait.Type, hostAwait.Namespace, wait.ReadyToolchainCluster)
-	require.NoError(t, err)
-
-	t.Log("all operators are ready and in running state")
-	return wait.NewAwaitilities(hostAwait, memberAwait, member2Await)
+	return wait.NewAwaitilities(hostAwait.ForTest(t), memberAwait.ForTest(t), member2Await.ForTest(t))
 }
 
 func getMemberAwaitility(t *testing.T, cl client.Client, hostAwait *wait.HostAwaitility, namespace string) *wait.MemberAwaitility {

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -53,6 +53,12 @@ type Awaitility struct {
 	MetricsURL    string
 }
 
+func (a *Awaitility) ForTest(t *testing.T) *Awaitility {
+	await := *a
+	await.T = t
+	return &await
+}
+
 // ReadyToolchainCluster is a ClusterCondition that represents cluster that is ready
 var ReadyToolchainCluster = &toolchainv1alpha1.ToolchainClusterCondition{
 	Type:   toolchainv1alpha1.ToolchainClusterReady,

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -63,6 +63,15 @@ func (a *HostAwaitility) WithRetryOptions(options ...RetryOption) *HostAwaitilit
 	}
 }
 
+func (a *HostAwaitility) ForTest(t *testing.T) *HostAwaitility {
+	return &HostAwaitility{
+		Awaitility:             a.Awaitility.ForTest(t),
+		RegistrationServiceNs:  a.RegistrationServiceNs,
+		RegistrationServiceURL: a.RegistrationServiceURL,
+		APIProxyURL:            a.APIProxyURL,
+	}
+}
+
 func (a *HostAwaitility) sprintAllResources() string {
 	all, err := a.allResources()
 	buf := &strings.Builder{}

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -65,6 +65,12 @@ func NewMemberAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns, c
 	}
 }
 
+func (a *MemberAwaitility) ForTest(t *testing.T) *MemberAwaitility {
+	return &MemberAwaitility{
+		Awaitility: a.Awaitility.ForTest(t),
+	}
+}
+
 func (a *MemberAwaitility) WithRetryOptions(options ...RetryOption) *MemberAwaitility {
 	return &MemberAwaitility{
 		Awaitility: a.Awaitility.WithRetryOptions(options...),


### PR DESCRIPTION
It makes sure that the initialization of the awaitilities is executed only once. It decreases the overall test execution by 4-5 minutes.