### PR TITLE
feat: introduce operator update tests

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -43,16 +43,16 @@ test-e2e-without-migration: prepare-e2e deploy-e2e e2e-run
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
 .PHONY: verify-migration-and-deploy-e2e
-verify-migration-and-deploy-e2e: prepare-projects e2e-deploy-latest e2e-service-account setup-toolchainclusters e2e-migration-first-run get-publish-and-install-operators e2e-migration-second-run
+verify-migration-and-deploy-e2e: prepare-projects e2e-deploy-latest e2e-service-account setup-toolchainclusters e2e-migration-setup get-publish-and-install-operators e2e-migration-verify
 
-.PHONY: e2e-migration-first-run
-e2e-migration-first-run:
+.PHONY: e2e-migration-setup
+e2e-migration-setup:
 	@echo "Setting up the environment before testing the operator migration..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/setup"
 	@echo "Environment successfully setup."
 
-.PHONY: e2e-migration-second-run
-e2e-migration-second-run:
+.PHONY: e2e-migration-verify
+e2e-migration-verify:
 	@echo "Updating operators and verifying resources..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/verify"
 	@echo "Migration tests successfully finished"

--- a/make/test.mk
+++ b/make/test.mk
@@ -38,7 +38,7 @@ test-e2e: prepare-e2e verify-migration-and-deploy-e2e e2e-run
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
 .PHONY: test-e2e-without-migration
-## Run the e2e tests with migration tests
+## Run the e2e tests without migration tests
 test-e2e-without-migration: prepare-e2e deploy-e2e e2e-run
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -47,7 +47,7 @@ cover-migration-and-deploy: prepare-projects e2e-deploy-latest e2e-service-accou
 
 .PHONY: e2e-migration-first-run
 e2e-migration-first-run:
-	@echo "Running before migration tests to setup the environment..."
+	@echo "Setting up the environment before testing the operator migration..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/setup"
 	@echo "Before migration tests successfuly finished."
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -49,7 +49,7 @@ cover-migration-and-deploy: prepare-projects e2e-deploy-latest e2e-service-accou
 e2e-migration-first-run:
 	@echo "Setting up the environment before testing the operator migration..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/setup"
-	@echo "Before migration tests successfuly finished."
+	@echo "Environment successfully setup."
 
 .PHONY: e2e-migration-second-run
 e2e-migration-second-run:

--- a/make/test.mk
+++ b/make/test.mk
@@ -55,7 +55,7 @@ e2e-migration-first-run:
 e2e-migration-second-run:
 	@echo "Updating operators and verifying resources..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/verify"
-	@echo "After migration tests successfuly finished"
+	@echo "Migration tests successfully finished"
 
 .PHONY: e2e-deploy-latest
 e2e-deploy-latest:

--- a/make/test.mk
+++ b/make/test.mk
@@ -33,7 +33,7 @@ SETUP_E2E_SERVICE_ACCOUNTS ?= true
 .PHONY: test-e2e
 ## Run the e2e tests
 test-e2e: INSTALL_OPERATOR=true
-test-e2e: prepare-e2e cover-migration-and-deploy e2e-run
+test-e2e: prepare-e2e verify-migration-and-deploy-e2e e2e-run
 	@echo "The tests successfully finished"
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
@@ -42,8 +42,8 @@ test-e2e: prepare-e2e cover-migration-and-deploy e2e-run
 test-e2e-without-migration: prepare-e2e deploy-e2e e2e-run
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
-.PHONY: cover-migration-and-deploy
-cover-migration-and-deploy: prepare-projects e2e-deploy-latest e2e-service-account setup-toolchainclusters e2e-migration-first-run get-publish-and-install-operators e2e-migration-second-run
+.PHONY: verify-migration-and-deploy-e2e
+verify-migration-and-deploy-e2e: prepare-projects e2e-deploy-latest e2e-service-account setup-toolchainclusters e2e-migration-first-run get-publish-and-install-operators e2e-migration-second-run
 
 .PHONY: e2e-migration-first-run
 e2e-migration-first-run:

--- a/make/test.mk
+++ b/make/test.mk
@@ -32,13 +32,41 @@ SETUP_E2E_SERVICE_ACCOUNTS ?= true
 
 .PHONY: test-e2e
 ## Run the e2e tests
-test-e2e: deploy-e2e e2e-run
+test-e2e: INSTALL_OPERATOR=true
+test-e2e: prepare-e2e cover-migration-and-deploy e2e-run
 	@echo "The tests successfully finished"
 	@echo "To clean the cluster run 'make clean-e2e-resources'"
 
+.PHONY: test-e2e-without-migration
+## Run the e2e tests with migration tests
+test-e2e-without-migration: prepare-e2e deploy-e2e e2e-run
+	@echo "To clean the cluster run 'make clean-e2e-resources'"
+
+.PHONY: cover-migration-and-deploy
+cover-migration-and-deploy: prepare-projects e2e-deploy-latest e2e-service-account setup-toolchainclusters e2e-migration-first-run get-publish-and-install-operators e2e-migration-second-run
+
+.PHONY: e2e-migration-first-run
+e2e-migration-first-run:
+	@echo "Running before migration tests to setup the environment..."
+	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/setup"
+	@echo "Before migration tests successfuly finished."
+
+.PHONY: e2e-migration-second-run
+e2e-migration-second-run:
+	@echo "Running after migration tests to verify that the migration was successful..."
+	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/verify"
+	@echo "After migration tests successfuly finished"
+
+.PHONY: e2e-deploy-latest
+e2e-deploy-latest:
+	$(MAKE) get-publish-and-install-operators MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} ENVIRONMENT=${ENVIRONMENT} INSTALL_OPERATOR=${INSTALL_OPERATOR} DEPLOY_LATEST=true
+
+.PHONY: prepare-e2e
+prepare-e2e: build clean-e2e-files
+
 .PHONY: deploy-e2e
 deploy-e2e: INSTALL_OPERATOR=true
-deploy-e2e: build clean-e2e-files label-olm-ns deploy-host deploy-members e2e-service-account setup-toolchainclusters
+deploy-e2e: prepare-projects get-publish-and-install-operators e2e-service-account setup-toolchainclusters
 	@echo "Operators are successfuly deployed using the ${ENVIRONMENT} environment."
 	@echo ""
 
@@ -74,9 +102,13 @@ test-e2e-registration-local:
 
 .PHONY: e2e-run
 e2e-run:
-	oc get toolchaincluster -n $(HOST_NS)
-	oc get toolchaincluster -n $(MEMBER_NS)
-	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ./test/e2e ./test/metrics -p 1 -v -timeout=90m -failfast || \
+	@echo "Running e2e tests..."
+	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/e2e ./test/metrics"
+	@echo "The e2e tests successfully finished"
+
+.PHONY: execute-tests
+execute-tests:
+	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -p 1 -v -timeout=90m -failfast || \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs
@@ -162,6 +194,9 @@ get-and-publish-operators: PUBLISH_OPERATOR=true
 get-and-publish-operators: INSTALL_OPERATOR=false
 get-and-publish-operators: clean-e2e-files get-and-publish-host-operator get-and-publish-member-operator
 
+.PHONY: get-publish-and-install-operators
+get-publish-and-install-operators: get-and-publish-host-operator create-host-resources get-and-publish-member-operator
+
 .PHONY: get-and-publish-member-operator
 get-and-publish-member-operator:
 ifneq (${MEMBER_NS_2},"")
@@ -196,19 +231,19 @@ endif
 #
 ###########################################################
 
-.PHONY: deploy-members
-deploy-members: create-member1 create-member2 get-and-publish-member-operator
+.PHONY: prepare-projects
+prepare-projects: label-olm-ns create-host-project create-member1 create-member2
 
 .PHONY: create-member1
 create-member1:
-	@echo "Deploying member operator to $(MEMBER_NS)..."
+	@echo "Preparing namespace for member operator: $(MEMBER_NS)..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS}
 	-oc label ns --overwrite=true ${MEMBER_NS} app=member-operator
 
 .PHONY: create-member2
 create-member2:
 ifeq ($(SECOND_MEMBER_MODE),true)
-	@echo "Deploying second member operator to ${MEMBER_NS_2}..."
+	@echo "Preparing namespace for second member operator: ${MEMBER_NS_2}..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS_2}
 	-oc label ns --overwrite=true ${MEMBER_NS_2} app=member-operator
 endif
@@ -218,7 +253,7 @@ deploy-host: create-host-project get-and-publish-host-operator create-host-resou
 
 .PHONY: create-host-project
 create-host-project:
-	@echo "Deploying host operator to ${HOST_NS}..."
+	@echo "Preparing namespace for host operator ${HOST_NS}..."
 	$(MAKE) create-project PROJECT_NAME=${HOST_NS}
 	-oc label ns --overwrite=true ${HOST_NS} app=host-operator
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -53,7 +53,7 @@ e2e-migration-first-run:
 
 .PHONY: e2e-migration-second-run
 e2e-migration-second-run:
-	@echo "Running after migration tests to verify that the migration was successful..."
+	@echo "Updating operators and verifying resources..."
 	$(MAKE) execute-tests MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} TESTS_TO_EXECUTE="./test/migration/verify"
 	@echo "After migration tests successfuly finished"
 

--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -1,0 +1,22 @@
+package setup
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-e2e/test/migration"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+)
+
+func TestSetupMigration(t *testing.T) {
+	// given
+	awaitilities := WaitForDeployments(t)
+
+	runner := migration.SetupMigrationRunner{
+		T:            t,
+		Awaitilities: awaitilities,
+		WithCleanup:  false,
+	}
+
+	runner.Run()
+
+}

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -1,0 +1,157 @@
+package migration
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	test "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ProvisionedUser             = "migration-provisioned"
+	DeactivatedUser             = "migration-deactivated"
+	BannedUser                  = "migration-banned-provisioned"
+	AppStudioProvisionedUser    = "migration-appstudio-provisioned"
+	SecondMemberProvisionedUser = "migration-second-member-provisioned-user"
+
+	ProvisionedAppStudioSpace    = "migration-appstudio-provisioned-space"
+	SecondMemberProvisionedSpace = "migration-second-member-provisioned-space"
+)
+
+type SetupMigrationRunner struct {
+	T            *testing.T
+	Awaitilities wait.Awaitilities
+	WithCleanup  bool
+}
+
+func (r *SetupMigrationRunner) Run() {
+	var wg sync.WaitGroup
+
+	toRun := []func(){
+		r.prepareAppStudioProvisionedSpace,
+		r.prepareSecondMemberProvisionedSpace,
+		r.prepareProvisionedUser,
+		r.prepareSecondMemberProvisionedUser,
+		r.prepareDeactivatedUser,
+		r.prepareBannedUser,
+		r.prepareAppStudioProvisionedUser}
+
+	for _, funcToRun := range toRun {
+		wg.Add(1)
+		go func(run func()) {
+			defer wg.Done()
+			run()
+		}(funcToRun)
+	}
+
+	wg.Wait()
+}
+
+func (r *SetupMigrationRunner) prepareAppStudioProvisionedSpace() {
+	r.createAndWaitForSpace(ProvisionedAppStudioSpace, "appstudio", r.Awaitilities.Member1())
+}
+
+func (r *SetupMigrationRunner) prepareSecondMemberProvisionedSpace() {
+	r.createAndWaitForSpace(SecondMemberProvisionedSpace, "base", r.Awaitilities.Member2())
+}
+
+func (r *SetupMigrationRunner) createAndWaitForSpace(name, tierName string, targetCluster *wait.MemberAwaitility) {
+	hostAwait := r.Awaitilities.Host()
+	space := test.NewSpace(hostAwait.Namespace, name, tierName, targetCluster)
+	err := hostAwait.Client.Create(context.TODO(), space)
+	require.NoError(r.T, err)
+
+	_, err = hostAwait.WaitForSpace(space.Name,
+		wait.UntilSpaceHasConditions(test.Provisioned()))
+	require.NoError(r.T, err)
+	if r.WithCleanup {
+		cleanup.AddCleanTasks(r.T, r.Awaitilities.Host().Client, space)
+	}
+}
+
+func (r *SetupMigrationRunner) prepareProvisionedUser() {
+	r.prepareUser(ProvisionedUser, r.Awaitilities.Member1())
+}
+
+func (r *SetupMigrationRunner) prepareSecondMemberProvisionedUser() {
+	r.prepareUser(SecondMemberProvisionedUser, r.Awaitilities.Member2())
+}
+
+func (r *SetupMigrationRunner) prepareDeactivatedUser() {
+	userSignup := r.prepareUser(DeactivatedUser, r.Awaitilities.Member1())
+	hostAwait := r.Awaitilities.Host()
+
+	// deactivate the UserSignup
+	userSignup, err := hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		states.SetDeactivated(us, true)
+	})
+	require.NoError(r.T, err)
+	r.T.Logf("user signup '%s' set to deactivated", userSignup.Name)
+
+	// verify that MUR is deleted
+	err = hostAwait.WaitUntilMasterUserRecordDeleted(userSignup.Status.CompliantUsername)
+	require.NoError(r.T, err)
+}
+
+func (r *SetupMigrationRunner) prepareBannedUser() {
+	userSignup := r.prepareUser(BannedUser, r.Awaitilities.Member1())
+	hostAwait := r.Awaitilities.Host()
+
+	// Create the BannedUser
+	bannedUser := test.NewBannedUser(hostAwait, userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
+	err := hostAwait.Client.Create(context.TODO(), bannedUser)
+	require.NoError(r.T, err)
+
+	r.T.Logf("BannedUser '%s' created", bannedUser.Spec.Email)
+
+	// Confirm the user is banned
+	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(userSignup.Name,
+		wait.ContainsCondition(test.Banned()[0]))
+	require.NoError(r.T, err)
+}
+
+func (r *SetupMigrationRunner) prepareAppStudioProvisionedUser() {
+	r.prepareUser(AppStudioProvisionedUser, r.Awaitilities.Member1())
+	hostAwait := r.Awaitilities.Host()
+
+	// promote to appstudio
+	changeTierRequest := test.NewChangeTierRequest(hostAwait.Namespace, AppStudioProvisionedUser, "appstudio")
+	err := hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
+	require.NoError(r.T, err)
+
+	r.T.Logf("user %s was promoted to appstudio tier", AppStudioProvisionedUser)
+
+	// verify that it's promoted
+	_, err = r.Awaitilities.Host().WaitForMasterUserRecord(AppStudioProvisionedUser,
+		wait.UntilMasterUserRecordHasTierName("appstudio"),
+		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
+	require.NoError(r.T, err)
+}
+
+func (r *SetupMigrationRunner) prepareUser(name string, targetCluster *wait.MemberAwaitility) *v1alpha1.UserSignup {
+	requestBuilder := test.NewSignupRequest(r.T, r.Awaitilities).
+		Username(name).
+		ManuallyApprove().
+		TargetCluster(targetCluster)
+	if !r.WithCleanup {
+		requestBuilder = requestBuilder.DisableCleanup()
+	}
+
+	signup, _ := requestBuilder.
+		RequireConditions(test.ConditionSet(test.Default(), test.ApprovedByAdmin())...).
+		Execute().
+		Resources()
+	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(signup.Status.CompliantUsername,
+		wait.UntilMasterUserRecordHasTierName("base"),
+		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
+	require.NoError(r.T, err)
+	return signup
+}

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -1,0 +1,161 @@
+package verify
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	"github.com/codeready-toolchain/toolchain-e2e/test/migration"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAfterMigration(t *testing.T) {
+	// given
+	awaitilities := WaitForDeployments(t)
+
+	// get Signups for the users provisioned in the setup part
+	provisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.ProvisionedUser)
+	secondMemberProvisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.SecondMemberProvisionedUser)
+	appstudioProvisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.AppStudioProvisionedUser)
+	deactivatedSignup := listAndGetSignupWithState(t, awaitilities.Host(), toolchainv1alpha1.UserSignupStateLabelValueDeactivated)
+	bannedSignup := listAndGetSignupWithState(t, awaitilities.Host(), toolchainv1alpha1.UserSignupStateLabelValueBanned)
+
+	var wg sync.WaitGroup
+
+	// prepare all functions to verify the state of the Signups and Spaces
+	toRun := []func(){
+		// Spaces
+		func() { verifyAppStudioProvisionedSpace(t, awaitilities) },
+		func() { verifySecondMemberProvisionedSpace(t, awaitilities) },
+		// UserSignups
+		func() { verifyProvisionedSignup(t, awaitilities, provisionedSignup) },
+		func() { verifySecondMemberProvisionedSignup(t, awaitilities, secondMemberProvisionedSignup) },
+		func() { verifyAppStudioProvisionedSignup(t, awaitilities, appstudioProvisionedSignup) },
+		func() { verifyDeactivatedSignup(t, awaitilities, deactivatedSignup) },
+		func() { verifyBannedSignup(t, awaitilities, bannedSignup) },
+	}
+
+	// when & then - run all functions in parallel
+	for _, funcToRun := range toRun {
+		wg.Add(1)
+		go func(run func()) {
+			defer wg.Done()
+			run()
+		}(funcToRun)
+	}
+
+	wg.Wait()
+
+	cleanup.ExecuteAllCleanTasks()
+
+	t.Run("run migration setup", func(t *testing.T) {
+		// We need to run the migration setup part to be sure that when the PR is merged
+		// then the "setup migration test" will pass for the next PRs
+		// This means, that the migration setup logic has to be written in a way that is
+		// compatible with both versions of the operators (the old one as well as the new one)
+		runner := migration.SetupMigrationRunner{
+			T:            t,
+			Awaitilities: awaitilities,
+			WithCleanup:  true,
+		}
+
+		runner.Run()
+	})
+}
+
+func verifyAppStudioProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
+	space := VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, awaitilities.Member1(), migration.ProvisionedAppStudioSpace, "appstudio")
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
+}
+
+func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
+	space := VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, awaitilities.Member2(), migration.SecondMemberProvisionedSpace, "base")
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
+}
+
+func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+	DeactivateAndCheckUser(t, awaitilities, signup)
+	ReactivateAndCheckUser(t, awaitilities, signup)
+}
+
+func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
+}
+
+func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio")
+}
+
+func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
+
+	_, err := awaitilities.Host().WaitForUserSignup(signup.Name,
+		wait.UntilUserSignupContainsConditions(ConditionSet(Default(), DeactivatedWithoutPreDeactivation())...),
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
+	require.NoError(t, err)
+	require.True(t, states.Deactivated(signup), "usersignup should be deactivated")
+
+	err = awaitilities.Host().WaitUntilMasterUserRecordDeleted(migration.DeactivatedUser)
+	require.NoError(t, err)
+
+	ReactivateAndCheckUser(t, awaitilities, signup)
+}
+
+func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
+	hostAwait := awaitilities.Host()
+	cleanup.AddCleanTasks(t, hostAwait.Client, signup)
+
+	// verify that it's still banned
+	_, err := hostAwait.WaitForUserSignup(signup.Name,
+		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...),
+		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
+	require.NoError(t, err)
+	err = hostAwait.WaitUntilMasterUserRecordDeleted(migration.DeactivatedUser)
+	require.NoError(t, err)
+
+	// get the BannedUser resource
+	matchEmailHash := client.MatchingLabels{
+		toolchainv1alpha1.BannedUserEmailHashLabelKey: md5.CalcMd5(signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]),
+	}
+	bannedUsers := &toolchainv1alpha1.BannedUserList{}
+	err = hostAwait.Client.List(context.TODO(), bannedUsers, client.InNamespace(hostAwait.Namespace), matchEmailHash)
+	require.NoError(t, err)
+	require.Len(t, bannedUsers.Items, 1)
+
+	// Unban the user by deletign the BannedUser resource
+	err = hostAwait.Client.Delete(context.TODO(), &bannedUsers.Items[0])
+	require.NoError(t, err)
+
+	// verify that it's unbanned
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+}
+
+func getSignupFromMUR(t *testing.T, hostAwait *wait.HostAwaitility, murName string) *toolchainv1alpha1.UserSignup {
+	provisionedMur, err := hostAwait.WaitForMasterUserRecord(murName)
+	require.NoError(t, err)
+	signup, err := hostAwait.WaitForUserSignup(provisionedMur.Labels[toolchainv1alpha1.OwnerLabelKey])
+	require.NoError(t, err)
+
+	return signup
+}
+
+func listAndGetSignupWithState(t *testing.T, hostAwait *wait.HostAwaitility, state string) *toolchainv1alpha1.UserSignup {
+	userSignups := &toolchainv1alpha1.UserSignupList{}
+	err := hostAwait.Client.List(context.TODO(), userSignups, client.InNamespace(hostAwait.Namespace), client.MatchingLabels{toolchainv1alpha1.UserSignupStateLabelKey: state})
+	require.NoError(t, err)
+
+	require.Len(t, userSignups.Items, 1)
+	return &userSignups.Items[0]
+}

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -122,7 +122,7 @@ func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *to
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
 	require.NoError(t, err)
-	err = hostAwait.WaitUntilMasterUserRecordDeleted(migration.DeactivatedUser)
+	err = hostAwait.WaitUntilMasterUserRecordDeleted(migration.BannedUser)
 	require.NoError(t, err)
 
 	// get the BannedUser resource

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -57,10 +57,24 @@ func TestAfterMigration(t *testing.T) {
 	cleanup.ExecuteAllCleanTasks()
 
 	t.Run("run migration setup with new operator versions for compatibility", func(t *testing.T) {
-		// We need to run the migration setup part to be sure that when the PR is merged
-		// then the "setup migration test" will pass for the next PRs
-		// This means, that the migration setup logic has to be written in a way that is
-		// compatible with both versions of the operators (the old one as well as the new one)
+		// We need to run the migration setup part to ensure the compatibility with both versions of the sandbox (the old one as well as the new one)
+		// Consider this:
+		//    1. there is a running version of host/member-operator that populates the `UserAccount.Spec.NSTemplateSet` field
+		//    2. the `migration setup logic` checks and expects that this field is populated
+		//    3. there is a migration PR that drops usage of that `UserAccount.Spec.NSTemplateSet` field so it won't be populated any more
+		//    4. there is also paired e2e PR that modifies the `verify migration test` so it doesn't expect the field to be populated
+		//    5. the tests are green - so far so good.
+		//    6. now, when the PRs are merged, we need to make sure that the setup will pass also for all the following PRs. If the logic wasn't compatible
+		//       then the next PRs would fail in the `migration setup logic` because it would still contain the logic that would check and expect
+		//       `UserAccount.Spec.NSTemplateSet` to be populated.
+		//
+		// That use-case could fit to any situation where the setup part relies on a functionality/feature that is present in the current version of operators
+		// but won't be present in the next one.
+		//
+		// This is based on the assumption that everything what is merged in master works as expected. This means that we can "just" create either UserSignup
+		// or Space and wait for the provisioned status (or any other status/state that signs that the process is done). We don't have to verify the actual
+		// content of the resources, nor labels, etc... because it was already verified when the PR that was merged. If we agree on such a generic setup logic,
+		// then we can easily make sure that it's fully compatible with both versions of Dev Sandbox.
 		runner := migration.SetupMigrationRunner{
 			T:            t,
 			Awaitilities: awaitilities,

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -134,7 +134,7 @@ func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *to
 	require.NoError(t, err)
 	require.Len(t, bannedUsers.Items, 1)
 
-	// Unban the user by deletign the BannedUser resource
+	// Unban the user by deleting the BannedUser resource
 	err = hostAwait.Client.Delete(context.TODO(), &bannedUsers.Items[0])
 	require.NoError(t, err)
 

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -24,6 +24,7 @@ func TestAfterMigration(t *testing.T) {
 	provisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.ProvisionedUser)
 	secondMemberProvisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.SecondMemberProvisionedUser)
 	appstudioProvisionedSignup := getSignupFromMUR(t, awaitilities.Host(), migration.AppStudioProvisionedUser)
+	// note: listing banned/deactivated UserSignups should be done as part of setup because the tests are run in parallel and there can be multiple banned/deactivated UserSignups at that point which could lead to test flakiness
 	deactivatedSignup := listAndGetSignupWithState(t, awaitilities.Host(), toolchainv1alpha1.UserSignupStateLabelValueDeactivated)
 	bannedSignup := listAndGetSignupWithState(t, awaitilities.Host(), toolchainv1alpha1.UserSignupStateLabelValueBanned)
 

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -55,7 +55,7 @@ func TestAfterMigration(t *testing.T) {
 
 	cleanup.ExecuteAllCleanTasks()
 
-	t.Run("run migration setup", func(t *testing.T) {
+	t.Run("run migration setup with new operator versions for compatibility", func(t *testing.T) {
 		// We need to run the migration setup part to be sure that when the PR is merged
 		// then the "setup migration test" will pass for the next PRs
 		// This means, that the migration setup logic has to be written in a way that is


### PR DESCRIPTION
This PR introduces migration infra & tests. It covers that the operator updates don't break anything and don't cause deletion of the existing accounts.
I called them "migration tests", but we could also call them "update tests" - I can change it if needed.

There are 3 significant changes:
1. a few modifications/refactoring in `test.mk` so:
    - by default the `test-e2e` target will:
      * setup the projects
      * deploy the latest version of our operators
      * run "before migration" tests which will provision UserSignups and Spaces
      * reinstall the operators to use the one from PR
      * run "after migration"tests which will check that nothing is broken nor deleted
      * run the standard set of tests
    - there is a new target `test-e2e-without-migration` which will skip the migration part. That means that it won't install the latest versions of operators nor run the migration tests.
    
2. new `test/migration/setup/setup_migration_test.go`
    - creates a few UserSignups & Spaces and puts the into various states
    - doesn't clean them so they can be used in the next "after migration" step
    - runs everything in go routines in parallel - to make it faster
    
3. new `test/migration/verify/verify_migration_test.go`
    - gets all UserSignups & Spaces in the previous step
    - verifies that they exist in the expected state
    - does a few operations on the resources to verify that everthing works as expected
    - all these verifications runs in go routines in parallel (to make it faster)
    - at the end it also executes the same set of setup functions as it was executed in `test/migration/setup/setup_migration_test.go` to verify that the setup logic is compatible also with the new version of the operator and e2e tests
    
    