### PR TITLE
Add query for kube-apiserver

### DIFF
--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -26,9 +26,6 @@ const (
 
 	OSAPIServerNamespace = "openshift-apiserver"
 	OSAPIServerWorkload  = "apiserver"
-
-	OSKubeAPIServerNamespace = "openshift-kube-apiserver"
-	OSKubeAPIServerWorkload  = "apiserver"
 )
 
 type Gatherer struct {

--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -26,6 +26,9 @@ const (
 
 	OSAPIServerNamespace = "openshift-apiserver"
 	OSAPIServerWorkload  = "apiserver"
+
+	OSKubeAPIServerNamespace = "openshift-kube-apiserver"
+	OSKubeAPIServerWorkload  = "apiserver"
 )
 
 type Gatherer struct {
@@ -54,6 +57,7 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 
 	// Add default queries
 	g.AddQueries(
+		queries.QueryOpenshiftKubeAPIMemoryUtilisation(prometheusClient),
 		queries.QueryClusterCPUUtilisation(prometheusClient),
 		queries.QueryClusterMemoryUtilisation(prometheusClient),
 		queries.QueryNodeMemoryUtilisation(prometheusClient),

--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -57,13 +57,13 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 
 	// Add default queries
 	g.AddQueries(
-		queries.QueryOpenshiftKubeAPIMemoryUtilisation(prometheusClient),
 		queries.QueryClusterCPUUtilisation(prometheusClient),
 		queries.QueryClusterMemoryUtilisation(prometheusClient),
 		queries.QueryNodeMemoryUtilisation(prometheusClient),
 		queries.QueryEtcdMemoryUsage(prometheusClient),
 		queries.QueryWorkloadCPUUsage(prometheusClient, OLMOperatorNamespace, OLMOperatorWorkload),
 		queries.QueryWorkloadMemoryUsage(prometheusClient, OLMOperatorNamespace, OLMOperatorWorkload),
+		queries.QueryOpenshiftKubeAPIMemoryUtilisation(prometheusClient),
 		queries.QueryWorkloadCPUUsage(prometheusClient, OSAPIServerNamespace, OSAPIServerWorkload),
 		queries.QueryWorkloadMemoryUsage(prometheusClient, OSAPIServerNamespace, OSAPIServerWorkload),
 		queries.QueryWorkloadCPUUsage(prometheusClient, cfg.HostOperatorNamespace, cfg.HostOperatorWorkload),

--- a/setup/metrics/queries/query.go
+++ b/setup/metrics/queries/query.go
@@ -42,6 +42,15 @@ func (b BaseQuery) ResultType() string {
 	return string(b.resultType)
 }
 
+func QueryOpenshiftKubeAPIMemoryUtilisation(apiClient prometheus.API) *BaseQuery {
+	return &BaseQuery{
+		apiClient:  apiClient,
+		name:       "openshift-kube-apiserver",
+		query:      `sum(container_memory_usage_bytes{namespace="openshift-kube-apiserver", pod=~"kube-apiserver-.*"})`,
+		resultType: Memory,
+	}
+}
+
 func QueryEtcdMemoryUsage(apiClient prometheus.API) *BaseQuery {
 	return &BaseQuery{
 		apiClient:  apiClient,


### PR DESCRIPTION
Adding memory query for kube-apiserver since there was an increase in its memory usage that went undetected after GitOps Primer operator was onboarded.

Sample of results with the new query included:
```
📈 Results 📉
Average Idler Update Time: 1.31 s
Average Time Per User: 5.00 s
Average openshift-kube-apiserver: 12030.16 MB <- new query
Max openshift-kube-apiserver: 12030.16 MB
Average Cluster CPU Utilisation: 16.72 %
Max Cluster CPU Utilisation: 16.72 %
Average Cluster Memory Utilisation: 37.13 %
Max Cluster Memory Utilisation: 37.13 %
Average Node Memory Usage: 38.37 %
Max Node Memory Usage: 38.37 %
Average etcd Instance Memory Usage: 586.21 MB
Max etcd Instance Memory Usage: 586.21 MB
Average olm-operator CPU Usage: 0.0025
Max olm-operator CPU Usage: 0.0025
Average olm-operator Memory Usage: 163.63 MB
Max olm-operator Memory Usage: 163.63 MB
Average apiserver CPU Usage: 0.0210
Max apiserver CPU Usage: 0.0210
Average apiserver Memory Usage: 207.93 MB
Max apiserver Memory Usage: 207.93 MB
Average host-operator-controller-manager CPU Usage: 0.0030
Max host-operator-controller-manager CPU Usage: 0.0030
Average host-operator-controller-manager Memory Usage: 40.14 MB
Max host-operator-controller-manager Memory Usage: 40.14 MB
Average member-operator-controller-manager CPU Usage: 0.0046
Max member-operator-controller-manager CPU Usage: 0.0046
Average member-operator-controller-manager Memory Usage: 41.48 MB
Max member-operator-controller-manager Memory Usage: 41.48 MB
```