### PR TITLE
refactor: extract some functions to make it available outside of the e2e package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	honnef.co/go/tools v0.0.1-2020.1.6 // indirect
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
@@ -35,5 +34,7 @@ require (
 	k8s.io/metrics v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220118183120-7037f272026f
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0
@@ -34,7 +34,5 @@ require (
 	k8s.io/metrics v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvo
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.1.0 h1:j7GpgZ7PdFqNsmncycTHsLmVPf5/3wJtlgW9TNDYD9Y=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
-github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df h1:ls6/74C2mDHyo7wkeSC1CiajnhofOmDzupb9P7jQj0E=
-github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df/go.mod h1:4qzQR2EDx/JVGVAGnyjyvRafDe2KesPUCrh/XdY9F5w=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -116,6 +114,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574 h1:xjmJjUvjGOW42y4Wd/l6qHkoRAfNiQ5C6PbCWUlXqoo=
 github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220118183120-7037f272026f h1:h0ffai1jpjKcEBXtHnFVZW5GuCK71ULBoJAaKV8oERk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220118183120-7037f272026f/go.mod h1:4qzQR2EDx/JVGVAGnyjyvRafDe2KesPUCrh/XdY9F5w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvo
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.1.0 h1:j7GpgZ7PdFqNsmncycTHsLmVPf5/3wJtlgW9TNDYD9Y=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
+github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df h1:ls6/74C2mDHyo7wkeSC1CiajnhofOmDzupb9P7jQj0E=
+github.com/MatousJobanek/toolchain-common v0.0.0-20220118175315-c78f396a70df/go.mod h1:4qzQR2EDx/JVGVAGnyjyvRafDe2KesPUCrh/XdY9F5w=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -114,8 +116,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574 h1:xjmJjUvjGOW42y4Wd/l6qHkoRAfNiQ5C6PbCWUlXqoo=
 github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155 h1:pgIv+T2J4BK4BvxJCIkcqeuk8Xsrq2n8VG4UspRYEhs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220110102259-392256a24155/go.mod h1:6fAhxW0MpXz2KgrNT+12zodepWFqNSOJcy6H2Ip4kV8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -833,7 +833,6 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210521090106-6ca3eb03dfc2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1047,7 +1046,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -8,6 +8,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	testtier "github.com/codeready-toolchain/toolchain-common/pkg/test/tier"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -244,7 +245,7 @@ func setupSpaces(t *testing.T, awaitilities Awaitilities, tierName, nameFmt stri
 	// verify ice cream tier created successfully
 	tier, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(tierName)
 	require.NoError(t, err)
-	hash, err := tiers.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
+	hash, err := testtier.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
 	require.NoError(t, err)
 	t.Logf("NSTemplateTier hash is: %s", hash)
 
@@ -263,7 +264,7 @@ func createSpace(t *testing.T, awaitilities Awaitilities, tierName, name, hash s
 			Namespace: awaitilities.Host().Namespace,
 			Name:      name,
 			Labels: map[string]string{
-				tiers.TemplateTierHashLabelKey(tierName): hash,
+				testtier.TemplateTierHashLabelKey(tierName): hash,
 			},
 		},
 		Spec: toolchainv1alpha1.SpaceSpec{
@@ -277,7 +278,7 @@ func createSpace(t *testing.T, awaitilities Awaitilities, tierName, name, hash s
 
 	// then
 	require.NoError(t, err)
-	t.Logf("Space created - %s: %s", tiers.TemplateTierHashLabelKey(tierName), hash)
+	t.Logf("Space created - %s: %s", testtier.TemplateTierHashLabelKey(tierName), hash)
 	return space
 }
 

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -8,7 +8,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,11 +29,6 @@ func NewSpace(namespace, name, tierName string, targetCluster *wait.MemberAwaiti
 		space.Spec.TargetCluster = targetCluster.ClusterName
 	}
 	return space
-}
-
-// GenerateName appends generated UUID to the given string
-func GenerateName(prefix string) string {
-	return fmt.Sprintf("%s-%s", prefix, uuid.Must(uuid.NewV4()).String())
 }
 
 // VerifyResourcesProvisionedForSpaceWithTier verifies that the Space for the given name is provisioned with all needed labels and conditions.

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -31,8 +31,7 @@ func NewSpace(namespace, name, tierName string, targetCluster *wait.MemberAwaiti
 	return space
 }
 
-// VerifyResourcesProvisionedForSpaceWithTier verifies that the Space for the given name is provisioned with all needed labels and conditions.
-// It also checks the NSTemplateSet and all related namespace & cluster scoped resources
+// Same as VerifyResourcesProvisionedForSpaceWithTiers but reuses the provided tier name for the namespace and cluster resources names
 func VerifyResourcesProvisionedForSpaceWithTier(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, spaceName, tierName string) *toolchainv1alpha1.Space {
 	return VerifyResourcesProvisionedForSpaceWithTiers(t, awaitilities, targetCluster, spaceName, tierName, tierName, tierName)
 }

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -1,0 +1,95 @@
+package testsupport
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+// NewSpace initializes a new Space object with the given value. If the targetCluster is nil, then the Space.Spec.TargetCluster is not set.
+func NewSpace(namespace, name, tierName string, targetCluster *wait.MemberAwaitility) *toolchainv1alpha1.Space {
+	space := &toolchainv1alpha1.Space{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: toolchainv1alpha1.SpaceSpec{
+			TierName: tierName,
+		},
+	}
+	if targetCluster != nil {
+		space.Spec.TargetCluster = targetCluster.ClusterName
+	}
+	return space
+}
+
+// GenerateName appends generated UUID to the given string
+func GenerateName(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, uuid.Must(uuid.NewV4()).String())
+}
+
+// VerifyResourcesProvisionedForSpaceWithTier verifies that the Space for the given name is provisioned with all needed labels and conditions.
+// It also checks the NSTemplateSet and all related namespace & cluster scoped resources
+func VerifyResourcesProvisionedForSpaceWithTier(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, spaceName, tierName string) *toolchainv1alpha1.Space {
+	return VerifyResourcesProvisionedForSpaceWithTiers(t, awaitilities, targetCluster, spaceName, tierName, tierName, tierName)
+}
+
+// VerifyResourcesProvisionedForSpaceWithTiers verifies that the Space for the given name is provisioned with all needed labels and conditions.
+// It also checks the NSTemplateSet and that all related namespace-scoped resources are provisoned for the given aliasTierNamespaces, and cluster scoped resources for aliasTierClusterResources.
+func VerifyResourcesProvisionedForSpaceWithTiers(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, spaceName, tierName, aliasTierNamespaces, aliasTierClusterResources string) *toolchainv1alpha1.Space {
+	hostAwait := awaitilities.Host()
+
+	tier, err := hostAwait.WaitForNSTemplateTier(tierName)
+	require.NoError(t, err)
+	hash, err := tiers.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
+	require.NoError(t, err)
+
+	// wait for space to be fully provisioned
+	space, err := hostAwait.WaitForSpace(spaceName,
+		wait.UntilSpaceHasTier(tierName),
+		wait.UntilSpaceHasLabelWithValue(fmt.Sprintf("toolchain.dev.openshift.com/%s-tier-hash", tierName), hash),
+		wait.UntilSpaceHasConditions(Provisioned()),
+		wait.UntilSpaceHasStatusTargetCluster(targetCluster.ClusterName))
+	require.NoError(t, err)
+
+	// verify that there is only one toolchain.dev.openshift.com/<>-tier-hash label
+	found := false
+	for key := range space.GetLabels() {
+		if strings.HasPrefix(key, "toolchain.dev.openshift.com/") && strings.HasSuffix(key, "-tier-hash") {
+			if !found {
+				found = true
+			} else {
+				assert.FailNowf(t, "the space %s should have only one -tier-hash label, but has more of them: %v", space.Name, space.GetLabels())
+			}
+		}
+	}
+
+	// get refs & checks
+	templateRefs, namespacesChecks, clusterResourcesChecks := tiers.GetRefsAndChecksForTiers(t, hostAwait, tierName, aliasTierNamespaces, aliasTierClusterResources)
+
+	// get NSTemplateSet
+	nsTemplateSet, err := targetCluster.WaitForNSTmplSet(spaceName, wait.UntilNSTemplateSetHasTier(tierName), wait.UntilNSTemplateSetHasConditions(Provisioned()))
+	require.NoError(t, err)
+
+	// verify NSTemplateSet with namespace & cluster scoped resources
+	tiers.VerifyGivenNsTemplateSet(t, targetCluster, nsTemplateSet, namespacesChecks, clusterResourcesChecks, templateRefs)
+
+	if aliasTierNamespaces == "appstudio" {
+		// checks that namespace exists and has the expected label(s)
+		ns, err := targetCluster.WaitForNamespace(space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName)
+		require.NoError(t, err)
+		require.Contains(t, ns.Labels, toolchainv1alpha1.WorkspaceLabelKey)
+		assert.Equal(t, space.Name, ns.Labels[toolchainv1alpha1.WorkspaceLabelKey])
+	}
+
+	return space
+}

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	testtier "github.com/codeready-toolchain/toolchain-common/pkg/test/tier"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func VerifyResourcesProvisionedForSpaceWithTiers(t *testing.T, awaitilities wait
 
 	tier, err := hostAwait.WaitForNSTemplateTier(tierName)
 	require.NoError(t, err)
-	hash, err := tiers.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
+	hash, err := testtier.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
 	require.NoError(t, err)
 
 	// wait for space to be fully provisioned

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -46,6 +46,17 @@ var (
 	}
 )
 
+// GetRefsAndChecksForTiers returns refs for the given tierName, namespaceChecks for aliasTierNamespaces and CusterResourcesChecks for aliasTierClusterResources
+func GetRefsAndChecksForTiers(t *testing.T, hostAwait *wait.HostAwaitility, tierName, aliasTierNamespaces, aliasTierClusterResources string) (TemplateRefs, TierChecks, TierChecks) {
+	templateRefs := GetTemplateRefs(hostAwait, tierName)
+	namespacesChecks, err := NewChecks(aliasTierNamespaces)
+	require.NoError(t, err)
+	clusterResourcesChecks, err := NewChecks(aliasTierClusterResources)
+	require.NoError(t, err)
+
+	return templateRefs, namespacesChecks, clusterResourcesChecks
+}
+
 func NewChecks(tier string) (TierChecks, error) {
 	switch tier {
 	case base:

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -1,11 +1,6 @@
 package tiers
 
 import (
-	"crypto/md5"
-	"encoding/hex"
-	"encoding/json"
-	"sort"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
@@ -36,34 +31,4 @@ func clusterResourcesRevision(tier toolchainv1alpha1.NSTemplateTier) *string {
 		return &(tier.Spec.ClusterResources.TemplateRef)
 	}
 	return nil
-}
-
-// ComputeTemplateRefsHash computes the hash of the `.spec.namespaces[].templateRef` + `.spec.clusteResource.TemplateRef`
-func ComputeTemplateRefsHash(tier *toolchainv1alpha1.NSTemplateTier) (string, error) {
-	refs := []string{}
-	for _, ns := range tier.Spec.Namespaces {
-		refs = append(refs, ns.TemplateRef)
-	}
-	if tier.Spec.ClusterResources != nil {
-		refs = append(refs, tier.Spec.ClusterResources.TemplateRef)
-	}
-	sort.Strings(refs)
-	m, err := json.Marshal(templateRefs{Refs: refs})
-	if err != nil {
-		return "", err
-	}
-	md5hash := md5.New()
-	// Ignore the error, as this implementation cannot return one
-	_, _ = md5hash.Write(m)
-	hash := hex.EncodeToString(md5hash.Sum(nil))
-	return hash, nil
-}
-
-// TemplateTierHashLabel returns the label key to specify the version of the templates of the given tier
-func TemplateTierHashLabelKey(tierName string) string {
-	return toolchainv1alpha1.LabelKeyPrefix + tierName + "-tier-hash"
-}
-
-type templateRefs struct {
-	Refs []string `json:"refs"`
 }

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -1,6 +1,11 @@
 package tiers
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
@@ -31,4 +36,34 @@ func clusterResourcesRevision(tier toolchainv1alpha1.NSTemplateTier) *string {
 		return &(tier.Spec.ClusterResources.TemplateRef)
 	}
 	return nil
+}
+
+// ComputeTemplateRefsHash computes the hash of the `.spec.namespaces[].templateRef` + `.spec.clusteResource.TemplateRef`
+func ComputeTemplateRefsHash(tier *toolchainv1alpha1.NSTemplateTier) (string, error) {
+	refs := []string{}
+	for _, ns := range tier.Spec.Namespaces {
+		refs = append(refs, ns.TemplateRef)
+	}
+	if tier.Spec.ClusterResources != nil {
+		refs = append(refs, tier.Spec.ClusterResources.TemplateRef)
+	}
+	sort.Strings(refs)
+	m, err := json.Marshal(templateRefs{Refs: refs})
+	if err != nil {
+		return "", err
+	}
+	md5hash := md5.New()
+	// Ignore the error, as this implementation cannot return one
+	_, _ = md5hash.Write(m)
+	hash := hex.EncodeToString(md5hash.Sum(nil))
+	return hash, nil
+}
+
+// TemplateTierHashLabel returns the label key to specify the version of the templates of the given tier
+func TemplateTierHashLabelKey(tierName string) string {
+	return toolchainv1alpha1.LabelKeyPrefix + tierName + "-tier-hash"
+}
+
+type templateRefs struct {
+	Refs []string `json:"refs"`
 }

--- a/testsupport/util.go
+++ b/testsupport/util.go
@@ -1,0 +1,12 @@
+package testsupport
+
+import (
+	"fmt"
+
+	"github.com/gofrs/uuid"
+)
+
+// GenerateName appends generated UUID to the given string
+func GenerateName(prefix string) string {
+	return fmt.Sprintf("%s-%s", prefix, uuid.Must(uuid.NewV4()).String())
+}


### PR DESCRIPTION
This PR extracts some Space-related functions and makes them a bit more generic so they can be easily used in the migration tests