### PR TITLE
feat: run registration_service_test in parallel

### DIFF
--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -287,7 +287,7 @@ func TestSignupFails(t *testing.T) {
 		require.Equal(t, float64(403), response["code"])
 
 		hostAwait := await.Host()
-		hostAwait.WaitAndVerifyThatUserSignupIsNotCreated(identity.ID.String())
+		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitAndVerifyThatUserSignupIsNotCreated(identity.ID.String())
 	})
 }
 

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -1,4 +1,4 @@
-package e2e
+package parallel
 
 import (
 	"bytes"
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/toolchain-common/pkg/states"
-
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -26,230 +25,236 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 var httpClient = HTTPClient
 
-func TestRegistrationService(t *testing.T) {
-	suite.Run(t, &registrationServiceTestSuite{})
-}
+func TestLandingPageReachable(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
 
-type registrationServiceTestSuite struct {
-	suite.Suite
-	wait.Awaitilities
-	namespace string
-	route     string
-}
-
-func (s *registrationServiceTestSuite) SetupSuite() {
-	s.Awaitilities = WaitForDeployments(s.T())
-	hostAwait := s.Host()
-	s.namespace = hostAwait.RegistrationServiceNs
-	s.route = hostAwait.RegistrationServiceURL
-}
-
-func (s *registrationServiceTestSuite) TestLandingPageReachable() {
 	// just make sure that the landing page is reachable
-	req, err := http.NewRequest("GET", s.route, nil)
-	require.NoError(s.T(), err)
+	req, err := http.NewRequest("GET", route, nil)
+	require.NoError(t, err)
 
 	resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer Close(t, resp)`
-	require.NoError(s.T(), err)
-	defer Close(s.T(), resp)
+	require.NoError(t, err)
+	defer Close(t, resp)
 
-	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func (s *registrationServiceTestSuite) TestHealth() {
-	s.Run("get healthcheck 200 OK", func() {
+func TestHealth(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
+
+	t.Run("get healthcheck 200 OK", func(t *testing.T) {
 		// Call health endpoint.
-		req, err := http.NewRequest("GET", s.route+"/api/v1/health", nil)
-		require.NoError(s.T(), err)
+		req, err := http.NewRequest("GET", route+"/api/v1/health", nil)
+		require.NoError(t, err)
 
 		resp, err := httpClient.Do(req) //nolint:bodyclose // see `defer Close(...)`
-		require.NoError(s.T(), err)
-		defer Close(s.T(), resp)
+		require.NoError(t, err)
+		defer Close(t, resp)
 
-		assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), body)
+		require.NoError(t, err)
+		require.NotNil(t, body)
 
 		mp := make(map[string]interface{})
 		err = json.Unmarshal([]byte(body), &mp)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Verify JSON response.
 		alive := mp["alive"]
-		require.IsType(s.T(), true, alive)
-		require.True(s.T(), alive.(bool))
+		require.IsType(t, true, alive)
+		require.True(t, alive.(bool))
 
 		environment := mp["environment"]
-		require.IsType(s.T(), "", environment)
-		require.Equal(s.T(), "e2e-tests", environment.(string))
+		require.IsType(t, "", environment)
+		require.Equal(t, "e2e-tests", environment.(string))
 
 		revision := mp["revision"]
-		require.NotNil(s.T(), revision)
+		require.NotNil(t, revision)
 
 		buildTime := mp["buildTime"]
-		require.NotNil(s.T(), buildTime)
+		require.NotNil(t, buildTime)
 
 		startTime := mp["startTime"]
-		require.NotNil(s.T(), startTime)
+		require.NotNil(t, startTime)
 	})
 }
 
-func (s *registrationServiceTestSuite) TestWoopra() {
+func TestWoopra(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
+
 	assertNotSecuredGetResponseEquals := func(endPointPath, expectedResponseValue string) {
 		// Call woopra domain endpoint.
-		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/%s", s.route, endPointPath), nil)
-		require.NoError(s.T(), err)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/v1/%s", route, endPointPath), nil)
+		require.NoError(t, err)
 
 		resp, err := httpClient.Do(req) //nolint:bodyclose // see `defer Close(...)`
-		require.NoError(s.T(), err)
-		defer Close(s.T(), resp)
+		require.NoError(t, err)
+		defer Close(t, resp)
 
-		assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), body)
+		require.NoError(t, err)
+		require.NotNil(t, body)
 
 		value := string(body)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Verify JSON response.
-		require.Equal(s.T(), expectedResponseValue, value)
+		require.Equal(t, expectedResponseValue, value)
 	}
 
-	s.Run("get woopra domain 200 OK", func() {
+	t.Run("get woopra domain 200 OK", func(t *testing.T) {
 		// Call woopra domain endpoint.
 		assertNotSecuredGetResponseEquals("woopra-domain", "test woopra domain")
 	})
 
-	s.Run("get segment write key 200 OK", func() {
+	t.Run("get segment write key 200 OK", func(t *testing.T) {
 		// Call segment write key endpoint.
 		assertNotSecuredGetResponseEquals("segment-write-key", "test segment write key")
 	})
 }
 
-func (s *registrationServiceTestSuite) TestAuthConfig() {
-	s.Run("get authconfig 200 OK", func() {
+func TestAuthConfig(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
+
+	t.Run("get authconfig 200 OK", func(t *testing.T) {
 		// Call authconfig endpoint.
-		req, err := http.NewRequest("GET", s.route+"/api/v1/authconfig", nil)
-		require.NoError(s.T(), err)
+		req, err := http.NewRequest("GET", route+"/api/v1/authconfig", nil)
+		require.NoError(t, err)
 
 		resp, err := httpClient.Do(req) //nolint:bodyclose // see `defer Close(...)`
-		require.NoError(s.T(), err)
-		defer Close(s.T(), resp)
+		require.NoError(t, err)
+		defer Close(t, resp)
 
-		assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), body)
+		require.NoError(t, err)
+		require.NotNil(t, body)
 	})
 }
 
-func (s *registrationServiceTestSuite) TestSignupFails() {
+func TestSignupFails(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
+
 	identity0 := authsupport.NewIdentity()
 	emailClaim0 := authsupport.WithEmailClaim(uuid.Must(uuid.NewV4()).String() + "@acme.com")
 
-	s.Run("post signup error no token 401 Unauthorized", func() {
+	t.Run("post signup error no token 401 Unauthorized", func(t *testing.T) {
 		// Call signup endpoint without a token.
 		requestBody, err := json.Marshal(map[string]string{})
-		require.NoError(s.T(), err)
-		req, err := http.NewRequest("POST", s.route+"/api/v1/signup", bytes.NewBuffer(requestBody))
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
+		req, err := http.NewRequest("POST", route+"/api/v1/signup", bytes.NewBuffer(requestBody))
+		require.NoError(t, err)
 		req.Header.Set("content-type", "application/json")
 
 		resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer.Close(...)`
-		defer Close(s.T(), resp)
-		require.NoError(s.T(), err)
+		defer Close(t, resp)
+		require.NoError(t, err)
 
 		// Retrieve unauthorized http status code.
-		assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), body)
+		require.NoError(t, err)
+		require.NotNil(t, body)
 
 		mp := make(map[string]interface{})
 		err = json.Unmarshal([]byte(body), &mp)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Equal(s.T(), "no token found", tokenErr.(string))
+		require.Equal(t, "no token found", tokenErr.(string))
 	})
-	s.Run("post signup error invalid token 401 Unauthorized", func() {
+	t.Run("post signup error invalid token 401 Unauthorized", func(t *testing.T) {
 		// Call signup endpoint with an invalid token.
-		mp := invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", "1223123123", "", http.StatusUnauthorized)
+		mp := invokeEndpoint(t, "POST", route+"/api/v1/signup", "1223123123", "", http.StatusUnauthorized)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Equal(s.T(), "token contains an invalid number of segments", tokenErr.(string))
+		require.Equal(t, "token contains an invalid number of segments", tokenErr.(string))
 	})
-	s.Run("post signup exp token 401 Unauthorized", func() {
+	t.Run("post signup exp token 401 Unauthorized", func(t *testing.T) {
 		expClaim1 := authsupport.WithExpClaim(time.Now().Add(-60 * time.Second))
 
 		// Not identical to the token used in POST signup - should return resource not found.
 		token1, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, expClaim1)
-		require.NoError(s.T(), err)
-		mp := invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token1, "", http.StatusUnauthorized)
+		require.NoError(t, err)
+		mp := invokeEndpoint(t, "POST", route+"/api/v1/signup", token1, "", http.StatusUnauthorized)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Contains(s.T(), tokenErr.(string), "token is expired by ")
+		require.Contains(t, tokenErr.(string), "token is expired by ")
 	})
-	s.Run("get signup error no token 401 Unauthorized", func() {
+	t.Run("get signup error no token 401 Unauthorized", func(t *testing.T) {
 		// Call signup endpoint without a token.
-		req, err := http.NewRequest("GET", s.route+"/api/v1/signup", nil)
-		require.NoError(s.T(), err)
+		req, err := http.NewRequest("GET", route+"/api/v1/signup", nil)
+		require.NoError(t, err)
 		req.Header.Set("content-type", "application/json")
 
 		resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer.Close(...)`
-		require.NoError(s.T(), err)
-		defer Close(s.T(), resp)
+		require.NoError(t, err)
+		defer Close(t, resp)
 
 		// Retrieve unauthorized http status code.
-		assert.Equal(s.T(), http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 
 		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(s.T(), err)
-		require.NotNil(s.T(), body)
+		require.NoError(t, err)
+		require.NotNil(t, body)
 
 		mp := make(map[string]interface{})
 		err = json.Unmarshal([]byte(body), &mp)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Equal(s.T(), "no token found", tokenErr.(string))
+		require.Equal(t, "no token found", tokenErr.(string))
 	})
-	s.Run("get signup error invalid token 401 Unauthorized", func() {
+	t.Run("get signup error invalid token 401 Unauthorized", func(t *testing.T) {
 		// Call signup endpoint with an invalid token.
-		mp := invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", "1223123123", "", http.StatusUnauthorized)
+		mp := invokeEndpoint(t, "GET", route+"/api/v1/signup", "1223123123", "", http.StatusUnauthorized)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Equal(s.T(), "token contains an invalid number of segments", tokenErr.(string))
+		require.Equal(t, "token contains an invalid number of segments", tokenErr.(string))
 	})
-	s.Run("get signup exp token 401 Unauthorized", func() {
+	t.Run("get signup exp token 401 Unauthorized", func(t *testing.T) {
 		expClaim1 := authsupport.WithExpClaim(time.Now().Add(-60 * time.Second))
 
 		// Not identical to the token used in POST signup - should return resource not found.
 		token1, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, expClaim1)
-		require.NoError(s.T(), err)
-		mp := invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token1, "", http.StatusUnauthorized)
+		require.NoError(t, err)
+		mp := invokeEndpoint(t, "GET", route+"/api/v1/signup", token1, "", http.StatusUnauthorized)
 
 		// Check token error.
 		tokenErr := mp["error"]
-		require.Contains(s.T(), tokenErr.(string), "token is expired by ")
+		require.Contains(t, tokenErr.(string), "token is expired by ")
 	})
-	s.Run("get signup 404 NotFound", func() {
+	t.Run("get signup 404 NotFound", func(t *testing.T) {
 		// Get valid generated token for e2e tests. IAT claim is overridden
 		// to avoid token used before issued error.
 		identity1 := authsupport.NewIdentity()
@@ -258,13 +263,13 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 
 		// Not identical to the token used in POST signup - should return resource not found.
 		token1, err := authsupport.GenerateSignedE2ETestToken(*identity1, emailClaim1, iatClaim1)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Call signup endpoint with a valid token.
-		s.assertGetSignupReturnsNotFound(token1)
+		assertGetSignupReturnsNotFound(t, await, token1)
 	})
 
-	s.Run("get signup for crtadmin fails", func() {
+	t.Run("get signup for crtadmin fails", func(t *testing.T) {
 		// Get valid generated token for e2e tests. IAT claim is overridden
 		// to avoid token used before issued error. Username claim is also
 		// overridden to trigger error and ensure that usersignup is not created.
@@ -273,94 +278,100 @@ func (s *registrationServiceTestSuite) TestSignupFails() {
 		emailClaim := authsupport.WithEmailClaim(emailValue)
 		usernameClaim := authsupport.WithPreferredUsernameClaim("test-crtadmin")
 		token, err := authsupport.GenerateSignedE2ETestToken(*identity, emailClaim, usernameClaim)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Call signup endpoint with a valid token to initiate a signup process
-		response := invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusForbidden)
-		require.Equal(s.T(), "forbidden: failed to create usersignup for test-crtadmin", response["message"])
-		require.Equal(s.T(), "error creating UserSignup resource", response["details"])
-		require.Equal(s.T(), float64(403), response["code"])
+		response := invokeEndpoint(t, "POST", route+"/api/v1/signup", token, "", http.StatusForbidden)
+		require.Equal(t, "forbidden: failed to create usersignup for test-crtadmin", response["message"])
+		require.Equal(t, "error creating UserSignup resource", response["details"])
+		require.Equal(t, float64(403), response["code"])
 
-		hostAwait := s.Host()
-		userSignup, err := hostAwait.WaitForUserSignup(identity.ID.String())
-		require.Nil(s.T(), userSignup)
-		require.Error(s.T(), err)
-		require.EqualError(s.T(), err, "timed out waiting for the condition")
+		hostAwait := await.Host()
+		hostAwait.WaitAndVerifyThatUserSignupIsNotCreated(identity.ID.String())
 	})
 }
 
-func (s *registrationServiceTestSuite) TestSignupOK() {
+func TestSignupOK(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
 
-	hostAwait := s.Host()
-	memberAwait := s.Member1()
+	hostAwait := await.Host()
+	memberAwait := await.Member1()
 	signupUser := func(token, email, userSignupName string, identity *authsupport.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
-		invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusAccepted)
+		invokeEndpoint(t, "POST", route+"/api/v1/signup", token, "", http.StatusAccepted)
 
 		// Wait for the UserSignup to be created
 		userSignup, err := hostAwait.WaitForUserSignup(userSignupName,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), PendingApproval())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
+		cleanup.AddCleanTasks(hostAwait, userSignup)
 		emailAnnotation := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
-		assert.Equal(s.T(), email, emailAnnotation)
+		assert.Equal(t, email, emailAnnotation)
 
 		// Call get signup endpoint with a valid token and make sure it's pending approval
-		s.assertGetSignupStatusPendingApproval(identity.Username, token)
+		assertGetSignupStatusPendingApproval(t, await, identity.Username, token)
 
 		// Attempt to create same usersignup by calling post signup with same token should return an error
-		mp := invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token, "", http.StatusConflict)
-		assert.Equal(s.T(), fmt.Sprintf("Operation cannot be fulfilled on  \"\": UserSignup [id: %s; username: %s]. Unable to create UserSignup because there is already an active UserSignup with such ID",
+		mp := invokeEndpoint(t, "POST", route+"/api/v1/signup", token, "", http.StatusConflict)
+		assert.Equal(t, fmt.Sprintf("Operation cannot be fulfilled on  \"\": UserSignup [id: %s; username: %s]. Unable to create UserSignup because there is already an active UserSignup with such ID",
 			identity.ID, identity.Username), mp["message"])
-		assert.Equal(s.T(), "error creating UserSignup resource", mp["details"])
+		assert.Equal(t, "error creating UserSignup resource", mp["details"])
 
 		// Approve usersignup.
 		states.SetApproved(userSignup, true)
 		userSignup.Spec.TargetCluster = memberAwait.ClusterName
 		err = hostAwait.Client.Update(context.TODO(), userSignup)
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+		VerifyResourcesProvisionedForSignup(t, await, userSignup, "base")
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
-		s.assertGetSignupStatusProvisioned(identity.Username, token)
+		assertGetSignupStatusProvisioned(t, await, identity.Username, token)
 
 		return userSignup
 	}
 
-	s.Run("test activation-deactivation workflow", func() {
+	t.Run("test activation-deactivation workflow", func(t *testing.T) {
 		// Get valid generated token for e2e tests. IAT claim is overridden
 		// to avoid token used before issued error.
 		identity := authsupport.NewIdentity()
 		emailValue := uuid.Must(uuid.NewV4()).String() + "@acme.com"
 		emailClaim := authsupport.WithEmailClaim(emailValue)
-		t, err := authsupport.GenerateSignedE2ETestToken(*identity, emailClaim)
-		require.NoError(s.T(), err)
+		token, err := authsupport.GenerateSignedE2ETestToken(*identity, emailClaim)
+		require.NoError(t, err)
 
 		// Signup a new user
-		userSignup := signupUser(t, emailValue, identity.Username, identity)
+		userSignup := signupUser(token, emailValue, identity.Username, identity)
 
 		// Deactivate the usersignup
 		userSignup, err = hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 		_, err = hostAwait.WaitForUserSignup(userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), DeactivatedWithoutPreDeactivation())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
-		require.NoError(s.T(), err)
+		require.NoError(t, err)
 
 		// Now check that the reg-service treats the deactivated usersignup as nonexistent and returns 404
-		s.assertGetSignupReturnsNotFound(t)
+		assertGetSignupReturnsNotFound(t, await, token)
 
 		// Re-activate the usersignup by calling the signup endpoint with the same token/user again
-		signupUser(t, emailValue, identity.Username, identity)
+		signupUser(token, emailValue, identity.Username, identity)
 	})
 }
+func TestUserSignupFoundWhenNamedWithEncodedUsername(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
 
-func (s *registrationServiceTestSuite) TestUserSignupFoundWhenNamedWithEncodedUsername() {
-	hostAwait := s.Host()
+	hostAwait := await.Host()
 
 	// Create a token and identity to sign up with, but override the username with "arnold" so that we create a UserSignup
 	// with that name
@@ -369,232 +380,243 @@ func (s *registrationServiceTestSuite) TestUserSignupFoundWhenNamedWithEncodedUs
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
 	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, authsupport.WithSubClaim(identity0.ID.String()),
 		authsupport.WithPreferredUsernameClaim("arnold"))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Call the signup endpoint
-	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token0, "", http.StatusAccepted)
+	invokeEndpoint(t, "POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
 	userSignup, err := hostAwait.WaitForUserSignup("arnold",
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), PendingApproval())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
+	cleanup.AddCleanTasks(hostAwait, userSignup)
 	emailAnnotation := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
-	assert.Equal(s.T(), emailValue, emailAnnotation)
+	assert.Equal(t, emailValue, emailAnnotation)
 
 	// Call get signup endpoint with a valid token, however we will now override the claims to introduce the original
 	// sub claim and set username as a separate claim, then we will make sure the UserSignup is returned correctly
 	token0, err = authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0, authsupport.WithPreferredUsernameClaim("arnold"))
-	require.NoError(s.T(), err)
-	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
-	assert.Equal(s.T(), "", mp["compliantUsername"])
-	assert.Equal(s.T(), "arnold", mp["username"])
-	require.IsType(s.T(), false, mpStatus["ready"])
-	assert.False(s.T(), mpStatus["ready"].(bool))
-	assert.Equal(s.T(), "PendingApproval", mpStatus["reason"])
+	require.NoError(t, err)
+	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", token0, "", http.StatusOK))
+	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Equal(t, "arnold", mp["username"])
+	require.IsType(t, false, mpStatus["ready"])
+	assert.False(t, mpStatus["ready"].(bool))
+	assert.Equal(t, "PendingApproval", mpStatus["reason"])
 }
 
-func (s *registrationServiceTestSuite) TestPhoneVerification() {
-	hostAwait := s.Host()
+func TestPhoneVerification(t *testing.T) {
+	// given
+	t.Parallel()
+	await := WaitForDeployments(t)
+	route := await.Host().RegistrationServiceURL
+
+	hostAwait := await.Host()
 	// Create a token and identity to sign up with
 	identity0 := authsupport.NewIdentity()
 	emailValue := uuid.Must(uuid.NewV4()).String() + "@some.domain"
 	emailClaim0 := authsupport.WithEmailClaim(emailValue)
 	token0, err := authsupport.GenerateSignedE2ETestToken(*identity0, emailClaim0)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Call the signup endpoint
-	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", token0, "", http.StatusAccepted)
+	invokeEndpoint(t, "POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
 	userSignup, err := hostAwait.WaitForUserSignup(identity0.Username,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
+	cleanup.AddCleanTasks(hostAwait, userSignup)
 	emailAnnotation := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
-	assert.Equal(s.T(), emailValue, emailAnnotation)
+	assert.Equal(t, emailValue, emailAnnotation)
 
 	// Call get signup endpoint with a valid token and make sure verificationRequired is true
-	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
-	assert.Equal(s.T(), "", mp["compliantUsername"])
-	assert.Equal(s.T(), identity0.Username, mp["username"])
-	require.IsType(s.T(), false, mpStatus["ready"])
-	assert.False(s.T(), mpStatus["ready"].(bool))
-	assert.Equal(s.T(), "PendingApproval", mpStatus["reason"])
-	require.True(s.T(), mpStatus["verificationRequired"].(bool))
+	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", token0, "", http.StatusOK))
+	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Equal(t, identity0.Username, mp["username"])
+	require.IsType(t, false, mpStatus["ready"])
+	assert.False(t, mpStatus["ready"].(bool))
+	assert.Equal(t, "PendingApproval", mpStatus["reason"])
+	require.True(t, mpStatus["verificationRequired"].(bool))
 
 	// Confirm the status of the UserSignup is correct
 	_, err = hostAwait.WaitForUserSignup(identity0.Username,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm that a MUR hasn't been created
 	obj := &toolchainv1alpha1.MasterUserRecord{}
 	err = hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: hostAwait.Namespace, Name: identity0.Username}, obj)
-	require.Error(s.T(), err)
-	require.True(s.T(), errors.IsNotFound(err))
+	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	// Initiate the verification process
-	invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", token0,
+	invokeEndpoint(t, "PUT", route+"/api/v1/signup/verification", token0,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup
 	userSignup, err = hostAwait.WaitForUserSignup(identity0.Username)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm there is a verification code annotation value, and store it in a variable
 	verificationCode := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
-	require.NotEmpty(s.T(), verificationCode)
+	require.NotEmpty(t, verificationCode)
 
 	// Confirm the expiry time has been set
-	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
+	require.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
 
 	// Attempt to verify with an incorrect verification code
-	invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
+	invokeEndpoint(t, "GET", route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
 
 	// Retrieve the updated UserSignup
 	userSignup, err = hostAwait.WaitForUserSignup(identity0.Username)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Check attempts has been incremented
-	require.NotEmpty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
+	require.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
 
 	// Confirm the verification code has not changed
-	require.Equal(s.T(), verificationCode, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Equal(t, verificationCode, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Verify with the correct code
-	invokeEndpoint(s.T(), "GET", s.route+fmt.Sprintf("/api/v1/signup/verification/%s",
+	invokeEndpoint(t, "GET", route+fmt.Sprintf("/api/v1/signup/verification/%s",
 		userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]), token0, "", http.StatusOK)
 
 	// Retrieve the updated UserSignup
 	userSignup, err = hostAwait.WaitForUserSignup(identity0.Username,
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValuePending))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm all unrequired verification-related annotations have been removed
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationTimestampAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey])
-	require.Empty(s.T(), userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserVerificationAttemptsAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationTimestampAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCounterAnnotationKey])
+	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
-	mp, mpStatus = parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
-	assert.Equal(s.T(), "", mp["compliantUsername"])
-	assert.Equal(s.T(), identity0.Username, mp["username"])
-	require.IsType(s.T(), false, mpStatus["ready"])
-	assert.False(s.T(), mpStatus["ready"].(bool))
-	assert.Equal(s.T(), "PendingApproval", mpStatus["reason"])
-	require.False(s.T(), mpStatus["verificationRequired"].(bool))
+	mp, mpStatus = parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", token0, "", http.StatusOK))
+	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Equal(t, identity0.Username, mp["username"])
+	require.IsType(t, false, mpStatus["ready"])
+	assert.False(t, mpStatus["ready"].(bool))
+	assert.Equal(t, "PendingApproval", mpStatus["reason"])
+	require.False(t, mpStatus["verificationRequired"].(bool))
 
 	// Now approve the usersignup.
 	states.SetApproved(userSignup, true)
 
 	err = hostAwait.Client.Update(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm the MasterUserRecord is provisioned
 	_, err = hostAwait.WaitForMasterUserRecord(identity0.Username, wait.UntilMasterUserRecordHasCondition(Provisioned()))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Retrieve the UserSignup from the GET endpoint
-	_, mpStatus = parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", token0, "", http.StatusOK))
+	_, mpStatus = parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", token0, "", http.StatusOK))
 
 	// Confirm that VerificationRequired is no longer true
-	require.False(s.T(), mpStatus["verificationRequired"].(bool))
+	require.False(t, mpStatus["verificationRequired"].(bool))
 
 	// Create another token and identity to sign up with
 	otherIdentity := authsupport.NewIdentity()
 	otherEmailValue := uuid.Must(uuid.NewV4()).String() + "@other.domain"
 	otherEmailClaim := authsupport.WithEmailClaim(otherEmailValue)
 	otherToken, err := authsupport.GenerateSignedE2ETestToken(*otherIdentity, otherEmailClaim)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Call the signup endpoint
-	invokeEndpoint(s.T(), "POST", s.route+"/api/v1/signup", otherToken, "", http.StatusAccepted)
+	invokeEndpoint(t, "POST", route+"/api/v1/signup", otherToken, "", http.StatusAccepted)
 
 	// Wait for the UserSignup to be created
 	otherUserSignup, err := hostAwait.WaitForUserSignup(otherIdentity.Username,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
+	cleanup.AddCleanTasks(hostAwait, otherUserSignup)
 	otherEmailAnnotation := otherUserSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]
-	assert.Equal(s.T(), otherEmailValue, otherEmailAnnotation)
+	assert.Equal(t, otherEmailValue, otherEmailAnnotation)
 
 	// Initiate the verification process using the same phone number as previously
-	responseMap := invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
+	responseMap := invokeEndpoint(t, "PUT", route+"/api/v1/signup/verification", otherToken,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusForbidden)
 
-	require.NotEmpty(s.T(), responseMap)
-	require.Equal(s.T(), float64(http.StatusForbidden), responseMap["code"], "code not found in response body map %s", responseMap)
+	require.NotEmpty(t, responseMap)
+	require.Equal(t, float64(http.StatusForbidden), responseMap["code"], "code not found in response body map %s", responseMap)
 
-	require.Equal(s.T(), "Forbidden", responseMap["status"])
-	require.Equal(s.T(), "phone number already in use:cannot register using phone number: +61408999999", responseMap["message"])
-	require.Equal(s.T(), "phone number already in use", responseMap["details"])
+	require.Equal(t, "Forbidden", responseMap["status"])
+	require.Equal(t, "phone number already in use:cannot register using phone number: +61408999999", responseMap["message"])
+	require.Equal(t, "phone number already in use", responseMap["details"])
 
 	// Retrieve the updated UserSignup
 	otherUserSignup, err = hostAwait.WaitForUserSignup(otherIdentity.Username)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm there is no verification code annotation value
-	require.Empty(s.T(), otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.Empty(t, otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Retrieve the current UserSignup
 	userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Now mark the original UserSignup as deactivated
 	states.SetDeactivated(userSignup, true)
 
 	err = hostAwait.Client.Update(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Ensure the UserSignup is deactivated
 	_, err = hostAwait.WaitForUserSignup(userSignup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), ManuallyDeactivated())...))
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Now attempt the verification again
-	invokeEndpoint(s.T(), "PUT", s.route+"/api/v1/signup/verification", otherToken,
+	invokeEndpoint(t, "PUT", route+"/api/v1/signup/verification", otherToken,
 		`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 	// Retrieve the updated UserSignup again
 	otherUserSignup, err = hostAwait.WaitForUserSignup(otherIdentity.Username)
-	require.NoError(s.T(), err)
+	require.NoError(t, err)
 
 	// Confirm there is now a verification code annotation value
-	require.NotEmpty(s.T(), otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	require.NotEmpty(t, otherUserSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 }
 
-func (s *registrationServiceTestSuite) assertGetSignupStatusProvisioned(username, bearerToken string) {
-	hostAwait := s.Host()
-	memberAwait := s.Member1()
-	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
-	assert.Equal(s.T(), username, mp["compliantUsername"])
-	assert.Equal(s.T(), username, mp["username"])
-	require.IsType(s.T(), false, mpStatus["ready"])
-	assert.True(s.T(), mpStatus["ready"].(bool))
-	assert.Equal(s.T(), "Provisioned", mpStatus["reason"])
-	assert.Equal(s.T(), memberAwait.GetConsoleURL(), mp["consoleURL"])
+func assertGetSignupStatusProvisioned(t *testing.T, await wait.Awaitilities, username, bearerToken string) {
+	hostAwait := await.Host()
+	route := await.Host().RegistrationServiceURL
+	memberAwait := await.Member1()
+	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusOK))
+	assert.Equal(t, username, mp["compliantUsername"])
+	assert.Equal(t, username, mp["username"])
+	require.IsType(t, false, mpStatus["ready"])
+	assert.True(t, mpStatus["ready"].(bool))
+	assert.Equal(t, "Provisioned", mpStatus["reason"])
+	assert.Equal(t, memberAwait.GetConsoleURL(), mp["consoleURL"])
 	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
-	require.NoError(s.T(), err)
-	require.True(s.T(), found)
-	assert.Equal(s.T(), memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
-	assert.Equal(s.T(), hostAwait.APIProxyURL, mp["proxyURL"])
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, memberCluster.Spec.APIEndpoint, mp["apiEndpoint"])
+	assert.Equal(t, hostAwait.APIProxyURL, mp["proxyURL"])
 }
 
-func (s *registrationServiceTestSuite) assertGetSignupStatusPendingApproval(username, bearerToken string) {
-	mp, mpStatus := parseResponse(s.T(), invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusOK))
-	assert.Equal(s.T(), username, mp["username"])
-	require.IsType(s.T(), false, mpStatus["ready"])
-	assert.False(s.T(), mpStatus["ready"].(bool))
-	assert.Equal(s.T(), "PendingApproval", mpStatus["reason"])
+func assertGetSignupStatusPendingApproval(t *testing.T, await wait.Awaitilities, username, bearerToken string) {
+	route := await.Host().RegistrationServiceURL
+	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusOK))
+	assert.Equal(t, username, mp["username"])
+	require.IsType(t, false, mpStatus["ready"])
+	assert.False(t, mpStatus["ready"].(bool))
+	assert.Equal(t, "PendingApproval", mpStatus["reason"])
 }
 
-func (s *registrationServiceTestSuite) assertGetSignupReturnsNotFound(bearerToken string) {
-	invokeEndpoint(s.T(), "GET", s.route+"/api/v1/signup", bearerToken, "", http.StatusNotFound)
+func assertGetSignupReturnsNotFound(t *testing.T, await wait.Awaitilities, bearerToken string) {
+	route := await.Host().RegistrationServiceURL
+	invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusNotFound)
 }
 
 func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, requiredStatus int) map[string]interface{} {

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -287,7 +287,7 @@ func TestSignupFails(t *testing.T) {
 		require.Equal(t, float64(403), response["code"])
 
 		hostAwait := await.Host()
-		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitAndVerifyThatUserSignupIsNotCreated(identity.ID.String())
+		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 15)).WaitAndVerifyThatUserSignupIsNotCreated(identity.ID.String())
 	})
 }
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+var httpClient = HTTPClient
+
 func TestUserManagement(t *testing.T) {
 	suite.Run(t, &userManagementTestSuite{})
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -593,6 +593,26 @@ func (a *HostAwaitility) WaitForUserSignupByUserIDAndUsername(userID, username s
 	return userSignup, err
 }
 
+// WaitAndVerifyThatUserSignupIsNotCreated waits and checks that the UserSignup is not created
+func (a *HostAwaitility) WaitAndVerifyThatUserSignupIsNotCreated(name string) {
+	a.T.Logf("waiting and verifying that UserSignup '%s' in namespace '%s' is not created", name, a.Namespace)
+	var userSignup *toolchainv1alpha1.UserSignup
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+		obj := &toolchainv1alpha1.UserSignup{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, obj); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		userSignup = obj
+		return true, nil
+	})
+	if err == nil {
+		require.Fail(a.T, fmt.Sprintf("UserSignup '%s' should not be created, but it was found: %v", name, userSignup))
+	}
+}
+
 // WaitForBannedUser waits until there is a BannedUser available with the given email
 func (a *HostAwaitility) WaitForBannedUser(email string) (*toolchainv1alpha1.BannedUser, error) {
 	a.T.Logf("waiting for BannedUser for user '%s' in namespace '%s'", email, a.Namespace)


### PR DESCRIPTION
This is another PR in the effort of running e2e tests in parallel. This time it is for `registration_service_test.go`
Changes:
* moved `registration_service_test.go` to `parallel` dir
* transformed the test from suites to normal standalone tests (the testing framework doesn't have full support for running suites in parallel https://github.com/stretchr/testify/issues/187)
* introduce & use `WaitAndVerifyThatUserSignupIsNotCreated` to verify that a UserSignup is not created