### PR TITLE
Chore: Add empty metrics instance for appstudio

### DIFF
--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -73,6 +73,7 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 	return g
 }
 
+//nolint:golint,unused
 func NewEmpty(t terminal.Terminal, cl client.Client, token string, interval time.Duration) *Gatherer {
 	g := &Gatherer{
 		k8sClient:     cl,

--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -74,7 +74,7 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 }
 
 //nolint
-func NewEmpty(t terminal.Terminal, cl client.Client, token string, interval time.Duration) *Gatherer {
+func NewEmpty(t terminal.Terminal, cl client.Client, interval time.Duration) *Gatherer {
 	g := &Gatherer{
 		k8sClient:     cl,
 		queryInterval: interval,

--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -73,7 +73,7 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 	return g
 }
 
-//nolint:golint,unused
+//nolint
 func NewEmpty(t terminal.Terminal, cl client.Client, token string, interval time.Duration) *Gatherer {
 	g := &Gatherer{
 		k8sClient:     cl,

--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -73,6 +73,16 @@ func New(t terminal.Terminal, cl client.Client, token string, interval time.Dura
 	return g
 }
 
+func NewEmpty(t terminal.Terminal, cl client.Client, token string, interval time.Duration) *Gatherer {
+	g := &Gatherer{
+		k8sClient:     cl,
+		queryInterval: interval,
+		term:          t,
+	}
+	g.results = make(map[string]aggregateResult, len(g.mqueries))
+	return g
+}
+
 func (g *Gatherer) AddQueries(queries ...queries.Query) {
 	g.mqueries = append(g.mqueries, queries...)
 }


### PR DESCRIPTION
Hello, we are using the metrics pkg as an dependency for load testing AppStudio , well we just needed one empty metrics instance that we will add the workloads later from our script PTAL . 
 