### PR TITLE
feat: stop using SyncIndex

### DIFF
--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -154,15 +154,15 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	memberAwait := awaitilities.Member1()
 
 	// first group of users: the "cheesecake lovers"
-	cheesecakeSyncIndexes := setupAccounts(t, awaitilities, "cheesecake", "cheesecakelover%02d", memberAwait, count)
+	cheesecakeUsers := setupAccounts(t, awaitilities, "cheesecake", "cheesecakelover%02d", memberAwait, count)
 	// second group of users: the "cookie lovers"
-	cookieSyncIndexes := setupAccounts(t, awaitilities, "cookie", "cookielover%02d", memberAwait, count)
+	cookieUsers := setupAccounts(t, awaitilities, "cookie", "cookielover%02d", memberAwait, count)
 
 	// setup chocolate tier to be used for creating spaces without usersignups
 	spaces := setupSpaces(t, awaitilities, "chocolate", "chocolatelover%02d", memberAwait, count)
 
-	cheesecakeSyncIndexes = verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeSyncIndexes, "cheesecake", "base", "base", true)
-	cookieSyncIndexes = verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieSyncIndexes, "cookie", "base", "base", true)
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeUsers, "cheesecake", "base", "base")
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieUsers, "cookie", "base", "base")
 	verifyResourceUpdatesForSpaces(t, awaitilities, memberAwait, spaces, "chocolate", "base", "base")
 
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespaces (ie, same number of namespaces) but keep the ClusterResources refs
@@ -173,8 +173,8 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	updateTemplateTier(t, hostAwait, "chocolate", "advanced", "")
 
 	// then
-	cheesecakeSyncIndexes = verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeSyncIndexes, "cheesecake", "advanced", "base", false)
-	cookieSyncIndexes = verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieSyncIndexes, "cookie", "baseextendedidling", "baseextendedidling", false)
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeUsers, "cheesecake", "advanced", "base")
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieUsers, "cookie", "baseextendedidling", "baseextendedidling")
 	verifyResourceUpdatesForSpaces(t, awaitilities, memberAwait, spaces, "chocolate", "advanced", "base")
 
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for ClusterResources but keep the Namespaces refs
@@ -185,8 +185,8 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	updateTemplateTier(t, hostAwait, "chocolate", "", "advanced")
 
 	// then
-	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeSyncIndexes, "cheesecake", "advanced", "advanced", false)
-	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieSyncIndexes, "cookie", "base", "base", false)
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cheesecakeUsers, "cheesecake", "advanced", "advanced")
+	verifyResourceUpdatesForUserSignups(t, awaitilities, memberAwait, cookieUsers, "cookie", "base", "base")
 	verifyResourceUpdatesForSpaces(t, awaitilities, memberAwait, spaces, "chocolate", "advanced", "advanced")
 
 	// finally, verify the counters in the status.history for both 'cheesecake' and 'cookie' tiers
@@ -261,38 +261,33 @@ func setupSpaces(t *testing.T, awaitilities Awaitilities, tierName, nameFmt stri
 // 1. creating a new tier with the TemplateRefs of the "base" tier.
 // 2. creating 10 users (signups, MURs, etc.)
 // 3. promoting the users to the new tier
-// returns the tier, users and their "syncIndexes"
-func setupAccounts(t *testing.T, awaitilities Awaitilities, tierName, nameFmt string, targetCluster *MemberAwaitility, count int) map[string]string {
+// returns the usersignups
+func setupAccounts(t *testing.T, awaitilities Awaitilities, tierName, nameFmt string, targetCluster *MemberAwaitility, count int) []*toolchainv1alpha1.UserSignup {
 	// first, let's create the a new NSTemplateTier (to avoid messing with other tiers)
 	hostAwait := awaitilities.Host()
 	tier := CreateNSTemplateTier(t, hostAwait, tierName)
 
 	// let's create a few users (more than `maxPoolSize`)
 	// and wait until they are all provisioned by calling EnsureMUR()
-	users := make([]*toolchainv1alpha1.UserSignup, count)
+	userSignups := make([]*toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
-		users[i], _ = NewSignupRequest(t, awaitilities).
+		userSignups[i], _ = NewSignupRequest(t, awaitilities).
 			Username(fmt.Sprintf(nameFmt, i)).
 			ManuallyApprove().
-			EnsureMUR().
+			WaitForMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			TargetCluster(targetCluster).
 			Execute().
 			Resources()
 	}
 
-	// let's promote to users the new tier and retain the SyncIndexes (indexes by usersignup.Name)
-	syncIndexes := make(map[string]string, len(users))
-	for i, user := range users {
+	// let's promote to users the new tier
+	for i := range userSignups {
+		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "base")
 		username := fmt.Sprintf(nameFmt, i)
-		mur, err := hostAwait.WaitForMasterUserRecord(username,
-			UntilMasterUserRecordHasCondition(Provisioned())) // ignore other conditions, such as notification sent, etc.
-		require.NoError(t, err)
 		MoveUserToTier(t, hostAwait, username, tier.Name)
-		syncIndexes[user.Name] = mur.Spec.UserAccounts[0].SyncIndex
-		t.Logf("initial syncIndex for %s: '%s'", mur.Name, syncIndexes[user.Name])
 	}
-	return syncIndexes
+	return userSignups
 }
 
 // updateTemplateTier updates the given "tier" using the templateRefs of the "aliasTierNamespaces"
@@ -338,7 +333,7 @@ func verifyStatus(t *testing.T, hostAwait *HostAwaitility, tierName string, expe
 	}
 }
 
-func verifyResourceUpdatesForUserSignups(t *testing.T, awaitilities Awaitilities, memberAwaitility *MemberAwaitility, syncIndexes map[string]string, tierName, aliasTierNamespaces, aliasTierClusterResources string, tierNameChanged bool) map[string]string {
+func verifyResourceUpdatesForUserSignups(t *testing.T, awaitilities Awaitilities, memberAwaitility *MemberAwaitility, userSignups []*toolchainv1alpha1.UserSignup, tierName, aliasTierNamespaces, aliasTierClusterResources string) {
 
 	// verify that all TemplateUpdateRequests were deleted
 	hostAwait := awaitilities.Host()
@@ -346,10 +341,7 @@ func verifyResourceUpdatesForUserSignups(t *testing.T, awaitilities Awaitilities
 	require.NoError(t, err)
 
 	// verify individual user updates
-	updatedSyncIndexes := make(map[string]string, len(syncIndexes))
-	for userID, syncIndex := range syncIndexes {
-		usersignup, err := hostAwait.WaitForUserSignup(userID)
-		require.NoError(t, err)
+	for _, usersignup := range userSignups {
 		userAccount, err := memberAwaitility.WaitForUserAccount(usersignup.Status.CompliantUsername,
 			UntilUserAccountHasConditions(Provisioned()),
 			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Name, usersignup.Spec.OriginalSub)),
@@ -362,20 +354,9 @@ func verifyResourceUpdatesForUserSignups(t *testing.T, awaitilities Awaitilities
 			require.NoError(t, err, "Failing \nUserSignup: %+v \nUserAccount: %+v \nNSTemplateSet: %+v", usersignup, userAccount, nsTemplateSet)
 		}
 
-		// the syncIndex should be different if the tier changed. if only the template refs changed then the sync index is expected to be the same because UserAccounts no longer have references to the NSTemplateSet
-		mur, err := hostAwait.WaitForMasterUserRecord(usersignup.Status.CompliantUsername,
-			UntilMasterUserRecordHasCondition(Provisioned()), // ignore other conditions, such as notification sent, etc.
-			UntilMasterUserRecordHasSyncIndex(syncIndex, tierNameChanged),
-		)
-		require.NoError(t, err)
-		updatedSyncIndexes[userID] = mur.Spec.UserAccounts[0].SyncIndex
-		require.NotNil(t, userAccount)
-
 		// verify space and tier resources are correctly updated
-		VerifyResourcesProvisionedForSpaceWithTiers(t, awaitilities, memberAwaitility, mur.Name, tierName, aliasTierNamespaces, aliasTierClusterResources)
+		VerifyResourcesProvisionedForSpaceWithTiers(t, awaitilities, memberAwaitility, usersignup.Status.CompliantUsername, tierName, aliasTierNamespaces, aliasTierClusterResources)
 	}
-
-	return updatedSyncIndexes
 }
 
 func verifyResourceUpdatesForSpaces(t *testing.T, awaitilities Awaitilities, targetCluster *MemberAwaitility, spaces []string, tierName, aliasTierNamespaces, aliasTierClusterResources string) {

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -350,12 +350,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 				// Save the updated UserSignup's Status
 				require.NoError(t, hostAwait.Client.Status().Update(context.TODO(), userSignup))
 
-				// Trigger a reconciliation of the deactivation controller by updating the MUR
-				// - The SyncIndex property of the UserAccount is intended for the express purpose of triggering
-				//   a reconciliation, so we set it to some new unique value here
-				syncIndex := uuid.Must(uuid.NewV4()).String()
+				// Trigger a reconciliation of the deactivation controller by updating the MUR annotation
 				_, err := hostAwait.UpdateMasterUserRecordSpec(murName, func(mur *toolchainv1alpha1.MasterUserRecord) {
-					mur.Spec.UserAccounts[0].SyncIndex = syncIndex
+					if mur.Annotations == nil {
+						mur.Annotations = map[string]string{}
+					}
+					mur.Annotations["update-from-e2e-tests"] = "trigger"
 				})
 				if err != nil {
 					// the mur might already be deleted, so we can continue as long as the error is the mur was not found

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -343,21 +343,6 @@ func UntilMasterUserRecordHasConditions(expected ...toolchainv1alpha1.Condition)
 	}
 }
 
-// UntilMasterUserRecordHasSyncIndex checks if the MasterUserRecord has a
-// sync index that matches (or does not match) the given value
-func UntilMasterUserRecordHasSyncIndex(previousSyncIndex string, expectedToChange bool) MasterUserRecordWaitCriterion {
-	return MasterUserRecordWaitCriterion{
-		Match: func(actual *toolchainv1alpha1.MasterUserRecord) bool {
-			ua := actual.Spec.UserAccounts[0]
-			changed := ua.SyncIndex != previousSyncIndex
-			return changed == expectedToChange
-		},
-		Diff: func(actual *toolchainv1alpha1.MasterUserRecord) string {
-			return fmt.Sprintf("unexpected sync index value.\n\texpected to change: '%t'\n\tpreviousSyncIndex: '%s'\n\tcurrent: '%s'", expectedToChange, previousSyncIndex, actual.Spec.UserAccounts[0].SyncIndex)
-		},
-	}
-}
-
 func WithMurName(name string) MasterUserRecordWaitCriterion {
 	return MasterUserRecordWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.MasterUserRecord) bool {
@@ -377,7 +362,6 @@ func UntilMasterUserRecordHasUserAccountStatuses(expected ...toolchainv1alpha1.U
 				return false
 			}
 			for _, expUaStatus := range expected {
-				expUaStatus.SyncIndex = getUaSpecSyncIndex(actual, expUaStatus.Cluster.Name)
 				if !containsUserAccountStatus(actual.Status.UserAccounts, expUaStatus) {
 					return false
 				}
@@ -679,19 +663,9 @@ func (a *HostAwaitility) CheckMasterUserRecordIsDeleted(name string) {
 	require.Equal(a.T, wait.ErrWaitTimeout, err)
 }
 
-func getUaSpecSyncIndex(mur *toolchainv1alpha1.MasterUserRecord, cluster string) string {
-	for _, ua := range mur.Spec.UserAccounts {
-		if ua.TargetCluster == cluster {
-			return ua.SyncIndex
-		}
-	}
-	return ""
-}
-
 func containsUserAccountStatus(uaStatuses []toolchainv1alpha1.UserAccountStatusEmbedded, uaStatus toolchainv1alpha1.UserAccountStatusEmbedded) bool {
 	for _, status := range uaStatuses {
 		if reflect.DeepEqual(uaStatus.Cluster, status.Cluster) &&
-			uaStatus.SyncIndex == status.SyncIndex &&
 			test.ConditionsMatch(uaStatus.Conditions, status.Conditions...) {
 			return true
 		}


### PR DESCRIPTION
it drops the usage of SyncIndex from the code as it won't be updated/used by the controller anymore.
paired with: https://github.com/codeready-toolchain/host-operator/pull/617

originally, it was opened as https://github.com/codeready-toolchain/toolchain-e2e/pull/522 but I need to pair it with host-operator PR already as this is the first one that stops updating the SyncIndex in the MUR.status