### PR TITLE
Install rhoda and update other operator versions

### DIFF
--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -4,7 +4,7 @@ This document describes how to use the setup tool to set up a Dev Sandbox enviro
 
 == Prereqs
 
-. Provision the *latest available* GA version of OCP on AWS with sufficient resources: 3 `m5.4xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
+. Provision the *latest available* GA version of *OCP 4.10.x* on AWS with sufficient resources: 3 `m5.4xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
 +
 The latest version of openshift-install can be downloaded from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 +

--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -4,7 +4,7 @@ This document describes how to use the setup tool to set up a Dev Sandbox enviro
 
 == Prereqs
 
-. Provision the *latest available* GA version of *OCP 4.10.x* on AWS with sufficient resources: 3 `m5.4xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
+. Provision the *latest available* GA version of *OCP 4.10.x* on AWS with sufficient resources: 3 `m5.8xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
 +
 The latest version of openshift-install can be downloaded from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 +

--- a/setup/operators/installtemplates/devworkspace-operator.yaml
+++ b/setup/operators/installtemplates/devworkspace-operator.yaml
@@ -24,7 +24,7 @@ objects:
       name: devworkspace-operator
       source: devworkspace-operator-catalog
       sourceNamespace: ${DWO_NAMESPACE}
-      startingCSV: devworkspace-operator.v0.11.0
+      startingCSV: devworkspace-operator.v0.13.0
 parameters:
   - name: DWO_NAMESPACE
     value: openshift-operators

--- a/setup/operators/installtemplates/gitops-primer-template.yaml
+++ b/setup/operators/installtemplates/gitops-primer-template.yaml
@@ -23,7 +23,7 @@ objects:
       name: gitops-primer
       source: community-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: gitops-primer.v0.0.5
+      startingCSV: gitops-primer.v0.0.6
 parameters:
   - name: GITOPS_PRIMER_OPERATOR_NAMESPACE
     value: gitops-primer-system

--- a/setup/operators/installtemplates/kiali.yaml
+++ b/setup/operators/installtemplates/kiali.yaml
@@ -14,7 +14,7 @@ objects:
       name: kiali-ossm
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: kiali-operator.v1.24.10
+      startingCSV: kiali-operator.v1.36.7
 parameters:
   - name: KIALI_NAMESPACE
     value: openshift-operators

--- a/setup/operators/installtemplates/rhoas.yaml
+++ b/setup/operators/installtemplates/rhoas.yaml
@@ -23,7 +23,7 @@ objects:
     name: rhoas-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: rhoas-operator.0.7.10
+    startingCSV: rhoas-operator.0.9.6
 parameters:
 - name: RHOAS_NAMESPACE
   value: rhoas-operator

--- a/setup/operators/installtemplates/rhoda.yaml
+++ b/setup/operators/installtemplates/rhoda.yaml
@@ -14,7 +14,7 @@ objects:
       namespace: ${DBAAS_NAMESPACE}
     spec:
       sourceType: grpc
-      image: quay.io/tchughesiv/dbaas-operator-catalog:v0.1
+      image: quay.io/osd-addons/dbaas-operator-index@sha256:6325f547b394b1d6f7a528ab3c01bb8f9052762acc245fd453378f5a47830923
       displayName: DBaaS Operator
   - apiVersion: operators.coreos.com/v1alpha1
     kind: Subscription
@@ -27,7 +27,7 @@ objects:
       name: dbaas-operator
       source: dbaas-operator-catalog
       sourceNamespace: ${DBAAS_NAMESPACE}
-      startingCSV: dbaas-operator.v0.1.5
+      startingCSV: dbaas-operator.v0.1.4
   - apiVersion: operators.coreos.com/v1
     kind: OperatorGroup
     metadata:

--- a/setup/operators/installtemplates/rhoda.yaml
+++ b/setup/operators/installtemplates/rhoda.yaml
@@ -1,0 +1,38 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: install-dbaas-operator
+objects:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ${DBAAS_NAMESPACE}
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: dbaas-operator-catalog
+      namespace: ${DBAAS_NAMESPACE}
+    spec:
+      sourceType: grpc
+      image: quay.io/tchughesiv/dbaas-operator-catalog:v0.1
+      displayName: DBaaS Operator
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dbaas-sub
+      namespace: ${DBAAS_NAMESPACE}
+    spec:
+      channel: alpha
+      installPlanApproval: Automatic
+      name: dbaas-operator
+      source: dbaas-operator-catalog
+      sourceNamespace: ${DBAAS_NAMESPACE}
+      startingCSV: dbaas-operator.v0.1.5
+  - apiVersion: operators.coreos.com/v1
+    kind: OperatorGroup
+    metadata:
+      name: dbaas-operator
+      namespace: ${DBAAS_NAMESPACE}
+parameters:
+  - name: DBAAS_NAMESPACE
+    value: rhoda-operator

--- a/setup/operators/installtemplates/sbo.yaml
+++ b/setup/operators/installtemplates/sbo.yaml
@@ -23,7 +23,7 @@ objects:
       name: rh-service-binding-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: service-binding-operator.v1.0.0
+      startingCSV: service-binding-operator.v1.0.1
       config:
         resources:
           requests:

--- a/setup/operators/installtemplates/serverless-operator.yaml
+++ b/setup/operators/installtemplates/serverless-operator.yaml
@@ -23,7 +23,7 @@ objects:
       name: serverless-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: serverless-operator.v1.17.0
+      startingCSV: serverless-operator.v1.21.0
 parameters:
   - name: SERVERLESS_OPERATOR_NAMESPACE
     value: serverless-operator

--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -23,6 +23,7 @@ const (
 )
 
 var Templates = []string{
+	"rhoda.yaml",
 	"devworkspace-operator.yaml",
 	"rhoas.yaml",
 	"sbo.yaml",
@@ -32,7 +33,7 @@ var Templates = []string{
 	"kiali.yaml", // OSD comes with an operator that creates CSVs in all namespaces so kiali is being used in this case to mimic the behaviour on OCP clusters
 }
 
-var csvTimeout = 20 * time.Second
+var csvTimeout = 60 * time.Second
 
 func VerifySandboxOperatorsInstalled(cl client.Client) error {
 	subs := &v1alpha1.SubscriptionList{}

--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -26,7 +26,7 @@ var Templates = []string{
 	"rhoda.yaml",
 	"devworkspace-operator.yaml",
 	"rhoas.yaml",
-	"sbo.yaml",
+	// "sbo.yaml", // included when rhoda is installed
 	"serverless-operator.yaml",
 	"web-terminal-operator.yaml",
 	"gitops-primer-template.yaml",


### PR DESCRIPTION
- Installs the rhoda (DBaaS) operator which will automatically install the mongo, crunch and cockroach operators.
- Updates the starting versions for some of the other operators to speed up installation process
- Mention installing latest OCP 4.10.x in README