### PR TITLE
verify that User resource has email annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20220128141941-727c0ecfe260
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084
+	github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -113,11 +113,10 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20220128141941-727c0ecfe260 h1:o4s1tSe2YP9JyjBEaV41ZTM2U67agrU/utnB3NEEpF4=
-github.com/codeready-toolchain/api v0.0.0-20220128141941-727c0ecfe260/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084 h1:9V+OvCQU9h7V3W6bx0hhqO3JQL/hyENwuRPeq24XYf4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
+github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc h1:3724QOImc5jkpfc7UUXJ6G+BpaZQGG7Tjta0tYbaXvw=
+github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc h1:Uaj3pE4QytArKXv7RrXIgSEESllLC2BaMteDq6//qEc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -54,6 +54,7 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitil
 		wait.UntilUserAccountHasConditions(Provisioned()),
 		wait.UntilUserAccountHasSpec(ExpectedUserAccount(userSignup.Spec.Userid, tierName, templateRefs, userSignup.Spec.OriginalSub)),
 		wait.UntilUserAccountHasLabelWithValue(toolchainv1alpha1.TierLabelKey, mur.Spec.TierName),
+		wait.UntilUserAccountHasAnnotation(toolchainv1alpha1.UserEmailAnnotationKey, signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]),
 		wait.UntilUserAccountMatchesMur(hostAwait))
 	require.NoError(t, err)
 	require.NotNil(t, userAccount)
@@ -71,7 +72,10 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitil
 
 	if tierName != "appstudio" {
 		// Verify provisioned User
-		_, err = memberAwait.WaitForUser(userAccount.Name, wait.WithUserLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue))
+		_, err = memberAwait.WaitForUser(userAccount.Name,
+			wait.UntilUserHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
+			wait.UntilUserHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name),
+			wait.UntilUserHasAnnotation(toolchainv1alpha1.UserEmailAnnotationKey, signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]))
 		assert.NoError(t, err)
 
 		// Verify provisioned Identity
@@ -80,12 +84,16 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitil
 			userID = fmt.Sprintf("b64:%s", base64.RawStdEncoding.EncodeToString([]byte(userAccount.Spec.UserID)))
 		}
 
-		_, err = memberAwait.WaitForIdentity(ToIdentityName(userID), wait.WithIdentityLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue))
+		_, err = memberAwait.WaitForIdentity(ToIdentityName(userID),
+			wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
+			wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
 		assert.NoError(t, err)
 
 		// Verify the second identity
 		if encodedName != "" {
-			_, err = memberAwait.WaitForIdentity(ToIdentityName(encodedName), wait.WithIdentityLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue))
+			_, err = memberAwait.WaitForIdentity(ToIdentityName(encodedName),
+				wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
+				wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
 			assert.NoError(t, err)
 		}
 	} else {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -130,6 +130,19 @@ func UntilUserAccountHasLabelWithValue(key, value string) UserAccountWaitCriteri
 	}
 }
 
+// UntilUserAccountHasAnnotation checks if the UserAccount has the expected label
+func UntilUserAccountHasAnnotation(key, value string) UserAccountWaitCriterion {
+	return UserAccountWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.UserAccount) bool {
+			actualValue, exist := actual.Annotations[key]
+			return exist && actualValue == value
+		},
+		Diff: func(actual *toolchainv1alpha1.UserAccount) string {
+			return fmt.Sprintf("expected UserAccount annotation '%s' to be '%s'\nbut it was '%s'", key, value, actual.Annotations[key])
+		},
+	}
+}
+
 // UntilUserAccountHasSpec returns a `UserAccountWaitCriterion` which checks that the given
 // USerAccount has the expected spec
 func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAccountWaitCriterion {
@@ -1131,14 +1144,27 @@ func (a *MemberAwaitility) WaitForUser(name string, criteria ...UserWaitCriterio
 	return user, err
 }
 
-// WithUserLabel checks if the User has the expected label
-func WithUserLabel(key, value string) UserWaitCriterion {
+// UntilUserHasLabel checks if the User has the expected label
+func UntilUserHasLabel(key, value string) UserWaitCriterion {
 	return UserWaitCriterion{
 		Match: func(actual *userv1.User) bool {
 			return actual.Labels[key] == value
 		},
 		Diff: func(actual *userv1.User) string {
 			return fmt.Sprintf("expected User label '%s' to be '%s'\nbut it was '%s'", key, value, actual.Labels[key])
+		},
+	}
+}
+
+// UntilUserHasAnnotation checks if the User has the expected label
+func UntilUserHasAnnotation(key, value string) UserWaitCriterion {
+	return UserWaitCriterion{
+		Match: func(actual *userv1.User) bool {
+			actualValue, exist := actual.Annotations[key]
+			return exist && actualValue == value
+		},
+		Diff: func(actual *userv1.User) string {
+			return fmt.Sprintf("expected User annotation '%s' to be '%s'\nbut it was '%s'", key, value, actual.Annotations[key])
 		},
 	}
 }
@@ -1181,8 +1207,8 @@ func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWait
 	return identity, err
 }
 
-// WithIdentityLabel checks if the Identity has the expected label
-func WithIdentityLabel(key, value string) IdentityWaitCriterion {
+// UntilIdentityHasLabel checks if the Identity has the expected label
+func UntilIdentityHasLabel(key, value string) IdentityWaitCriterion {
 	return IdentityWaitCriterion{
 		Match: func(actual *userv1.Identity) bool {
 			return actual.Labels[key] == value

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -1156,7 +1156,7 @@ func UntilUserHasLabel(key, value string) UserWaitCriterion {
 	}
 }
 
-// UntilUserHasAnnotation checks if the User has the expected label
+// UntilUserHasAnnotation checks if the User has the expected annotation
 func UntilUserHasAnnotation(key, value string) UserWaitCriterion {
 	return UserWaitCriterion{
 		Match: func(actual *userv1.User) bool {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -130,7 +130,7 @@ func UntilUserAccountHasLabelWithValue(key, value string) UserAccountWaitCriteri
 	}
 }
 
-// UntilUserAccountHasAnnotation checks if the UserAccount has the expected label
+// UntilUserAccountHasAnnotation checks if the UserAccount has the expected annotation
 func UntilUserAccountHasAnnotation(key, value string) UserAccountWaitCriterion {
 	return UserAccountWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.UserAccount) bool {


### PR DESCRIPTION
verify that `User` & `UserAccount` resources have email annotation + a few refactoring changes to make the function names consistent

paired with https://github.com/codeready-toolchain/member-operator/pull/340