### PR TITLE
Fix flaky test

### DIFF
--- a/test/e2e/space_cleanup_test.go
+++ b/test/e2e/space_cleanup_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
@@ -37,11 +38,15 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 		t.Run("when mur is deleted", func(t *testing.T) {
 			// given
-			_, mur, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "lara", "ibm")
+			_, userSignup, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "lara", "ibm")
 
 			// when
-			err := hostAwait.Client.Delete(context.TODO(), mur)
+			// deactivate the UserSignup so that the MUR will be deleted
+			userSignup, err := hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(us, true)
+			})
 			require.NoError(t, err)
+			t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
 			// then
 			err = hostAwait.WaitUntilSpaceBindingDeleted(spaceBinding.Name)
@@ -55,7 +60,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 		awaitilities := WaitForDeployments(t)
 		hostAwait := awaitilities.Host()
 
-		deletionThreshold := time.Now().Add(-30 * time.Second)
+		deletionThreshold := -30 * time.Second // space will only be deleted if at least 30 seconds has elapsed since it was created
 
 		// check that the spaces were provisioned before 30 seconds
 		space1, err := hostAwait.WaitForSpace(space1.Name, wait.UntilSpaceHasCreationTimestampOlderThan(deletionThreshold))
@@ -97,10 +102,10 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 	})
 }
 
-func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*v1alpha1.Space, *v1alpha1.MasterUserRecord, *v1alpha1.SpaceBinding) {
+func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	space := CreateAndVerifySpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(targetMember), WithName(spaceName))
 
-	_, mur := NewSignupRequest(t, awaitilities).
+	userSignup, mur := NewSignupRequest(t, awaitilities).
 		Username(murName).
 		ManuallyApprove().
 		TargetCluster(targetMember).
@@ -110,5 +115,5 @@ func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilitie
 
 	spaceBinding := CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
 
-	return space, mur, spaceBinding
+	return space, userSignup, spaceBinding
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1476,14 +1476,15 @@ func UntilSpaceHasLabelWithValue(key, value string) SpaceWaitCriterion {
 }
 
 // UntilSpaceHasCreationTimestampOlderThan returns a `SpaceWaitCriterion` which checks that the given
-// Space has been created before the given time
-func UntilSpaceHasCreationTimestampOlderThan(t time.Time) SpaceWaitCriterion {
+// Space has a timestamp that has elapsed the provided difference duration
+func UntilSpaceHasCreationTimestampOlderThan(expectedElapsedTime time.Duration) SpaceWaitCriterion {
 	return SpaceWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.Space) bool {
+			t := time.Now().Add(expectedElapsedTime)
 			return t.After(actual.CreationTimestamp.Time)
 		},
 		Diff: func(actual *toolchainv1alpha1.Space) string {
-			return fmt.Sprintf("expected space to be created after %s; Actual creation timestamp %s", t.String(), actual.CreationTimestamp.String())
+			return fmt.Sprintf("expected space to be created after %s; Actual creation timestamp %s", expectedElapsedTime.String(), actual.CreationTimestamp.String())
 		},
 	}
 }


### PR DESCRIPTION
The `TestSpaceAndSpaceBindingCleanup` test becomes flaky after the changes from https://github.com/codeready-toolchain/host-operator/pull/595 are in place. These changes ensure the tests pass with and without the changes from that PR.

Summary of Changes:
1. The deletion of the MUR happens much faster with the changes from https://github.com/codeready-toolchain/host-operator/pull/595 and I suspect the UserSignup is recreating it right away so deleting the MUR directly and then verifying the SpaceBinding is deleted becomes flaky so to work around that we can instead deactivate the UserSignup to ensure the MUR stays deleted and then we can verify the SpaceBinding is deleted.
2. The `for Spaces` sub-tests fail because the previous test executes in under 30 seconds. To work around this I changed  the deletionThreshold timestamp to a duration instead and pass that into the `UntilSpaceHasCreationTimestampOlderThan` function so that we can compute the time as we wait and we should reach the point where 30 seconds has elapsed since the spaces were created.