### PR TITLE
refactoring: unify space functions

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -252,34 +251,10 @@ func setupSpaces(t *testing.T, awaitilities Awaitilities, tierName, nameFmt stri
 	var spaces []string
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf(nameFmt, i)
-		s := createSpace(t, awaitilities, tier.Name, name, hash, targetCluster)
+		s := CreateSpace(t, awaitilities, WithName(name), WithTierNameAndHashLabel(tier.Name, hash), WithTargetCluster(targetCluster))
 		spaces = append(spaces, s.Name)
 	}
 	return spaces
-}
-
-func createSpace(t *testing.T, awaitilities Awaitilities, tierName, name, hash string, targetCluster *MemberAwaitility) *toolchainv1alpha1.Space {
-	space := &toolchainv1alpha1.Space{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: awaitilities.Host().Namespace,
-			Name:      name,
-			Labels: map[string]string{
-				testtier.TemplateTierHashLabelKey(tierName): hash,
-			},
-		},
-		Spec: toolchainv1alpha1.SpaceSpec{
-			TargetCluster: targetCluster.ClusterName,
-			TierName:      tierName,
-		},
-	}
-
-	// when
-	err := awaitilities.Host().CreateWithCleanup(context.TODO(), space)
-
-	// then
-	require.NoError(t, err)
-	t.Logf("Space created - %s: %s", testtier.TemplateTierHashLabelKey(tierName), hash)
-	return space
 }
 
 // setupAccounts takes care of:

--- a/test/e2e/space_test.go
+++ b/test/e2e/space_test.go
@@ -22,23 +22,15 @@ func TestCreateSpace(t *testing.T) {
 	memberAwait := awaitilities.Member1()
 
 	t.Run("create space", func(t *testing.T) {
-		// given
-		space := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "appstudio", WithTargetCluster(memberAwait.ClusterName))
-
-		// when
-		err := hostAwait.Client.Create(context.TODO(), space)
-
-		// then
-		// then
-		require.NoError(t, err)
-		space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, memberAwait, space.Name, "appstudio")
+		// given & when & then
+		space := CreateAndVerifySpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(memberAwait))
 
 		t.Run("delete space", func(t *testing.T) {
 			// now, delete the Space and expect that the NSTemplateSet will be deleted as well,
 			// along with its associated namespace
 
 			// when
-			err = hostAwait.Client.Delete(context.TODO(), space)
+			err := hostAwait.Client.Delete(context.TODO(), space)
 
 			// then
 			require.NoError(t, err)
@@ -54,15 +46,11 @@ func TestCreateSpace(t *testing.T) {
 	t.Run("failed to create space", func(t *testing.T) {
 
 		t.Run("missing target member cluster", func(t *testing.T) {
-			// given
-			space := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "appstudio")
-
-			// when
-			err := hostAwait.Client.Create(context.TODO(), space)
+			// given & when
+			space := CreateSpace(t, awaitilities, WithTierName("appstudio"))
 
 			// then
-			require.NoError(t, err)
-			space, err = hostAwait.WaitForSpace(space.Name,
+			space, err := hostAwait.WaitForSpace(space.Name,
 				UntilSpaceHasConditions(ProvisioningPending("unspecified target member cluster")),
 				UntilSpaceHasStateLabel(toolchainv1alpha1.SpaceStateLabelValuePending))
 			require.NoError(t, err)
@@ -79,16 +67,13 @@ func TestCreateSpace(t *testing.T) {
 		})
 
 		t.Run("unknown target member cluster", func(t *testing.T) {
-			// given
-			s := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "appstudio", WithTargetCluster("unknown"))
-			s.Spec.TargetCluster = "unknown"
-
-			// when
-			err := hostAwait.Client.Create(context.TODO(), s)
+			// given & when
+			s := CreateSpace(t, awaitilities, WithTierName("appstudio"), func(space *toolchainv1alpha1.Space) {
+				space.Spec.TargetCluster = "unknown"
+			})
 
 			// then
-			require.NoError(t, err)
-			s, err = hostAwait.WaitForSpace(s.Name, UntilSpaceHasConditions(ProvisioningFailed("unknown target member cluster 'unknown'")))
+			s, err := hostAwait.WaitForSpace(s.Name, UntilSpaceHasConditions(ProvisioningFailed("unknown target member cluster 'unknown'")))
 			require.NoError(t, err)
 
 			t.Run("unable to delete space", func(t *testing.T) {
@@ -129,14 +114,10 @@ func TestSpaceRoles(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 
-	// given
-	s := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "appstudio", WithTargetCluster(memberAwait.ClusterName))
-
-	// when
-	err := hostAwait.CreateWithCleanup(context.TODO(), s)
+	// given & when
+	s := CreateSpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(memberAwait))
 
 	// then
-	require.NoError(t, err)
 	nsTmplSet, err := memberAwait.WaitForNSTmplSet(s.Name, UntilNSTemplateSetHasConditions(Provisioned()))
 	require.NoError(t, err)
 	// wait until NSTemplateSet has been created and Space is in `Ready` status
@@ -390,14 +371,10 @@ func TestPromoteSpace(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 
-	space := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "base", WithTargetCluster(memberAwait.ClusterName))
-
-	// when
-	err := hostAwait.CreateWithCleanup(context.TODO(), space)
+	//  when
+	space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(memberAwait))
 
 	// then
-	require.NoError(t, err)
-
 	space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, memberAwait, space.Name, "base")
 
 	t.Run("to advanced tier", func(t *testing.T) {
@@ -405,11 +382,11 @@ func TestPromoteSpace(t *testing.T) {
 		ctr := NewChangeTierRequest(hostAwait.Namespace, space.Name, "advanced")
 
 		// when
-		err = hostAwait.Client.Create(context.TODO(), ctr)
+		err := hostAwait.Client.Create(context.TODO(), ctr)
 
 		// then
 		require.NoError(t, err)
-		_, err := hostAwait.WaitForChangeTierRequest(ctr.Name, toBeComplete)
+		_, err = hostAwait.WaitForChangeTierRequest(ctr.Name, toBeComplete)
 		require.NoError(t, err)
 		VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, memberAwait, space.Name, "advanced")
 	})
@@ -424,15 +401,14 @@ func TestRetargetSpace(t *testing.T) {
 	member2Await := awaitilities.Member2()
 
 	t.Run("to no other cluster", func(t *testing.T) {
-		// given
-		space := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "base", WithTargetCluster(member1Await.ClusterName))
-		err := hostAwait.CreateWithCleanup(context.TODO(), space)
-		require.NoError(t, err)
+		// given & when
+		space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
+
 		// wait until Space has been provisioned on member-1
 		VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, member1Await, space.Name, "base")
 
 		// when
-		space, err = hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {
+		space, err := hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {
 			s.Spec.TargetCluster = ""
 		})
 		require.NoError(t, err)
@@ -448,15 +424,14 @@ func TestRetargetSpace(t *testing.T) {
 	})
 
 	t.Run("to another cluster", func(t *testing.T) {
-		// given
-		space := NewSpace(hostAwait.Namespace, GenerateName("oddity"), "base", WithTargetCluster(member1Await.ClusterName))
-		err := hostAwait.CreateWithCleanup(context.TODO(), space)
-		require.NoError(t, err)
+		// given & when
+		space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
+
 		// wait until Space has been provisioned on member-1
 		space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, member1Await, space.Name, "base")
 
 		// when
-		space, err = hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {
+		space, err := hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {
 			s.Spec.TargetCluster = member2Await.ClusterName
 		})
 		require.NoError(t, err)

--- a/test/e2e/space_test.go
+++ b/test/e2e/space_test.go
@@ -115,13 +115,11 @@ func TestSpaceRoles(t *testing.T) {
 	memberAwait := awaitilities.Member1()
 
 	// given & when
-	s := CreateSpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(memberAwait))
+	s := CreateAndVerifySpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(memberAwait))
 
 	// then
 	nsTmplSet, err := memberAwait.WaitForNSTmplSet(s.Name, UntilNSTemplateSetHasConditions(Provisioned()))
 	require.NoError(t, err)
-	// wait until NSTemplateSet has been created and Space is in `Ready` status
-	s = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, memberAwait, s.Name, "appstudio")
 
 	// given
 	adminTierTmpl := NewTierTemplate(t, hostAwait.Namespace, "space-role-admin-123456", "space-role-admin", "appstudio", "123456", []byte(spaceAdminTmpl))
@@ -371,11 +369,8 @@ func TestPromoteSpace(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 
-	//  when
-	space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(memberAwait))
-
-	// then
-	space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, memberAwait, space.Name, "base")
+	//  when & then
+	space := CreateAndVerifySpace(t, awaitilities, WithTierName("base"), WithTargetCluster(memberAwait))
 
 	t.Run("to advanced tier", func(t *testing.T) {
 		// given
@@ -401,11 +396,9 @@ func TestRetargetSpace(t *testing.T) {
 	member2Await := awaitilities.Member2()
 
 	t.Run("to no other cluster", func(t *testing.T) {
-		// given & when
-		space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
-
+		// given
 		// wait until Space has been provisioned on member-1
-		VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, member1Await, space.Name, "base")
+		space := CreateAndVerifySpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
 
 		// when
 		space, err := hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {
@@ -424,11 +417,9 @@ func TestRetargetSpace(t *testing.T) {
 	})
 
 	t.Run("to another cluster", func(t *testing.T) {
-		// given & when
-		space := CreateSpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
-
+		// given
 		// wait until Space has been provisioned on member-1
-		space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, member1Await, space.Name, "base")
+		space := CreateAndVerifySpace(t, awaitilities, WithTierName("base"), WithTargetCluster(member1Await))
 
 		// when
 		space, err := hostAwait.UpdateSpace(space.Name, func(s *toolchainv1alpha1.Space) {

--- a/test/e2e/spacebinding_test.go
+++ b/test/e2e/spacebinding_test.go
@@ -47,10 +47,7 @@ func TestSpaceBindingCleanup(t *testing.T) {
 }
 
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, hostAwait *wait.HostAwaitility, targetMember *wait.MemberAwaitility, murName, spaceName string) (*v1alpha1.Space, *v1alpha1.MasterUserRecord, *v1alpha1.SpaceBinding) {
-	space := NewSpace(hostAwait.Namespace, spaceName, "appstudio", WithTargetCluster(targetMember.ClusterName))
-	err := hostAwait.CreateWithCleanup(context.TODO(), space)
-	require.NoError(t, err)
-	space = VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, targetMember, space.Name, "appstudio")
+	space := CreateAndVerifySpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(targetMember), WithName(spaceName))
 
 	_, mur := NewSignupRequest(t, awaitilities).
 		Username(murName).
@@ -61,7 +58,7 @@ func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilitie
 		Execute().Resources()
 
 	spaceBinding := newSpaceBinding(space.Namespace, mur.Name, space.Name, "admin")
-	err = hostAwait.CreateWithCleanup(context.TODO(), spaceBinding)
+	err := hostAwait.CreateWithCleanup(context.TODO(), spaceBinding)
 	require.NoError(t, err)
 
 	return space, mur, spaceBinding

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -64,7 +64,7 @@ func (r *SetupMigrationRunner) prepareSecondMemberProvisionedSpace() {
 
 func (r *SetupMigrationRunner) createAndWaitForSpace(name, tierName string, targetCluster *wait.MemberAwaitility) {
 	hostAwait := r.Awaitilities.Host()
-	space := test.NewSpace(hostAwait.Namespace, name, tierName, test.WithTargetCluster(targetCluster.ClusterName))
+	space := test.NewSpace(r.Awaitilities, test.WithName(name), test.WithTierName(tierName), test.WithTargetCluster(targetCluster))
 	err := hostAwait.Client.Create(context.TODO(), space)
 	require.NoError(r.T, err)
 

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -1,7 +1,9 @@
 package testsupport
 
 import (
+	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -12,18 +14,29 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// NewSpace initializes a new Space object with the given value. If the targetCluster is nil, then the Space.Spec.TargetCluster is not set.
-func NewSpace(namespace, name, tierName string, opts ...SpaceOption) *toolchainv1alpha1.Space {
+var notAllowedChars = regexp.MustCompile("[^-a-z0-9]")
+
+// NewSpace initializes a new Space object with the given options. By default it sets tierName to "base".
+func NewSpace(awaitilities wait.Awaitilities, opts ...SpaceOption) *toolchainv1alpha1.Space {
+	namePrefix := strings.ToLower(awaitilities.Host().T.Name())
+	// Remove all invalid characters
+	namePrefix = notAllowedChars.ReplaceAllString(namePrefix, "")
+
+	// Trim if the length exceeds 50 chars (63 is the max)
+	if len(namePrefix) > 50 {
+		namePrefix = namePrefix[0:50]
+	}
+
 	space := &toolchainv1alpha1.Space{
-		ObjectMeta: v1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    awaitilities.Host().Namespace,
+			GenerateName: namePrefix + "-",
 		},
 		Spec: toolchainv1alpha1.SpaceSpec{
-			TierName: tierName,
+			TierName: "base",
 		},
 	}
 	for _, apply := range opts {
@@ -34,10 +47,73 @@ func NewSpace(namespace, name, tierName string, opts ...SpaceOption) *toolchainv
 
 type SpaceOption func(*toolchainv1alpha1.Space)
 
-func WithTargetCluster(clusterName string) SpaceOption {
+func WithTargetCluster(memberCluster *wait.MemberAwaitility) SpaceOption {
 	return func(s *toolchainv1alpha1.Space) {
-		s.Spec.TargetCluster = clusterName
+		s.Spec.TargetCluster = memberCluster.ClusterName
 	}
+}
+
+func WithTierName(tierName string) SpaceOption {
+	return func(s *toolchainv1alpha1.Space) {
+		s.Spec.TierName = tierName
+	}
+}
+
+func WithName(name string) SpaceOption {
+	return func(s *toolchainv1alpha1.Space) {
+		s.Name = name
+		s.GenerateName = ""
+	}
+}
+
+func WithTierNameAndHashLabel(tierName, hash string) SpaceOption {
+	return func(s *toolchainv1alpha1.Space) {
+		s.Spec.TierName = tierName
+		if s.Labels == nil {
+			s.Labels = map[string]string{}
+		}
+		s.Labels[testtier.TemplateTierHashLabelKey(tierName)] = hash
+	}
+}
+
+// CreateSpace initializes a new Space object using the NewSpace function, and then creates it in the cluster
+func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOption) *toolchainv1alpha1.Space {
+	space := NewSpace(awaitilities, opts...)
+
+	err := awaitilities.Host().CreateWithCleanup(context.TODO(), space)
+	require.NoError(t, err)
+	return space
+}
+
+// CreateAndVerifySpace does the same as CreateSpace plus it also verifies the provisioned resources in the cluster using function VerifyResourcesProvisionedForSpace
+func CreateAndVerifySpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOption) *toolchainv1alpha1.Space {
+	space := CreateSpace(t, awaitilities, opts...)
+	return VerifyResourcesProvisionedForSpace(t, awaitilities, space)
+}
+
+func getSpaceTargetMember(t *testing.T, awaitilities wait.Awaitilities, space *toolchainv1alpha1.Space) *wait.MemberAwaitility {
+	for _, member := range awaitilities.AllMembers() {
+		if space.Spec.TargetCluster == member.ClusterName {
+			return member
+		}
+	}
+
+	require.FailNowf(t, "Unable to find a target member cluster", "Space: %+v", space)
+	return nil
+}
+
+// VerifyResourcesProvisionedForSpace waits until the space has some target cluster and a tier name set together with the additional criteria (if provided)
+// then it gets the target member cluster specified for the space and verifies all resources provisioned for the Space
+func VerifyResourcesProvisionedForSpace(t *testing.T, awaitilities wait.Awaitilities, space *toolchainv1alpha1.Space, additionalCriteria ...wait.SpaceWaitCriterion) *toolchainv1alpha1.Space {
+
+	space, err := awaitilities.Host().WaitForSpace(space.Name,
+		append(additionalCriteria,
+			wait.UntilSpaceHasAnyTargetClusterSet(),
+			wait.UntilSpaceHasAnyTierNameSet())...)
+	require.NoError(t, err)
+	targetMember := getSpaceTargetMember(t, awaitilities, space)
+
+	return VerifyResourcesProvisionedForSpaceWithTier(t, awaitilities, targetMember, space.Name, space.Spec.TierName)
 }
 
 // Same as VerifyResourcesProvisionedForSpaceWithTiers but reuses the provided tier name for the namespace and cluster resources names

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -10,6 +10,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/md5"
@@ -1481,7 +1482,7 @@ func UntilSpaceHasTier(expected string) SpaceWaitCriterion {
 			return actual.Spec.TierName == expected
 		},
 		Diff: func(actual *toolchainv1alpha1.Space) string {
-			return fmt.Sprintf("expected tiernames to match:\n%s", Diff(expected, actual.Spec.TierName))
+			return fmt.Sprintf("expected tier name to match:\n%s", Diff(expected, actual.Spec.TierName))
 		},
 	}
 }
@@ -1508,6 +1509,49 @@ func UntilSpaceHasStateLabel(expected string) SpaceWaitCriterion {
 		},
 		Diff: func(actual *toolchainv1alpha1.Space) string {
 			return fmt.Sprintf("expected Space to match the state label value: %s \nactual labels: %s", expected, actual.Labels)
+		},
+	}
+}
+
+// UntilSpaceHasConditionForTime returns a `SpaceWaitCriterion` which checks that the given
+// Space has the condition set at least for the given amount of time
+func UntilSpaceHasConditionForTime(expected toolchainv1alpha1.Condition, duration time.Duration) SpaceWaitCriterion {
+	return SpaceWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.Space) bool {
+			foundCond, exists := condition.FindConditionByType(actual.Status.Conditions, expected.Type)
+			if exists && foundCond.Reason == expected.Reason && foundCond.Status == expected.Status {
+				return foundCond.LastTransitionTime.Time.Before(time.Now().Add(-duration))
+			}
+			return false
+		},
+		Diff: func(actual *toolchainv1alpha1.Space) string {
+			return fmt.Sprintf("expected conditions to match:\n%s\nAnd having the LastTransitionTime %s or older", Diff(expected, actual.Status.Conditions), time.Now().Add(-duration).String())
+		},
+	}
+}
+
+// UntilSpaceHasAnyTargetClusterSet returns a `SpaceWaitCriterion` which checks that the given
+// Space has any `spec.targetCluster` set
+func UntilSpaceHasAnyTargetClusterSet() SpaceWaitCriterion {
+	return SpaceWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.Space) bool {
+			return actual.Spec.TargetCluster != ""
+		},
+		Diff: func(actual *toolchainv1alpha1.Space) string {
+			return fmt.Sprintf("expected target clusters not to be empty. Actual Space resource:\n%v", actual)
+		},
+	}
+}
+
+// UntilSpaceHasAnyTierNameSet returns a `SpaceWaitCriterion` which checks that the given
+// Space has any `spec.tierName` set
+func UntilSpaceHasAnyTierNameSet() SpaceWaitCriterion {
+	return SpaceWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.Space) bool {
+			return actual.Spec.TierName != ""
+		},
+		Diff: func(actual *toolchainv1alpha1.Space) string {
+			return fmt.Sprintf("expected tier name not to be empty. Actual Space resource:\n%v", actual)
 		},
 	}
 }


### PR DESCRIPTION
The PR brings a few more helper functions for easy creation and verification of Space resources.
It also replaces the current usages with the new unified functions.
There is maybe one unused criterion function - I'll use it in the next PR - it was just easier to include this here as well :-) 