### PR TITLE
refactor: improve the flow of the space_cleanup_test.go

### DIFF
--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -87,7 +87,7 @@ func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOpti
 	return space, signup, spaceBinding
 }
 
-// CreateSpace initializes a new Space object using the NewSpace function, and then creates it in the cluster
+// CreateSpaceWithBinding initializes a new Space object using the NewSpace function, and then creates it in the cluster
 // It also automatically creates SpaceBinding for it and for the given MasterUserRecord
 func CreateSpaceWithBinding(t *testing.T, awaitilities wait.Awaitilities, mur *toolchainv1alpha1.MasterUserRecord, opts ...SpaceOption) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBinding) {
 	space := NewSpace(awaitilities, opts...)


### PR DESCRIPTION
I merged the two cleanup tests which makes the flow much better - no idea why I didn't realize it before :man_shrugging:  :man_facepalming: 
https://github.com/codeready-toolchain/toolchain-e2e/pull/479#discussion_r812968732