### PR TITLE
fix: capture metric baseline values from both members

### DIFF
--- a/test/e2e/toolchainstatus_test.go
+++ b/test/e2e/toolchainstatus_test.go
@@ -20,7 +20,6 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	memberAwait2 := awaitilities.Member2()
 	hostAwait.UpdateToolchainConfig(
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))
@@ -37,7 +36,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	err = hostAwait.DeletePods(client.InNamespace(hostAwait.Namespace), client.MatchingLabels{"name": "controller-manager"})
 	require.NoError(t, err)
 
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 	t.Run("tampering activation-counter annotations", func(t *testing.T) {
 

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -32,7 +32,7 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
@@ -91,7 +91,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 
 	// when
@@ -139,7 +139,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 
 	t.Run("restart host-operator pod and verify that metrics are still available", func(t *testing.T) {
 		// given
-		metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName})
+		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// when deleting the host-operator pod to emulate an operator restart during redeployment.
 		err := hostAwait.DeletePods(client.InNamespace(hostAwait.Namespace), client.MatchingLabels{"name": "controller-manager"})
@@ -169,7 +169,7 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 
 	for i := 1; i <= 2; i++ {
@@ -213,7 +213,7 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 	VerifyMemberMetricsService(t, memberAwait)
 
 	// given
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
 	userSignup, _ := NewSignupRequest(t, awaitilities).
@@ -244,7 +244,7 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	t.Run("unban the banned user", func(t *testing.T) {
 		// given
-		metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
+		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// when unbaning the user
 		err = hostAwait.Client.Delete(context.TODO(), bannedUser)
@@ -276,7 +276,7 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
-	metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
+	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 	// Create UserSignup
 	_, mur := NewSignupRequest(t, awaitilities).
@@ -314,7 +314,7 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 
 	t.Run("re-enabled mur", func(t *testing.T) {
 		// given
-		metricsAssertion := InitMetricsAssertion(t, hostAwait, []string{memberAwait.ClusterName, memberAwait2.ClusterName})
+		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// When re-enabling MUR
 		mur, err = hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
@@ -40,23 +41,23 @@ const (
 )
 
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
-func InitMetricsAssertion(t *testing.T, a metricsProvider, memberClusterNames []string) *MetricsAssertionHelper {
+func InitMetricsAssertion(t *testing.T, awaitilities wait.Awaitilities) *MetricsAssertionHelper {
 	// Wait for pending usersignup deletions before capturing baseline values so that test assertions are stable
-	err := a.WaitForTestResourcesCleanup(5 * time.Second)
+	err := awaitilities.Host().WaitForTestResourcesCleanup(5 * time.Second)
 	require.NoError(t, err)
 
 	// Capture baseline values
 	m := &MetricsAssertionHelper{
-		await:          a,
+		await:          awaitilities.Host(),
 		baselineValues: make(map[string]float64),
 		t:              t,
 	}
-	m.captureBaselineValues(memberClusterNames)
+	m.captureBaselineValues(awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
 	t.Logf("captured baselines:\n%s", spew.Sdump(m.baselineValues))
 	return m
 }
 
-func (m *MetricsAssertionHelper) captureBaselineValues(memberClusterNames []string) {
+func (m *MetricsAssertionHelper) captureBaselineValues(memberClusterNames ...string) {
 	m.baselineValues[UserSignupsMetric] = m.await.GetMetricValue(UserSignupsMetric)
 	m.baselineValues[UserSignupsApprovedMetric] = m.await.GetMetricValue(UserSignupsApprovedMetric)
 	m.baselineValues[UserSignupsDeactivatedMetric] = m.await.GetMetricValue(UserSignupsDeactivatedMetric)


### PR DESCRIPTION
capture metric baseline values from both members, otherwise, it cannot calculate the delta properly which can lead to a flaky test