### PR TITLE
update linter config

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,8 +25,11 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.29
-        args: -E gofmt,golint,megacheck,misspell
+        version: v1.43.0
+        skip-go-installation: true # we already installed Go with `actions/setup-go@v2` above
+        skip-pkg-cache: true
+        skip-build-cache: true
+        args: --config=./.golangci.yml --verbose
   
   unit-tests:
     name: Unit Tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,9 @@ linters:
   enable:
     - gofmt 
     - unparam
+    - revive
+  disable:
+    - golint
 
 # all available settings of specific linters
 linters-settings:

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -17,4 +17,4 @@ lint-go-code:
 ifeq (, $(shell which golangci-lint 2>/dev/null))
 	$(error "golangci-lint not found in PATH. Please install it using instructions on https://golangci-lint.run/usage/install/#local-installation")
 endif
-	golangci-lint ${V_FLAG} run -E gofmt,golint,megacheck,misspell
+	golangci-lint ${V_FLAG} run -c .golangci.yml

--- a/setup/metrics/format_test.go
+++ b/setup/metrics/format_test.go
@@ -10,7 +10,7 @@ func TestBytesToMBString(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Run("zero", func(t *testing.T) {
 			// given
-			var val float64 = 0
+			var val float64
 
 			// when
 			result := bytesToMBString(val)
@@ -34,7 +34,7 @@ func TestSimple(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Run("zero", func(t *testing.T) {
 			// given
-			var val float64 = 0
+			var val float64
 
 			// when
 			result := simple(val)
@@ -44,7 +44,7 @@ func TestSimple(t *testing.T) {
 
 		t.Run("non-zero value", func(t *testing.T) {
 			// given
-			var val float64 = 123456789.123456789
+			val := 123456789.123456789
 
 			// when
 			result := simple(val)

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -76,10 +76,7 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		// set api proxy values
 		apiRoute, err := initHostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
 		require.NoError(t, err)
-		initHostAwait.APIProxyURL = fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path)
-		if strings.HasSuffix(initHostAwait.APIProxyURL, "/") {
-			initHostAwait.APIProxyURL = initHostAwait.APIProxyURL[:len(initHostAwait.APIProxyURL)-1]
-		}
+		initHostAwait.APIProxyURL = strings.TrimSuffix(fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path), "/")
 
 		// wait for member operators to be ready
 		initMemberAwait = getMemberAwaitility(t, cl, initHostAwait, memberNs)

--- a/testsupport/tier_setup.go
+++ b/testsupport/tier_setup.go
@@ -7,7 +7,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint: golint
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint: revive
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
disable `golint`, use `revive` instead, and fix errors reported by
the latter, plus a `gosimple` suggestion, too.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
