### PR TITLE
Test migration to user tiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220525173141-368ad66e7e07
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220530143713-7cfc4ff163ce
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.12.0
 	github.com/ghodss/yaml v1.0.0
@@ -33,7 +33,5 @@ require (
 	k8s.io/metrics v0.22.7
 	sigs.k8s.io/controller-runtime v0.10.3
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220525173141-368ad66e7e07
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.12.0
 	github.com/ghodss/yaml v1.0.0
@@ -33,5 +33,7 @@ require (
 	k8s.io/metrics v0.22.7
 	sigs.k8s.io/controller-runtime v0.10.3
 )
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -132,11 +132,9 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20220420163009-01d30d6cedd9/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/codeready-toolchain/api v0.0.0-20220428144214-2de3d242bdf9/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0 h1:SpXi3ckV7o8VdjVF6Web1qqRCTgkquJ4Io/Jla+54M0=
 github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb h1:S4i4LR9qaZLEoYrH0ZhJFZ0qF3CQie2ScQfElQBPJnM=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb/go.mod h1:MRW2K1Es7tjgbqLt024he5iaDcpnMx03Xf2TaFG67ww=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -665,6 +663,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07 h1:BkPWBr5cKr82Onhnba1vNGcOdxgvOwu8R3oC7VqkEmk=
+github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07/go.mod h1:3AJ9BfCZIJRG3SIvLk/8nG94AbpGsJR/rSvQCg39OCQ=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u9
 github.com/codeready-toolchain/api v0.0.0-20220428144214-2de3d242bdf9/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0 h1:SpXi3ckV7o8VdjVF6Web1qqRCTgkquJ4Io/Jla+54M0=
 github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220530143713-7cfc4ff163ce h1:Zyv3cdI1/WdAG6mTOQnxFpjeLQHeOn58Tb1Q9GKgy3w=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220530143713-7cfc4ff163ce/go.mod h1:3AJ9BfCZIJRG3SIvLk/8nG94AbpGsJR/rSvQCg39OCQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -663,8 +665,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07 h1:BkPWBr5cKr82Onhnba1vNGcOdxgvOwu8R3oC7VqkEmk=
-github.com/rajivnathan/toolchain-common v0.0.0-20220525173141-368ad66e7e07/go.mod h1:3AJ9BfCZIJRG3SIvLk/8nG94AbpGsJR/rSvQCg39OCQ=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -136,10 +136,10 @@ func TestE2EFlow(t *testing.T) {
 	// Confirm the originalSub property has been set during signup
 	require.Equal(t, originalSubJohnClaim, originalSubJohnSignup.Spec.OriginalSub)
 
-	VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "base", "base")
-	VerifyResourcesProvisionedForSignup(t, awaitilities, originalSubJohnSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, targetedJohnSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, originalSubJohnSignup, "deactivate30", "base")
 
 	johnsmithMur, err := hostAwait.GetMasterUserRecord(johnsmithName)
 	require.NoError(t, err)
@@ -160,8 +160,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 		})
 
 		t.Run("delete identity and wait until recreated", func(t *testing.T) {
@@ -175,8 +175,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 		})
 
 		t.Run("delete user mapping and wait until recreated", func(t *testing.T) {
@@ -191,8 +191,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 		})
 
 		t.Run("delete identity mapping and wait until recreated", func(t *testing.T) {
@@ -207,8 +207,8 @@ func TestE2EFlow(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 		})
 
 		t.Run("delete namespaces and wait until recreated", func(t *testing.T) {
@@ -232,8 +232,8 @@ func TestE2EFlow(t *testing.T) {
 				_, err := memberAwait.WaitForNamespace(johnSignup.Spec.Username, ref, "base", wait.UntilNamespaceIsActive())
 				require.NoError(t, err)
 			}
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 		})
 
 		t.Run("delete useraccount and expect recreation", func(t *testing.T) {
@@ -255,7 +255,7 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// then verify the recreated user account
-			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, johnSignup, "deactivate30", "base")
 		})
 	})
 
@@ -289,7 +289,7 @@ func TestE2EFlow(t *testing.T) {
 
 		require.Equal(t, "laracroft", laraSignUp.Status.CompliantUsername)
 
-		VerifyResourcesProvisionedForSignup(t, awaitilities, laraSignUp, "base", "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, laraSignUp, "deactivate30", "base")
 
 		VerifySpaceBinding(t, hostAwait, laraUserName, laraUserName, "admin")
 
@@ -391,27 +391,27 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("role accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 			DeletedRoleAndAwaitRecreation(t, memberAwait, devNs, "rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("role accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 			DeletedRoleAndAwaitRecreation(t, memberAwait, stageNs, "rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("rolebinding accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, devNs, "user-rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("rolebinding accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, stageNs, "user-rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
@@ -455,7 +455,7 @@ func TestE2EFlow(t *testing.T) {
 		assert.NoError(t, err, "johnsmith-stage namespace is not deleted")
 
 		// also, verify that other user's resource are left intact
-		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "base", "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -398,20 +398,20 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("namespace rolebinding accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, devNs, "crtadmin-pods")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("namespace role accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 			DeletedRoleAndAwaitRecreation(t, memberAwait, stageNs, "exec-pods")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("namespace rolebinding accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {
 
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, stageNs, "crtadmin-pods")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		// roles and role bindings defined in the spacerole templates
@@ -424,7 +424,7 @@ func TestE2EFlow(t *testing.T) {
 		t.Run("space rolebinding accidentally deleted by user in dev namespace is recreated", func(t *testing.T) {
 			DeleteRoleBindingAndAwaitRecreation(t, memberAwait, devNs, "wonderwoman-rbac-edit")
 			// then the user account should be recreated
-			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 		})
 
 		t.Run("space role accidentally deleted by user in stage namespace is recreated", func(t *testing.T) {

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -79,7 +79,7 @@ func TestNSTemplateTiers(t *testing.T) {
 			tiers.MoveSpaceToTier(t, hostAwait, testingTiersName, tierToCheck)
 
 			// then
-			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, tierToCheck, tierToCheck)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", tierToCheck)
 		})
 	}
 }

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -55,7 +55,7 @@ func TestNSTemplateTiers(t *testing.T) {
 	}
 
 	// wait for the user to be provisioned for the first time
-	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", "base") // deactivate30 is the default UserTier and base is the default SpaceTier
 	for _, tierToCheck := range tiersToCheck {
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
@@ -79,7 +79,7 @@ func TestNSTemplateTiers(t *testing.T) {
 			tiers.MoveSpaceToTier(t, hostAwait, testingTiersName, tierToCheck)
 
 			// then
-			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", tierToCheck)
+			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", tierToCheck) // deactivate30 is the default UserTier
 		})
 	}
 }

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -74,7 +74,7 @@ func TestNSTemplateTiers(t *testing.T) {
 			}
 		})
 
-		t.Run(fmt.Sprintf("promote %s user to %s tier", testingTiersName, tierToCheck), func(t *testing.T) {
+		t.Run(fmt.Sprintf("promote %s space to %s tier", testingTiersName, tierToCheck), func(t *testing.T) {
 			// when
 			tiers.MoveSpaceToTier(t, hostAwait, testingTiersName, tierToCheck)
 

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -16,17 +16,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var toBeComplete = toolchainv1alpha1.Condition{
-	Type:   toolchainv1alpha1.ChangeTierRequestComplete,
-	Status: corev1.ConditionTrue,
-	Reason: toolchainv1alpha1.ChangeTierRequestChangedReason,
-}
 
 const (
 	MaxPoolSize = 5 // same as hard-coded value in host operator
@@ -60,10 +53,9 @@ func TestNSTemplateTiers(t *testing.T) {
 	for _, tier := range allTiers.Items {
 		assert.Contains(t, tiersToCheck, tier.Name)
 	}
-	var changeTierRequestNames []string
 
 	// wait for the user to be provisioned for the first time
-	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", "base")
 	for _, tierToCheck := range tiersToCheck {
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
@@ -82,27 +74,13 @@ func TestNSTemplateTiers(t *testing.T) {
 			}
 		})
 
-		t.Run(fmt.Sprintf("promote to %s tier", tierToCheck), func(t *testing.T) {
-			// given
-			t.Logf("promoting %s user to %s tier", testingTiersName, tierToCheck)
-			changeTierRequest := tiers.NewChangeTierRequest(hostAwait.Namespace, testingTiersName, tierToCheck)
-
+		t.Run(fmt.Sprintf("promote %s user to %s tier", testingTiersName, tierToCheck), func(t *testing.T) {
 			// when
-			err = hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
+			tiers.MoveSpaceToTier(t, hostAwait, testingTiersName, tierToCheck)
 
 			// then
-			require.NoError(t, err)
-			_, err := hostAwait.WaitForChangeTierRequest(changeTierRequest.Name, toBeComplete)
-			require.NoError(t, err)
 			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, tierToCheck, tierToCheck)
-			changeTierRequestNames = append(changeTierRequestNames, changeTierRequest.Name)
 		})
-	}
-
-	// then - wait until all ChangeTierRequests are deleted by our automatic GC
-	for _, name := range changeTierRequestNames {
-		err := hostAwait.WaitUntilChangeTierRequestDeleted(name)
-		assert.NoError(t, err)
 	}
 }
 
@@ -279,7 +257,7 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 
 	// let's promote to users the new tier
 	for i := range userSignups {
-		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "base", "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignups[i], "deactivate30", "base")
 		username := fmt.Sprintf(nameFmt, i)
 		tiers.MoveSpaceToTier(t, hostAwait, username, tier.Name)
 	}

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -211,7 +211,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
 		require.NoError(t, err)
 		require.False(t, states.Deactivating(promotedUserSignup), "usersignup should not be deactivating")
-		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "advanced", "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "nodeactivation", "base")
 	})
 }
 

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -103,7 +103,7 @@ func TestSetDefaultTier(t *testing.T) {
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultTier("advanced").DefaultSpaceTier("advanced"))
+		hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
 		// Create and approve a new user that should be provisioned to the advanced tier
 		NewSignupRequest(t, awaitilities).
 			Username("defaulttierchanged").

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -328,7 +328,7 @@ func TestSignupOK(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait the Master User Record to be provisioned
-		VerifyResourcesProvisionedForSignup(t, await, userSignup, "base", "base")
+		VerifyResourcesProvisionedForSignup(t, await, userSignup, "deactivate30", "base")
 
 		// Call signup endpoint with same valid token to check if status changed to Provisioned now
 		assertGetSignupStatusProvisioned(t, await, identity.Username, token)

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -354,24 +354,12 @@ func TestPromoteSpace(t *testing.T) {
 	space := CreateAndVerifySpace(t, awaitilities, WithTierName("base"), WithTargetCluster(memberAwait))
 
 	t.Run("to advanced tier", func(t *testing.T) {
-		// given
-		ctr := tiers.NewChangeTierRequest(hostAwait.Namespace, space.Name, "advanced")
-
 		// when
-		err := hostAwait.Client.Create(context.TODO(), ctr)
+		tiers.MoveSpaceToTier(t, hostAwait, space.Name, "advanced")
 
 		// then
-		require.NoError(t, err)
-		_, err = hostAwait.WaitForChangeTierRequest(ctr.Name, toBeComplete)
-		require.NoError(t, err)
 		VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
 	})
-}
-
-var toBeComplete = toolchainv1alpha1.Condition{
-	Type:   toolchainv1alpha1.ChangeTierRequestComplete,
-	Status: corev1.ConditionTrue,
-	Reason: toolchainv1alpha1.ChangeTierRequestChangedReason,
 }
 
 func TestRetargetSpace(t *testing.T) {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -90,7 +90,7 @@ func TestProxyFlow(t *testing.T) {
 			user.signup, _ = req.Resources()
 			user.token = req.GetToken()
 
-			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "appstudio", "appstudio")
+			VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "deactivate30", "appstudio")
 			_, err := hostAwait.GetMasterUserRecord(user.username)
 			require.NoError(t, err)
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -57,7 +57,7 @@ func TestProxyFlow(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	hostAwait.UpdateToolchainConfig(config.Tiers().DefaultTier("appstudio").DefaultSpaceTier("appstudio"))
+	hostAwait.UpdateToolchainConfig(config.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"))
 
 	users := []proxyUser{
 		{

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -50,6 +50,73 @@ func (s *userManagementTestSuite) SetupSuite() {
 	s.Awaitilities = WaitForDeployments(s.T())
 }
 
+// TODO remove once user tier migration is complete
+func TestUserTierMigration(t *testing.T) {
+	// given
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
+
+	// Create and approve "testingtiers" signups
+	testingTiersName := "testingtiers"
+	testingtiers, _ := NewSignupRequest(t, awaitilities).
+		Username(testingTiersName).
+		ManuallyApprove().
+		TargetCluster(awaitilities.Member1()).
+		EnsureMUR().
+		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+		Execute().
+		Resources()
+
+	// all tiers to check - keep the base as the last one, it will verify downgrade back to the default tier at the end of the test
+	tiersToCheck := []string{"advanced", "basedeactivationdisabled", "baseextended", "baseextendedidling", "baselarge", "hackathon", "test", "appstudio", "base1ns", "base"}
+
+	// when the tiers are created during the startup then we can verify them
+	allTiers := &toolchainv1alpha1.NSTemplateTierList{}
+	err := hostAwait.Client.List(context.TODO(), allTiers, client.InNamespace(hostAwait.Namespace))
+	require.NoError(t, err)
+	assert.Len(t, allTiers.Items, len(tiersToCheck))
+
+	for _, tier := range allTiers.Items {
+		assert.Contains(t, tiersToCheck, tier.Name)
+	}
+
+	// wait for the user to be provisioned for the first time
+	VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", "base") // deactivate30 is the default UserTier and base is the default SpaceTier
+	for _, tierToCheck := range tiersToCheck {
+
+		t.Run(fmt.Sprintf("change %s user tier to %s tier to test migration", testingTiersName, tierToCheck), func(t *testing.T) {
+			// when
+			// set MUR TierName to an NSTemplateTier name
+			tiers.MoveMURToTier(t, hostAwait, testingTiersName, tierToCheck)
+
+			// then
+			expectedUserTier := getUserTierForNSTemplateTier(tierToCheck)
+			require.NotEqual(t, "invalid", expectedUserTier, fmt.Sprintf("NSTemplateTier '%s' does not map to a UserTier", tierToCheck))
+
+			// the MUR TierName should be automatically updated to a UserTier
+			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, expectedUserTier, "base") // base is the default SpaceTier
+		})
+	}
+}
+
+// TODO remove once user tier migration is complete
+func getUserTierForNSTemplateTier(nsTemplateTier string) string {
+	switch nsTemplateTier {
+	case "appstudio", "base", "base1ns", "baseextendedidling", "test":
+		return "deactivate30"
+	case "hackathon":
+		return "deactivate80"
+	case "baselarge":
+		return "deactivate90"
+	case "baseextended":
+		return "deactivate180"
+	case "advanced", "basedeactivationdisabled":
+		return "nodeactivation"
+	default:
+		return "invalid"
+	}
+}
+
 // TestVerifyUserTiers lists all UserTiers and validates each one
 // Functional testing is covered by the deactivation tests below, it's not necessary to test each
 // UserTier with deactivation since it's only the deactivationTimeoutDays value that changes and the deactivation
@@ -523,15 +590,15 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
 
-		// Get the base tier that has deactivation disabled
-		baseDeactivationDisabledTier, err := hostAwait.WaitForNSTemplateTier("basedeactivationdisabled")
+		// Get the user tier that has deactivation disabled
+		deactivationDisabledUserTier, err := hostAwait.WaitForUserTier("nodeactivation")
 		require.NoError(t, err)
 
 		// Move the user to the new tier without deactivation enabled
-		tiers.MoveMURToTier(t, hostAwait, userSignupMember1.Status.CompliantUsername, baseDeactivationDisabledTier.Name)
+		tiers.MoveMURToTier(t, hostAwait, userSignupMember1.Status.CompliantUsername, deactivationDisabledUserTier.Name)
 		murMember1, err = hostAwait.WaitForMasterUserRecord(murMember1.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()),
-			wait.UntilMasterUserRecordHasTierName(baseDeactivationDisabledTier.Name)) // ignore other conditions, such as notification sent, etc.
+			wait.UntilMasterUserRecordHasTierName(deactivationDisabledUserTier.Name)) // ignore other conditions, such as notification sent, etc.
 		require.NoError(s.T(), err)
 
 		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -53,6 +53,10 @@ func (s *userManagementTestSuite) SetupSuite() {
 	s.Awaitilities = WaitForDeployments(s.T())
 }
 
+// TestVerifyUserTiers lists all UserTiers and validates each one
+// Functional testing is covered by the deactivation tests below, it's not necessary to test each
+// UserTier with deactivation since it's only the deactivationTimeoutDays value that changes and the deactivation
+// logic handles them in the same way
 func (s *userManagementTestSuite) TestVerifyUserTiers() {
 	hostAwait := s.Host()
 

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -657,7 +657,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 		require.NoError(s.T(), err)
 
 		// Verify resources have been provisioned
-		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "base", "base")
+		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "deactivate30", "base")
 	})
 
 	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
@@ -708,7 +708,7 @@ func (s *userManagementTestSuite) TestUserDeactivationNSTemplateTier() {
 			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
-			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "deactivate30", "base")
 
 			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
@@ -953,7 +953,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute().Resources()
 
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 
 	// Disable MUR
 	mur, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
@@ -993,7 +993,7 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 		})
 		require.NoError(s.T(), err)
 
-		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 	})
 }
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -599,5 +599,5 @@ func (s *userSignupIntegrationTest) TestUserSignupMigration() {
 	require.NoError(s.T(), err)
 
 	// Confirm that the migrated UserSignup is provisioned ok
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, migrated, "base", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, migrated, "deactivate30", "base")
 }

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -75,7 +75,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
@@ -117,7 +117,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
 
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
@@ -130,7 +130,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(s.T(), err)
 
-				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 			})
 		})
 	})
@@ -270,7 +270,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
@@ -298,7 +298,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
@@ -349,7 +349,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	require.NoError(s.T(), err)
 
 	// Confirm the MUR was created and target cluster was set
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 }
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {
@@ -513,5 +513,5 @@ func (s *userSignupIntegrationTest) TestSkipSpaceCreation() {
 	// annotation should be set
 	require.True(s.T(), userSignup.Annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey] == "true")
 
-	VerifyResourcesProvisionedForSignupWithoutSpace(s.T(), s.Awaitilities, userSignup, "base")
+	VerifyResourcesProvisionedForSignupWithoutSpace(s.T(), s.Awaitilities, userSignup, "deactivate30")
 }

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -151,7 +151,6 @@ func (r *SetupMigrationRunner) prepareUser(name string, targetCluster *wait.Memb
 		Execute().
 		Resources()
 	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(signup.Status.CompliantUsername,
-		wait.UntilMasterUserRecordHasTierName("base"),
 		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
 	require.NoError(r.T, err)
 	return signup

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -125,14 +125,13 @@ func (r *SetupMigrationRunner) prepareAppStudioProvisionedUser() {
 	hostAwait := r.Awaitilities.Host()
 
 	// promote to appstudio
-	changeTierRequest := tiers.NewChangeTierRequest(hostAwait.Namespace, AppStudioProvisionedUser, "appstudio")
-	err := hostAwait.CreateWithCleanup(context.TODO(), changeTierRequest)
-	require.NoError(r.T, err)
+	tiers.MoveSpaceToTier(r.T, hostAwait, AppStudioProvisionedUser, "appstudio")
+	tiers.MoveMURToTier(r.T, hostAwait, AppStudioProvisionedUser, "appstudio")
 
 	r.T.Logf("user %s was promoted to appstudio tier", AppStudioProvisionedUser)
 
 	// verify that it's promoted
-	_, err = r.Awaitilities.Host().WaitForMasterUserRecord(AppStudioProvisionedUser,
+	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(AppStudioProvisionedUser,
 		wait.UntilMasterUserRecordHasTierName("appstudio"),
 		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
 	require.NoError(r.T, err)

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -126,13 +126,11 @@ func (r *SetupMigrationRunner) prepareAppStudioProvisionedUser() {
 
 	// promote to appstudio
 	tiers.MoveSpaceToTier(r.T, hostAwait, AppStudioProvisionedUser, "appstudio")
-	tiers.MoveMURToTier(r.T, hostAwait, AppStudioProvisionedUser, "appstudio")
 
 	r.T.Logf("user %s was promoted to appstudio tier", AppStudioProvisionedUser)
 
 	// verify that it's promoted
 	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(AppStudioProvisionedUser,
-		wait.UntilMasterUserRecordHasTierName("appstudio"),
 		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
 	require.NoError(r.T, err)
 }

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -110,20 +110,20 @@ func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitili
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio", "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -110,26 +110,20 @@ func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitili
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	// TODO temporarily check only Spaces until UserTier migration is completed
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
-	// VerifySpaceRelatedResources(t, awaitilities, signup, "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	// TODO temporarily check only Spaces until UserTier migration is completed
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
-	// VerifySpaceRelatedResources(t, awaitilities, signup, "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	// TODO temporarily check only Spaces until UserTier migration is completed
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
-	// VerifySpaceRelatedResources(t, awaitilities, signup, "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -110,20 +110,20 @@ func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitili
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio", "appstudio")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
@@ -174,7 +174,7 @@ func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *to
 	require.NoError(t, err)
 
 	// verify that it's unbanned
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 }
 
 func checkMURMigratedAndGetSignup(t *testing.T, hostAwait *wait.HostAwaitility, murName string) *toolchainv1alpha1.UserSignup {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -110,20 +110,26 @@ func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitili
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+	// TODO temporarily check only Spaces until UserTier migration is completed
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
+	// VerifySpaceRelatedResources(t, awaitilities, signup, "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+	// TODO temporarily check only Spaces until UserTier migration is completed
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
+	// VerifySpaceRelatedResources(t, awaitilities, signup, "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	cleanup.AddCleanTasks(awaitilities.Host(), signup)
-	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "appstudio", "appstudio")
+	// TODO temporarily check only Spaces until UserTier migration is completed
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
+	// VerifySpaceRelatedResources(t, awaitilities, signup, "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {

--- a/testsupport/deactivation.go
+++ b/testsupport/deactivation.go
@@ -77,7 +77,7 @@ func ReactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSi
 	require.NoError(t, err)
 	require.False(t, states.Deactivated(userSignup), "usersignup should not be deactivated")
 
-	VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "base", "base")
+	VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup, "deactivate30", "base")
 
 	return userSignup
 }

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -267,7 +267,7 @@ func (r *SignupRequest) Execute() *SignupRequest {
 
 	if r.ensureMUR {
 		expectedSpaceTier := "base"
-		if hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier != nil {
+		if hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultSpaceTier != nil {
 			expectedSpaceTier = *hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultSpaceTier
 		}
 		VerifyResourcesProvisionedForSignup(r.t, r.awaitilities, userSignup, "deactivate30", expectedSpaceTier)

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -247,12 +247,12 @@ func (r *SignupRequest) Execute() *SignupRequest {
 	}
 
 	if r.ensureMUR {
-		expectedTier := "base"
+		expectedSpaceTier := "base"
 		if hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier != nil {
-			expectedTier = *hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultTier
+			expectedSpaceTier = *hostAwait.GetToolchainConfig().Spec.Host.Tiers.DefaultSpaceTier
 		}
-		VerifyResourcesProvisionedForSignup(r.t, r.awaitilities, userSignup, expectedTier, expectedTier)
-		mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasTierName(expectedTier))
+		VerifyResourcesProvisionedForSignup(r.t, r.awaitilities, userSignup, "deactivate30", expectedSpaceTier)
+		mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername)
 		require.NoError(r.t, err)
 		r.mur = mur
 	}

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -170,16 +170,3 @@ func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName s
 	})
 	require.NoError(t, err)
 }
-
-func NewChangeTierRequest(namespace, murName, tier string) *toolchainv1alpha1.ChangeTierRequest {
-	return &toolchainv1alpha1.ChangeTierRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
-			GenerateName: "changetierrequest-",
-		},
-		Spec: toolchainv1alpha1.ChangeTierRequestSpec{
-			MurName:  murName,
-			TierName: tier,
-		},
-	}
-}

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -21,13 +21,13 @@ import (
 
 func VerifyMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, signups []*toolchainv1alpha1.UserSignup) {
 	for _, signup := range signups {
-		VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "base", "base")
+		VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 	}
 }
 
 func VerifyResourcesProvisionedForSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup, userTierName, spaceTierName string) {
 	VerifyUserRelatedResources(t, awaitilities, signup, userTierName)
-	VerifySpaceRelatedResources(t, awaitilities, signup, userTierName, spaceTierName)
+	VerifySpaceRelatedResources(t, awaitilities, signup, spaceTierName)
 }
 
 func VerifyResourcesProvisionedForSignupWithoutSpace(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup, userTierName string) {
@@ -137,7 +137,7 @@ func VerifyUserRelatedResources(t *testing.T, awaitilities wait.Awaitilities, si
 	return userSignup, mur
 }
 
-func VerifySpaceRelatedResources(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup, userTierName, spaceTierName string) {
+func VerifySpaceRelatedResources(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup, spaceTierName string) {
 
 	hostAwait := awaitilities.Host()
 
@@ -147,7 +147,6 @@ func VerifySpaceRelatedResources(t *testing.T, awaitilities wait.Awaitilities, u
 	require.NoError(t, err)
 
 	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername,
-		wait.UntilMasterUserRecordHasTierName(userTierName),
 		wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 	require.NoError(t, err)
 

--- a/testsupport/wait/diff.go
+++ b/testsupport/wait/diff.go
@@ -1,9 +1,15 @@
 package wait
 
 import (
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 )
 
 func Diff(expected, actual interface{}) string {
-	return cmp.Diff(expected, actual)
+	msg := &strings.Builder{}
+	msg.WriteString("-expected\n")
+	msg.WriteString("+actual\n")
+	msg.WriteString(cmp.Diff(expected, actual))
+	return msg.String()
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -995,51 +995,6 @@ func HasClusterResourcesTemplateRef(expected string) NSTemplateTierSpecMatcher {
 	}
 }
 
-// WaitForChangeTierRequest waits until there a ChangeTierRequest is available with the given status conditions
-func (a *HostAwaitility) WaitForChangeTierRequest(name string, expected toolchainv1alpha1.Condition) (*toolchainv1alpha1.ChangeTierRequest, error) {
-	var changeTierRequest *toolchainv1alpha1.ChangeTierRequest
-	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		obj := &toolchainv1alpha1.ChangeTierRequest{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, obj); err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		changeTierRequest = obj
-		return test.ConditionsMatch(obj.Status.Conditions, expected), nil
-	})
-	// log message if an error occurred
-	if err != nil {
-		if changeTierRequest == nil {
-			e, _ := yaml.Marshal(expected)
-			a.T.Logf("failed to find ChangeTierRequest '%s' with condition\n%s. Actual: nil", name, e)
-		} else {
-			a.T.Logf("expected conditions to match: '%s'", Diff(expected, changeTierRequest.Status.Conditions))
-		}
-	}
-	return changeTierRequest, err
-}
-
-// WaitUntilChangeTierRequestDeleted waits until the ChangeTierRequest with the given name is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilChangeTierRequestDeleted(name string) error {
-	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		changeTierRequest := &toolchainv1alpha1.ChangeTierRequest{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, changeTierRequest); err != nil {
-			if errors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, err
-		}
-		return false, nil
-	})
-	// log message if an error occurred
-	if err != nil {
-		a.T.Logf("failed to wait until ChangeTierRequest '%s' was deleted: %v\n", name, err)
-	}
-	return err
-}
-
 // NotificationWaitCriterion a struct to compare with an expected Notification
 type NotificationWaitCriterion struct {
 	Match func(toolchainv1alpha1.Notification) bool


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/642

- Adds a temporary test for user tier migration
- Temporary updates to general migration tests to pass with user tier migration
- Remove usages of ChangeTierRequests