### PR TITLE
fix: get rid of reg-service flakiness

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -19,11 +19,11 @@ dev-deploy-e2e-two-members: deploy-e2e-to-dev-namespaces-two-members print-reg-s
 
 .PHONY: deploy-e2e-to-dev-namespaces
 deploy-e2e-to-dev-namespaces:
-	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: deploy-e2e-to-dev-namespaces-two-members
 deploy-e2e-to-dev-namespaces-two-members:
-	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: dev-deploy-e2e-local
 dev-deploy-e2e-local: deploy-e2e-local-to-dev-namespaces print-reg-service-link
@@ -33,11 +33,11 @@ dev-deploy-e2e-local-two-members: deploy-e2e-local-to-dev-namespaces-two-members
 
 .PHONY: deploy-e2e-local-to-dev-namespaces
 deploy-e2e-local-to-dev-namespaces:
-	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: deploy-e2e-local-to-dev-namespaces-two-members
 deploy-e2e-local-to-dev-namespaces-two-members:
-	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: print-reg-service-link
 print-reg-service-link:
@@ -79,14 +79,14 @@ print-reg-service-link:
 .PHONY: dev-deploy-e2e-member-local
 ## Deploy the e2e resources with the local 'member-operator' repository only
 dev-deploy-e2e-member-local:
-	$(MAKE) dev-deploy-e2e MEMBER_REPO_PATH=${PWD}/../member-operator ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) dev-deploy-e2e MEMBER_REPO_PATH=${PWD}/../member-operator ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: dev-deploy-e2e-host-local
 ## Deploy the e2e resource with the local 'host-operator' repository only
 dev-deploy-e2e-host-local:
-	$(MAKE) dev-deploy-e2e HOST_REPO_PATH=${PWD}/../host-operator ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) dev-deploy-e2e HOST_REPO_PATH=${PWD}/../host-operator ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 
 .PHONY: dev-deploy-e2e-registration-local
 ## Deploy the e2e resources with the local 'registration-service' repository only
 dev-deploy-e2e-registration-local:
-	$(MAKE) dev-deploy-e2e REG_REPO_PATH=${PWD}/../registration-service ENVIRONMENT=${DEV_ENVIRONMENT} SETUP_E2E_SERVICE_ACCOUNTS=false IS_OSD=${IS_OSD}
+	$(MAKE) dev-deploy-e2e REG_REPO_PATH=${PWD}/../registration-service ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}

--- a/make/test.mk
+++ b/make/test.mk
@@ -28,7 +28,7 @@ else
 PUBLISH_OPERATOR := true
 endif
 
-SETUP_E2E_SERVICE_ACCOUNTS ?= true
+E2E_TEST_EXECUTION ?= true
 
 ifeq ($(IS_OSD),true)
 LETS_ENCRYPT_PARAM := --lets-encrypt
@@ -204,7 +204,7 @@ setup-toolchainclusters:
 
 .PHONY: e2e-service-account
 e2e-service-account:
-ifeq ($(SETUP_E2E_SERVICE_ACCOUNTS),true)
+ifeq ($(E2E_TEST_EXECUTION),true)
 	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/add-cluster.sh  SCRIPT_PARAMS="-t member -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s ${LETS_ENCRYPT_PARAM}"
 	$(MAKE) run-cicd-script SCRIPT_PATH=scripts/add-cluster.sh  SCRIPT_PARAMS="-t host -tn e2e -mn $(MEMBER_NS) -hn $(HOST_NS) -s ${LETS_ENCRYPT_PARAM}"
 	if [[ ${SECOND_MEMBER_MODE} == true ]]; then $(MAKE) run-cicd-script SCRIPT_PATH=scripts/add-cluster.sh  SCRIPT_PARAMS="-t member -tn e2e -mn $(MEMBER_NS_2) -hn $(HOST_NS) -s -mm 2 ${LETS_ENCRYPT_PARAM}"; fi
@@ -303,8 +303,10 @@ create-host-resources:
 		echo "{\"spec\":{\"members\":{\"specificPerMemberCluster\":{\"member-$${TOOLCHAIN_CLUSTER_NAME}2\":{\"webhook\":{\"deploy\":false}}}}}}" > $$PATCH_FILE; \
 		oc patch toolchainconfig config -n $(HOST_NS) --type=merge --patch "$$(cat $$PATCH_FILE)"; \
 	fi;
-	# delete registration-service pods in case they already exist
+ifneq ($(E2E_TEST_EXECUTION),true)
+	# if it's not part of e2e test execution, then delete registration-service pods in case they already exist
 	oc delete pods --namespace ${HOST_NS} -l name=registration-service || true
+endif
 
 .PHONY: create-has-application-crd
 create-has-application-crd:

--- a/make/test.mk
+++ b/make/test.mk
@@ -304,7 +304,7 @@ create-host-resources:
 		oc patch toolchainconfig config -n $(HOST_NS) --type=merge --patch "$$(cat $$PATCH_FILE)"; \
 	fi;
 ifneq ($(E2E_TEST_EXECUTION),true)
-	# if it's not part of e2e test execution, then delete registration-service pods in case they already exist
+	# if it's not part of e2e test execution, then delete registration-service pods in case they already exist so that the ToolchainConfig will be reloaded
 	oc delete pods --namespace ${HOST_NS} -l name=registration-service || true
 endif
 

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -16,6 +16,8 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/metrics"
+	"github.com/redhat-cop/operator-utils/pkg/util"
+	"k8s.io/kubectl/pkg/util/podutils"
 
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/require"
@@ -457,6 +459,19 @@ func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int) {
 		require.NoError(a.T, a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, name), deployment))
 		if int(deployment.Status.AvailableReplicas) != replicas {
 			return false, nil
+		}
+		pods := &corev1.PodList{}
+		require.NoError(a.T, a.Client.List(context.TODO(), pods, client.InNamespace(a.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)))
+		if len(pods.Items) != replicas {
+			return false, nil
+		}
+		for i := range pods.Items {
+			if util.IsBeingDeleted(&pods.Items[i]) {
+				return false, nil
+			}
+			if !podutils.IsPodReady(&pods.Items[i]) {
+				return false, nil
+			}
 		}
 		return true, nil
 	})

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -465,11 +465,8 @@ func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int) {
 		if len(pods.Items) != replicas {
 			return false, nil
 		}
-		for i := range pods.Items {
-			if util.IsBeingDeleted(&pods.Items[i]) {
-				return false, nil
-			}
-			if !podutils.IsPodReady(&pods.Items[i]) {
+		for _, pod := range pods.Items {
+			if util.IsBeingDeleted(&pod) || !podutils.IsPodReady(&pod) {
 				return false, nil
 			}
 		}

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -465,7 +465,7 @@ func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int) {
 		if len(pods.Items) != replicas {
 			return false, nil
 		}
-		for _, pod := range pods.Items {
+		for _, pod := range pods.Items { // nolint
 			if util.IsBeingDeleted(&pod) || !podutils.IsPodReady(&pod) {
 				return false, nil
 			}


### PR DESCRIPTION
this PR brings two improvements to get rid of reg-service flakiness:
* it doesn't force-restart the reg-service pods if it's part of e2e test execution
* lists all pods of the deployment the test is waiting for and checks that:
   * the number of pod matches the expected number of replicase
   * none of the pod is being deleted
   * all pods are ready