### PR TITLE
Fix e2e tests with userID encoding change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc h1:3724QOImc5jkpfc7UUXJ6G+BpaZQGG7Tjta0tYbaXvw=
 github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc h1:Uaj3pE4QytArKXv7RrXIgSEESllLC2BaMteDq6//qEc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c h1:GWGa61wWVjWpv8mdanaViMJasrju0SQIB/9WPT8xA7Y=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc h1:3724QOI
 github.com/codeready-toolchain/api v0.0.0-20220215110522-1a78f33ee8fc/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc h1:Uaj3pE4QytArKXv7RrXIgSEESllLC2BaMteDq6//qEc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220216032108-e7a7e76307dc/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c h1:GWGa61wWVjWpv8mdanaViMJasrju0SQIB/9WPT8xA7Y=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220224002917-4cf25d8f8a1c/go.mod h1:BjfWQlOcdmZpbPYKk54Qj7PNEKAVbcYhaWWLPCJ8atg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -451,8 +451,4 @@ func TestE2EFlow(t *testing.T) {
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
 	})
 
-	t.Run("deactivate UserSignup and ensure that all user and identity resources are deleted", func(t *testing.T) {
-		// TODO
-	})
-
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -451,4 +451,8 @@ func TestE2EFlow(t *testing.T) {
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
 	})
 
+	t.Run("deactivate UserSignup and ensure that all user and identity resources are deleted", func(t *testing.T) {
+		// TODO
+	})
+
 }

--- a/test/e2e/registration_service_test.go
+++ b/test/e2e/registration_service_test.go
@@ -376,16 +376,18 @@ func (s *registrationServiceTestSuite) TestSignupOK() {
 		}
 
 		for i, userID := range userIDs {
-			identity := authsupport.NewIdentity()
-			emailValue := uuid.Must(uuid.NewV4()).String() + "@acme.com"
-			emailClaim := authsupport.WithEmailClaim(emailValue)
-			t, err := authsupport.GenerateSignedE2ETestToken(*identity, emailClaim, authsupport.WithSubClaim(userID))
-			require.NoError(s.T(), err)
+			s.Run(fmt.Sprintf("for User ID = %s", userID), func() {
+				identity := authsupport.NewIdentity()
+				emailValue := uuid.Must(uuid.NewV4()).String() + "@acme.com"
+				emailClaim := authsupport.WithEmailClaim(emailValue)
+				t, err := authsupport.GenerateSignedE2ETestToken(*identity, emailClaim, authsupport.WithSubClaim(userID))
+				require.NoError(s.T(), err)
 
-			// Signup a new user
-			userSignup := signupUser(t, emailValue, encodedUserIDs[i], identity)
+				// Signup a new user
+				userSignup := signupUser(t, emailValue, encodedUserIDs[i], identity)
 
-			require.Equal(s.T(), userID, userSignup.Spec.Userid)
+				require.Equal(s.T(), userID, userSignup.Spec.Userid)
+			})
 		}
 	})
 }

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -71,7 +71,7 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitil
 			wait.UntilUserHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 			wait.UntilUserHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name),
 			wait.UntilUserHasAnnotation(toolchainv1alpha1.UserEmailAnnotationKey, signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]))
-		assert.NoError(t, err)
+		assert.NoError(t, err, fmt.Sprintf("no user with name '%s' found", userAccount.Name))
 
 		// Verify provisioned Identity
 		identityName := identity.NewIdentityNamingStandard(userAccount.Spec.UserID, "rhd").IdentityName()
@@ -79,14 +79,14 @@ func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitil
 		_, err = memberAwait.WaitForIdentity(identityName,
 			wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 			wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
-		assert.NoError(t, err)
+		assert.NoError(t, err, fmt.Sprintf("no identity with name '%s' found", identityName))
 
 		// Verify the second identity
 		if encodedName != "" {
 			_, err = memberAwait.WaitForIdentity(ToIdentityName(encodedName),
 				wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 				wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
-			assert.NoError(t, err)
+			assert.NoError(t, err, fmt.Sprintf("no encoded identity with name '%s' found", ToIdentityName(encodedName)))
 		}
 	} else {
 		// we don't expect User nor Identity resources to be present for AppStudio tier

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -1204,7 +1204,17 @@ func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWait
 		}
 		return false, nil
 	})
+	if err != nil {
+		a.printIdentities(name)
+	}
 	return identity, err
+}
+
+func (a *MemberAwaitility) printIdentities(expectedName string) {
+	buf := &strings.Builder{}
+	buf.WriteString(fmt.Sprintf("failed to find Identity '%s'\n", expectedName))
+	buf.WriteString(a.listAndReturnContent("Identity", "", &userv1.IdentityList{}))
+	a.T.Log(buf.String())
 }
 
 // UntilIdentityHasLabel checks if the Identity has the expected label


### PR DESCRIPTION
Fixes e2e tests to work with new UserID encoding rules.

https://github.com/codeready-toolchain/member-operator/pull/342