### PR TITLE
Test deactivation controller with UserTiers

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,10 +136,10 @@ func TestE2EFlow(t *testing.T) {
 	// Confirm the originalSub property has been set during signup
 	require.Equal(t, originalSubJohnClaim, originalSubJohnSignup.Spec.OriginalSub)
 
-	VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, originalSubJohnSignup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, originalSubJohnSignup, "base", "base")
 
 	johnsmithMur, err := hostAwait.GetMasterUserRecord(johnsmithName)
 	require.NoError(t, err)
@@ -160,8 +160,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
@@ -175,8 +175,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -191,8 +191,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
@@ -207,8 +207,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
@@ -232,8 +232,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := memberAwait.WaitForNamespace(johnSignup.Spec.Username, ref, "base", wait.UntilNamespaceIsActive())
 				require.NoError(t, err)
 			}
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 		})
 
 		t.Run("delete useraccount and expect recreation", func(t *testing.T) {
@@ -255,7 +255,7 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// then verify the recreated user account
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
 		})
 	})
 
@@ -289,7 +289,7 @@ func TestE2EFlow(t *testing.T) {
 
 		require.Equal(t, "laracroft", laraSignUp.Status.CompliantUsername)
 
-		VerifyResourcesProvisionedForSignup(t, awaitilities, laraSignUp, "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, laraSignUp, "base", "base")
 
 		VerifySpaceBinding(t, hostAwait, laraUserName, laraUserName, "admin")
 
@@ -391,27 +391,27 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("role accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 			DeletedRoleAndAwaitRecreation(t, memberAwait, devNs, "rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
 		})
 
 		t.Run("role accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 			DeletedRoleAndAwaitRecreation(t, memberAwait, stageNs, "rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
 		})
 
 		t.Run("rolebinding accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, devNs, "user-rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
 		})
 
 		t.Run("rolebinding accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, stageNs, "user-rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
 		})
 	})
 
@@ -455,7 +455,7 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
 
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -226,8 +226,8 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Move the user to the new tier
-		tiers.MoveUserToTier(t, hostAwait, updatedUserSignup.Spec.Username, "advanced")
+		// Move the space to the new tier
+		tiers.MoveSpaceToTier(t, hostAwait, updatedUserSignup.Spec.Username, "advanced")
 
 		// Ensure the deactivating state is reset after promotion
 		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
@@ -281,7 +281,7 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 	for i := range userSignups {
 		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "base")
 		username := fmt.Sprintf(nameFmt, i)
-		tiers.MoveUserToTier(t, hostAwait, username, tier.Name)
+		tiers.MoveSpaceToTier(t, hostAwait, username, tier.Name)
 	}
 	return userSignups
 }

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -226,14 +226,14 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Move the space to the new tier
-		tiers.MoveSpaceToTier(t, hostAwait, updatedUserSignup.Spec.Username, "advanced")
+		// Move the MUR to the user tier with longer deactivation time
+		tiers.MoveMURToTier(t, hostAwait, updatedUserSignup.Spec.Username, "advanced")
 
 		// Ensure the deactivating state is reset after promotion
 		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
 		require.NoError(t, err)
 		require.False(t, states.Deactivating(promotedUserSignup), "usersignup should not be deactivating")
-		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "advanced", "advanced")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "advanced", "base")
 	})
 }
 

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -63,7 +63,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	var changeTierRequestNames []string
 
 	// wait for the user to be provisioned for the first time
-	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "base", "base")
 	for _, tierToCheck := range tiersToCheck {
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
@@ -94,7 +94,7 @@ func TestNSTemplateTiers(t *testing.T) {
 			require.NoError(t, err)
 			_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, tierToCheck)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, tierToCheck, tierToCheck)
 			changeTierRequestNames = append(changeTierRequestNames, changeTierRequest.Name)
 		})
 	}
@@ -233,7 +233,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
 		require.NoError(t, err)
 		require.False(t, states.Deactivating(promotedUserSignup), "usersignup should not be deactivating")
-		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "advanced")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "advanced", "advanced")
 	})
 }
 
@@ -279,7 +279,7 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 
 	// let's promote to users the new tier
 	for i := range userSignups {
-		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "base", "base")
 		username := fmt.Sprintf(nameFmt, i)
 		tiers.MoveSpaceToTier(t, hostAwait, username, tier.Name)
 	}

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -328,7 +328,7 @@ func TestSignupOK(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(t, await, userSignup, "base")
+		VerifyResourcesProvisionedForSignup(t, await, userSignup, "base", "base")
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		assertGetSignupStatusProvisioned(t, await, identity.Username, token)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -90,7 +90,7 @@ func TestProxyFlow(t *testing.T) {
 			user.signup, _ = req.Resources()
 			user.token = req.GetToken()
 
-			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "appstudio")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "appstudio", "appstudio")
 			_, err := hostAwait.GetMasterUserRecord(user.username)
 			require.NoError(t, err)
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var httpClient = HTTPClient
@@ -327,7 +326,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(s.T(), err)
 
 		// Verify resources still exist
-		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base")
+		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "deactivate30", "base")
 	})
 
 	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
@@ -381,7 +380,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
-			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "deactivate30", "base")
 
 			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
@@ -468,8 +467,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 
 		// User on member cluster 1
 		userSignupMember1, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("usertodeactivate").
-			Email("usertodeactivate@redhat.com").
+			Username("usertodeactivatex").
+			Email("usertodeactivatex@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -478,8 +477,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 
 		// User on member cluster 2
 		userSignupMember2, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("usertodeactivate2").
-			Email("usertodeactivate2@example.com").
+			Username("usertodeactivate2x").
+			Email("usertodeactivate2x@example.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait2).
@@ -499,8 +498,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 
 		// User on member cluster 1
 		userNoEmail, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("usernoemail").
-			Email("usernoemail@redhat.com").
+			Username("usernoemailx").
+			Email("usernoemailx@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -523,8 +522,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
 
 		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
-			Username("usernodeactivate").
-			Email("usernodeactivate@redhat.com").
+			Username("usernodeactivatex").
+			Email("usernodeactivatex@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -536,7 +535,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 		require.NoError(t, err)
 
 		// Move the user to the new tier without deactivation enabled
-		tiers.MoveSpaceToTier(t, hostAwait, userSignupMember1.Status.CompliantUsername, baseDeactivationDisabledTier.Name)
+		tiers.MoveMURToTier(t, hostAwait, userSignupMember1.Status.CompliantUsername, baseDeactivationDisabledTier.Name)
 		murMember1, err = hostAwait.WaitForMasterUserRecord(murMember1.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()),
 			wait.UntilMasterUserRecordHasTierName(baseDeactivationDisabledTier.Name)) // ignore other conditions, such as notification sent, etc.
@@ -565,8 +564,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
 		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
-			Username("usertoautodeactivate").
-			Email("usertoautodeactivate@redhat.com").
+			Username("usertoautodeactivatex").
+			Email("usertoautodeactivatex@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -574,8 +573,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 			Execute().Resources()
 
 		deactivationExcludedUserSignupMember1, excludedMurMember1 := NewSignupRequest(t, s.Awaitilities).
-			Username("userdeactivationexcluded").
-			Email("userdeactivationexcluded@excluded.com").
+			Username("userdeactivationexcludedx").
+			Email("userdeactivationexcludedx@excluded.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -636,8 +635,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 		require.Equal(s.T(), 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
 		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
-			Username("usertostartdeactivating").
-			Email("usertostartdeactivating@redhat.com").
+			Username("usertostartdeactivatingx").
+			Email("usertostartdeactivatingx@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
@@ -666,7 +665,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 		require.NoError(s.T(), err)
 
 		// Verify resources have been provisioned
-		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base")
+		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base", "base")
 	})
 
 	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
@@ -680,8 +679,8 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 
 		// Create a new UserSignup
 		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("fulldeactivationlifecycle").
-			Email("fulldeactivationlifecycle@redhat.com").
+			Username("fulldeactivationlifecyclex").
+			Email("fulldeactivationlifecyclex@redhat.com").
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
 			Execute().Resources()
@@ -717,7 +716,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
-			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base", "base")
 
 			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
@@ -770,7 +769,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 				})
 				if err != nil {
 					// the mur might already be deleted, so we can continue as long as the error is the mur was not found
-					require.EqualError(t, err, `masteruserrecords.toolchain.dev.openshift.com "fulldeactivationlifecycle" not found`)
+					require.EqualError(t, err, `masteruserrecords.toolchain.dev.openshift.com "fulldeactivationlifecyclex" not found`)
 				}
 
 				// The user should now be set to deactivated
@@ -962,7 +961,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().Resources()
 
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 
 	// Disable MUR
 	mur, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
@@ -1002,7 +1001,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 	})
 }
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	identitypkg "github.com/codeready-toolchain/toolchain-common/pkg/identity"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 
@@ -48,6 +49,366 @@ func (s *userManagementTestSuite) SetupSuite() {
 }
 
 func (s *userManagementTestSuite) TestUserDeactivation() {
+	hostAwait := s.Host()
+	memberAwait := s.Member1()
+	memberAwait2 := s.Member2()
+	hostAwait.UpdateToolchainConfig(
+		testconfig.AutomaticApproval().Enabled(false),
+		testconfig.Deactivation().DeactivatingNotificationDays(-1))
+
+	config := hostAwait.GetToolchainConfig()
+	require.Equal(s.T(), -1, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
+
+	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
+
+		// User on member cluster 1
+		userSignupMember1, mur1 := NewSignupRequest(t, s.Awaitilities).
+			Username("usertodeactivate").
+			Email("usertodeactivate@redhat.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, mur1)
+
+		// User on member cluster 2
+		userSignupMember2, mur2 := NewSignupRequest(t, s.Awaitilities).
+			Username("usertodeactivate2").
+			Email("usertodeactivate2@example.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait2).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, mur2)
+
+		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember1)
+		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember2)
+
+		t.Run("reactivate a deactivated user", func(t *testing.T) {
+			ReactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember1)
+			ReactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember2)
+		})
+	})
+
+	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
+
+		// User on member cluster 1
+		userNoEmail, mur := NewSignupRequest(t, s.Awaitilities).
+			Username("usernoemail").
+			Email("usernoemail@redhat.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, mur)
+
+		// Delete the user's email and set them to deactivated
+		userSignup, err := hostAwait.UpdateUserSignup(userNoEmail.Name, func(us *toolchainv1alpha1.UserSignup) {
+			delete(us.Annotations, toolchainv1alpha1.UserSignupUserEmailAnnotationKey)
+			states.SetDeactivated(us, true)
+		})
+		require.NoError(s.T(), err)
+		s.T().Logf("user signup '%s' set to deactivated", userSignup.Name)
+
+		_, err = hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), UserSignupMissingEmailAnnotation())...))
+		require.NoError(t, err)
+	})
+
+	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
+
+		_, murMember1 := NewSignupRequest(t, s.Awaitilities).
+			Username("usernodeactivate").
+			Email("usernodeactivate@redhat.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
+
+		// Get the tier that has deactivation disabled
+		deactivationDisabledTier, err := hostAwait.WaitForUserTier("nodeactivation")
+		require.NoError(t, err)
+
+		// Move the user to the new tier without deactivation enabled
+		tiers.MoveMURToTier(t, hostAwait, murMember1.Name, deactivationDisabledTier.Name)
+		murMember1, err = hostAwait.WaitForMasterUserRecord(murMember1.Name,
+			wait.UntilMasterUserRecordHasCondition(Provisioned()),
+			wait.UntilMasterUserRecordHasTierName(deactivationDisabledTier.Name)) // ignore other conditions, such as notification sent, etc.
+		require.NoError(s.T(), err)
+
+		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
+		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
+		// time should test the behaviour of the deactivation controller reconciliation.
+		manyManyDaysAgo := 999999999999999
+		durationDelta := time.Duration(manyManyDaysAgo) * time.Hour * 24
+		updatedProvisionedTime := &metav1.Time{Time: time.Now().Add(-durationDelta)}
+		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = updatedProvisionedTime
+		})
+		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted", murMember1.Name)
+
+		// The user should not be deactivated so the MUR should not be deleted, expect an error
+		err = hostAwait.WithRetryOptions(wait.TimeoutOption(3 * time.Second)).WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murMember1.Name)
+		require.Error(s.T(), err)
+
+		// The space should not be deleted either, expect an error
+		err = hostAwait.WithRetryOptions(wait.TimeoutOption(3 * time.Second)).WaitUntilSpaceAndSpaceBindingsDeleted(murMember1.Name)
+		require.Error(t, err)
+	})
+
+	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
+		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
+			Username("usertoautodeactivate").
+			Email("usertoautodeactivate@redhat.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
+
+		deactivationExcludedUserSignupMember1, excludedMurMember1 := NewSignupRequest(t, s.Awaitilities).
+			Username("userdeactivationexcluded").
+			Email("userdeactivationexcluded@excluded.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
+
+		// Get the provisioned account's tier
+		baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
+		require.NoError(t, err)
+
+		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
+		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
+		// time should test the behaviour of the deactivation controller reconciliation.
+		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
+		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+		})
+		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name, murMember1.Status.ProvisionedTime.String())
+
+		// Use the same method above to change the provisioned time for the excluded user
+		excludedMurMember1, err = hostAwait.UpdateMasterUserRecordStatus(excludedMurMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+		})
+		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", excludedMurMember1.Name, excludedMurMember1.Status.ProvisionedTime.String())
+
+		// The non-excluded user should be deactivated
+		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murMember1.Name)
+		require.NoError(s.T(), err)
+
+		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(murMember1.Name)
+		require.NoError(t, err)
+
+		userSignupMember1, err = hostAwait.WaitForUserSignup(userSignupMember1.Name,
+			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), Deactivated())...),
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
+		require.NoError(s.T(), err)
+		require.True(t, states.Deactivated(userSignupMember1), "usersignup should be deactivated")
+
+		// The excluded user should still be active
+		_, err = hostAwait.WaitForMasterUserRecord(excludedMurMember1.Name)
+		require.NoError(s.T(), err)
+		deactivationExcludedUserSignupMember1, err = hostAwait.WaitForUserSignup(deactivationExcludedUserSignupMember1.Name,
+			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
+		require.NoError(s.T(), err)
+		require.False(t, states.Deactivated(deactivationExcludedUserSignupMember1), "deactivationExcludedUserSignup should not be deactivated")
+	})
+
+	s.T().Run("test deactivating state set OK", func(t *testing.T) {
+		// Reset configuration back to 3 days
+		hostAwait.UpdateToolchainConfig(
+			testconfig.AutomaticApproval().Enabled(false),
+			testconfig.Deactivation().DeactivatingNotificationDays(3))
+
+		config := hostAwait.GetToolchainConfig()
+		require.Equal(s.T(), 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
+
+		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
+			Username("usertostartdeactivating").
+			Email("usertostartdeactivating@redhat.com").
+			ManuallyApprove().
+			EnsureMUR().
+			TargetCluster(memberAwait).
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
+
+		// Get the provisioned account's tier
+		baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
+		require.NoError(t, err)
+
+		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the
+		// provisioned time to a time far enough in the past to trigger the deactivation process. Subtracting the given
+		// period from the current time and setting this as the provisioned time should test the behaviour of the
+		// deactivation controller reconciliation.
+		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
+		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+		})
+		require.NoError(s.T(), err)
+		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name,
+			murMember1.Status.ProvisionedTime.String())
+
+		// The user should be set to deactivating, but not deactivated
+		_, err = hostAwait.WaitForUserSignup(userSignupMember1.Name, wait.UntilUserSignupHasConditions(
+			ConditionSet(Default(), ApprovedByAdmin(), Deactivating())...))
+		require.NoError(s.T(), err)
+
+		// Verify resources still exist
+		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base")
+	})
+
+	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
+		// Set configuration to 3 days
+		hostAwait.UpdateToolchainConfig(
+			testconfig.AutomaticApproval().Enabled(true),
+			testconfig.Deactivation().DeactivatingNotificationDays(3))
+
+		hostConfig := hostAwait.GetToolchainConfig().Spec.Host
+		require.Equal(s.T(), 3, *hostConfig.Deactivation.DeactivatingNotificationDays)
+
+		// Create a new UserSignup
+		userSignup, mur := NewSignupRequest(t, s.Awaitilities).
+			Username("fulldeactivationlifecycle").
+			Email("fulldeactivationlifecycle@redhat.com").
+			EnsureMUR().
+			RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
+			Execute().Resources()
+
+		// TODO remove once UserTier migration is completed
+		s.promoteToDefaultUserTier(hostAwait.Client, mur)
+
+		// Wait for the UserSignup to have the desired state
+		userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
+		require.NoError(s.T(), err)
+
+		s.T().Run("user set to deactivating when provisioned time set in past", func(t *testing.T) {
+			// Get the provisioned account's tier
+			baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
+			require.NoError(t, err)
+
+			mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
+			require.NoError(t, err)
+
+			// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the
+			// provisioned time to a time far enough in the past to trigger the deactivation process. Subtracting the given
+			// period from the current time and setting this as the provisioned time should test the behaviour of the
+			// deactivation controller reconciliation.
+			tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
+			mur, err = hostAwait.UpdateMasterUserRecordStatus(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+				mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+			})
+			require.NoError(s.T(), err)
+			s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
+				mur.Status.ProvisionedTime.String())
+
+			// The user should be set to deactivating, but not deactivated
+			userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(
+				ConditionSet(Default(), ApprovedAutomatically(), Deactivating())...))
+			require.NoError(s.T(), err)
+
+			// Verify resources have been provisioned
+			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base")
+
+			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
+				// Set the provisioned time even further back
+				tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+4) * time.Hour * 24
+				mur, err = hostAwait.UpdateMasterUserRecordStatus(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+				})
+				murName := mur.Name
+				require.NoError(s.T(), err)
+				s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
+					mur.Status.ProvisionedTime.String())
+
+				// Set the LastTransitionTime of the status to 3 days in the past
+				deactivatingLastTransitionTime := metav1.Time{Time: time.Now().Add(time.Duration(-3) * time.Hour * 24)}
+
+				// Update the LastTransitionTime of the DeactivatingNotificationCreated condition
+				newConditions := make([]toolchainv1alpha1.Condition, len(userSignup.Status.Conditions))
+				copy(newConditions, userSignup.Status.Conditions)
+				for i, c := range newConditions {
+					if c.Type == toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated {
+						newCondition := toolchainv1alpha1.Condition{
+							Type:               c.Type,
+							Status:             c.Status,
+							LastTransitionTime: deactivatingLastTransitionTime,
+							Reason:             c.Reason,
+							Message:            c.Message,
+							LastUpdatedTime:    c.LastUpdatedTime,
+						}
+						newConditions[i] = newCondition
+						break
+					}
+				}
+				userSignup.Status.Conditions = newConditions
+
+				// Confirm that the LastTransitionTime has been correctly set
+				updated, found := condition.FindConditionByType(userSignup.Status.Conditions,
+					toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated)
+				require.True(t, found)
+				require.Equal(t, deactivatingLastTransitionTime, updated.LastTransitionTime)
+
+				// Save the updated UserSignup's Status
+				require.NoError(t, hostAwait.Client.Status().Update(context.TODO(), userSignup))
+
+				// Trigger a reconciliation of the deactivation controller by updating the MUR annotation
+				_, err := hostAwait.UpdateMasterUserRecordSpec(murName, func(mur *toolchainv1alpha1.MasterUserRecord) {
+					if mur.Annotations == nil {
+						mur.Annotations = map[string]string{}
+					}
+					mur.Annotations["update-from-e2e-tests"] = "trigger"
+				})
+				if err != nil {
+					// the mur might already be deleted, so we can continue as long as the error is the mur was not found
+					require.EqualError(t, err, `masteruserrecords.toolchain.dev.openshift.com "fulldeactivationlifecycle" not found`)
+				}
+
+				// The user should now be set to deactivated
+				userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+					wait.UntilUserSignupHasConditions(ConditionSet(ApprovedAutomatically(), Deactivated())...))
+				require.NoError(s.T(), err)
+
+				// The MUR should also be deleted
+				err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murName)
+				require.NoError(s.T(), err)
+
+				err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(murName)
+				require.NoError(t, err)
+			})
+		})
+	})
+}
+
+func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
 	memberAwait2 := s.Member2()
@@ -130,7 +491,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(t, err)
 
 		// Move the user to the new tier without deactivation enabled
-		tiers.MoveUserToTier(t, hostAwait, userSignupMember1.Spec.Username, baseDeactivationDisabledTier.Name)
+		tiers.MoveSpaceToTier(t, hostAwait, userSignupMember1.Status.CompliantUsername, baseDeactivationDisabledTier.Name)
 		murMember1, err = hostAwait.WaitForMasterUserRecord(murMember1.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()),
 			wait.UntilMasterUserRecordHasTierName(baseDeactivationDisabledTier.Name)) // ignore other conditions, such as notification sent, etc.
@@ -641,4 +1002,11 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 			})
 		}
 	})
+}
+
+// TODO remove once UserTier migration is completed
+func (s *userManagementTestSuite) promoteToDefaultUserTier(cl client.Client, mur *toolchainv1alpha1.MasterUserRecord) {
+	mur.Spec.TierName = "deactivate30"
+	err := cl.Update(context.TODO(), mur)
+	require.NoError(s.T(), err)
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -106,7 +106,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
 
 		// User on member cluster 1
-		userSignupMember1, mur1 := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember1, _ := NewSignupRequest(t, s.Awaitilities).
 			Username("usertodeactivate").
 			Email("usertodeactivate@redhat.com").
 			ManuallyApprove().
@@ -115,11 +115,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
 
-		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, mur1)
-
 		// User on member cluster 2
-		userSignupMember2, mur2 := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember2, _ := NewSignupRequest(t, s.Awaitilities).
 			Username("usertodeactivate2").
 			Email("usertodeactivate2@example.com").
 			ManuallyApprove().
@@ -127,9 +124,6 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait2).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
-
-		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, mur2)
 
 		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember1)
 		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember2)
@@ -143,7 +137,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
 
 		// User on member cluster 1
-		userNoEmail, mur := NewSignupRequest(t, s.Awaitilities).
+		userNoEmail, _ := NewSignupRequest(t, s.Awaitilities).
 			Username("usernoemail").
 			Email("usernoemail@redhat.com").
 			ManuallyApprove().
@@ -151,9 +145,6 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
-
-		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, mur)
 
 		// Delete the user's email and set them to deactivated
 		userSignup, err := hostAwait.UpdateUserSignup(userNoEmail.Name, func(us *toolchainv1alpha1.UserSignup) {

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -170,9 +170,6 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
 
-		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
-
 		// Get the tier that has deactivation disabled
 		deactivationDisabledTier, err := hostAwait.WaitForUserTier("nodeactivation")
 		require.NoError(t, err)

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -75,7 +75,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 		})
 	})
 
@@ -117,7 +117,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -130,7 +130,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
-				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 			})
 		})
 	})
@@ -270,7 +270,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 		})
 	})
 
@@ -298,7 +298,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 		})
 	})
 
@@ -349,7 +349,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -110,20 +110,20 @@ func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitili
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio", "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
@@ -174,7 +174,7 @@ func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *to
 	require.NoError(t, err)
 
 	// verify that it's unbanned
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
 }
 
 func checkMURMigratedAndGetSignup(t *testing.T, hostAwait *wait.HostAwaitility, murName string) *toolchainv1alpha1.UserSignup {

--- a/testsupport/deactivation.go
+++ b/testsupport/deactivation.go
@@ -77,7 +77,7 @@ func ReactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSi
 	require.NoError(t, err)
 	require.False(t, states.Deactivated(userSignup), "usersignup should not be deactivated")
 
-	VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
 
 	return userSignup
 }

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -310,7 +310,7 @@ func (r *signupRequest) Execute() SignupRequest {
 		if hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier != nil {
 			expectedTier = *hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier
 		}
-		VerifyResourcesProvisionedForSignup(r.t, r.awaitilities, userSignup, expectedTier)
+		VerifyResourcesProvisionedForSignup(r.t, r.awaitilities, userSignup, expectedTier, expectedTier)
 		mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasTierName(expectedTier))
 		require.NoError(r.t, err)
 		r.mur = mur

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -151,12 +151,13 @@ func duplicateTierTemplate(hostAwait *HostAwaitility, namespace, tierName, origT
 
 func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierName string) {
 	t.Logf("moving space '%s' to space tier '%s'", spacename, tierName)
-	space, err := hostAwait.WaitForSpace(spacename)
+	_, err := hostAwait.WaitForSpace(spacename)
 	require.NoError(t, err)
 
-	_, err = hostAwait.UpdateSpace(space, func(s *toolchainv1alpha1.Space) {
+	_, err = hostAwait.UpdateSpace(spacename, func(s *toolchainv1alpha1.Space) {
 		s.Spec.TierName = tierName
 	})
+	require.NoError(t, err)
 }
 
 func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -156,12 +156,25 @@ func duplicateTierTemplate(hostAwait *HostAwaitility, namespace, tierName, origT
 	return newTierTemplate.Name, nil
 }
 
-func MoveUserToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {
-	t.Logf("moving user '%s' to tier '%s'", username, tierName)
-	changeTierRequest := NewChangeTierRequest(hostAwait.Namespace, username, tierName)
-	err := hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
+func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierName string) {
+	t.Logf("moving space '%s' to space tier '%s'", spacename, tierName)
+	space, err := hostAwait.WaitForSpace(spacename)
 	require.NoError(t, err)
-	_, err = hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
+
+	space.Spec.TierName = tierName
+
+	err = hostAwait.Client.Update(context.TODO(), space)
+	require.NoError(t, err)
+}
+
+func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {
+	t.Logf("moving masteruserrecord '%s' to user tier '%s'", username, tierName)
+	mur, err := hostAwait.WaitForMasterUserRecord(username)
+	require.NoError(t, err)
+
+	mur.Spec.TierName = tierName
+
+	err = hostAwait.Client.Update(context.TODO(), mur)
 	require.NoError(t, err)
 }
 

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -164,9 +164,9 @@ func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName s
 	mur, err := hostAwait.WaitForMasterUserRecord(username)
 	require.NoError(t, err)
 
-	mur.Spec.TierName = tierName
-
-	err = hostAwait.Client.Update(context.TODO(), mur)
+	_, err = hostAwait.UpdateMasterUserRecord(false, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		mur.Spec.TierName = tierName
+	})
 	require.NoError(t, err)
 }
 

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -10,19 +10,12 @@ import (
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint:revive
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/require"
 )
 
 type TierModifier func(tier *toolchainv1alpha1.NSTemplateTier) error
-
-var toBeComplete = toolchainv1alpha1.Condition{
-	Type:   toolchainv1alpha1.ChangeTierRequestComplete,
-	Status: corev1.ConditionTrue,
-	Reason: toolchainv1alpha1.ChangeTierRequestChangedReason,
-}
 
 type CustomNSTemplateTier struct {
 	// the "base" NSTemplateTier

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -154,10 +154,9 @@ func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierNam
 	space, err := hostAwait.WaitForSpace(spacename)
 	require.NoError(t, err)
 
-	space.Spec.TierName = tierName
-
-	err = hostAwait.Client.Update(context.TODO(), space)
-	require.NoError(t, err)
+	_, err = hostAwait.UpdateSpace(space, func(s *toolchainv1alpha1.Space) {
+		s.Spec.TierName = tierName
+	})
 }
 
 func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/637

- tests that user deactivation works with both UserTier and NSTemplateTier (NSTemplateTier deactivation test will be removed after UserTier migration is complete)
- updates Verify functions to accept both `userTierName` and `spaceTierName` where `userTierName` corresponds to the expected MUR TierName and `spaceTierName` corresponds to  the expected Space TierName
- split `MoveUserToTier` helper function into `MoveSpaceToTier` and `MoveMURToTier`