### PR TITLE
feat: introduce test parallelism

### DIFF
--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -1,4 +1,4 @@
-package e2e
+package parallel
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 	// given
+	t.Parallel()
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -1,4 +1,4 @@
-package e2e
+package parallel
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 
 func TestCreateSpace(t *testing.T) {
 	// given
-
+	t.Parallel()
 	// make sure everything is ready before running the actual tests
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
@@ -85,7 +85,7 @@ func TestCreateSpace(t *testing.T) {
 }
 
 func TestSpaceRoles(t *testing.T) {
-
+	t.Parallel()
 	// instead of updating the NSTemplateSet, we should create SpaceBindings (with existing templateRefs!)
 	// and verify that the Roles and RoleBindings have been created on behalf of the 2 users
 	t.Skip("skipping until SpaceBindings are in place")
@@ -343,7 +343,7 @@ func TestSpaceRoles(t *testing.T) {
 }
 
 func TestPromoteSpace(t *testing.T) {
-
+	t.Parallel()
 	// given
 	// make sure everything is ready before running the actual tests
 	awaitilities := WaitForDeployments(t)
@@ -368,8 +368,15 @@ func TestPromoteSpace(t *testing.T) {
 	})
 }
 
+var toBeComplete = toolchainv1alpha1.Condition{
+	Type:   toolchainv1alpha1.ChangeTierRequestComplete,
+	Status: corev1.ConditionTrue,
+	Reason: toolchainv1alpha1.ChangeTierRequestChangedReason,
+}
+
 func TestRetargetSpace(t *testing.T) {
 	// given
+	t.Parallel()
 	// make sure everything is ready before running the actual tests
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
@@ -390,15 +397,6 @@ func TestRetargetSpace(t *testing.T) {
 	space = VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
 	err = member1Await.WaitUntilNSTemplateSetDeleted(space.Name) // expect NSTemplateSet to be delete on member-1 cluster
 	require.NoError(t, err)
-}
-
-func ProvisioningPending(msg string) toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.ConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  toolchainv1alpha1.SpaceProvisioningPendingReason,
-		Message: msg,
-	}
 }
 
 func ProvisioningFailed(msg string) toolchainv1alpha1.Condition {

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestAutomaticClusterAssignment(t *testing.T) {
@@ -160,4 +161,13 @@ func waitUntilSpaceIsPendingCluster(t *testing.T, hostAwait *wait.HostAwaitility
 		wait.UntilSpaceHasConditionForTime(ProvisioningPending("unspecified target member cluster"), time.Second))
 	require.NoError(t, err)
 	return space
+}
+
+func ProvisioningPending(msg string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.SpaceProvisioningPendingReason,
+		Message: msg,
+	}
 }

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -198,6 +200,26 @@ func (r *signupRequest) NoSpace() SignupRequest {
 	return r
 }
 
+var usernamesInParallel = &namesRegistry{usernames: map[string]string{}}
+
+type namesRegistry struct {
+	sync.RWMutex
+	usernames map[string]string
+}
+
+func (r *namesRegistry) add(t *testing.T, name string) {
+	r.Lock()
+	defer r.Unlock()
+	pwd := os.Getenv("PWD")
+	if !strings.HasSuffix(pwd, "parallel") {
+		return
+	}
+	if testName, exist := r.usernames[name]; exist {
+		require.Fail(t, fmt.Sprintf("The username '%s' was already used in the test '%s'", name, testName))
+	}
+	r.usernames[name] = t.Name()
+}
+
 func (r *signupRequest) Execute() SignupRequest {
 	hostAwait := r.awaitilities.Host()
 	err := hostAwait.WaitUntilBaseNSTemplateTierIsUpdated()
@@ -215,6 +237,8 @@ func (r *signupRequest) Execute() SignupRequest {
 		ID:       identityID,
 		Username: r.username,
 	}
+
+	usernamesInParallel.add(r.t, r.username)
 
 	claims := []authsupport.ExtraClaim{authsupport.WithEmailClaim(r.email)}
 	if r.originalSub != "" {

--- a/testsupport/spacebinding.go
+++ b/testsupport/spacebinding.go
@@ -45,10 +45,14 @@ func CreateSpaceBindingWithoutCleanup(t *testing.T, hostAwait *wait.HostAwaitili
 
 // NewSpaceBinding create an object SpaceBinding with the given values
 func NewSpaceBinding(mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, spaceRole string) *toolchainv1alpha1.SpaceBinding {
+	namePrefix := fmt.Sprintf("%s-%s", mur.Name, space.Name)
+	if len(namePrefix) > 50 {
+		namePrefix = namePrefix[0:50]
+	}
 	return &toolchainv1alpha1.SpaceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", mur.Name, space.Name),
-			Namespace: space.Namespace,
+			GenerateName: namePrefix + "-",
+			Namespace:    space.Namespace,
 			Labels: map[string]string{
 				toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: mur.Name,
 				toolchainv1alpha1.SpaceBindingSpaceLabelKey:            space.Name,


### PR DESCRIPTION
* creates a new directory called `parallel` which will contain tests that are executed in parallel
* moves `space_cleanup_test.go` and `space_test.go` in the directory (other tests will be moved in the following PRs)
* marks the test to be runnable in parallel
* adds configuration param to the `go test` command to configure the parallelism
* when the parallel tests are being executed, then check all usernames for any duplications
