### PR TITLE
Fix e2e tests with userID encoding change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc h1:3724QOI
 github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc h1:Uaj3pE4QytArKXv7RrXIgSEESllLC2BaMteDq6//qEc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c h1:GWGa61wWVjWpv8mdanaViMJasrju0SQIB/9WPT8xA7Y=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -451,4 +451,8 @@ func TestE2EFlow(t *testing.T) {
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
 	})
 
+	t.Run("deactivate UserSignup and ensure that all user and identity resources are deleted", func(t *testing.T) {
+		// TODO
+	})
+
 }


### PR DESCRIPTION
This PR just fixes the e2e tests to work with the UserID encoding changes made in toolchain-common.

PR: https://github.com/codeready-toolchain/member-operator/pull/341