### PR TITLE
test: wait until NSTemplateSet has expected space roles

### DIFF
--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -124,7 +124,8 @@ func TestSpaceRoles(t *testing.T) {
 		UntilNSTemplateSetHasSpaceRoles(
 			SpaceRole(appstudioTier.Spec.SpaceRoles["admin"].TemplateRef, ownerSignup.Name, ownerMUR.Name)),
 	)
-	// UntilNSTemplateSetHasSpaceRoles({"templateRef":"appstudio-admin-a30ac1d-a30ac1d","usernames":["spaceowner"]})
+	require.NoError(t, err)
+
 	// fetch the namespace check the `last-applied-space-roles` annotation
 	_, err = memberAwait.WaitForNamespace(s.Name, nsTmplSet.Spec.Namespaces[0].TemplateRef, "appstudio",
 		UntilNamespaceIsActive(),

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -98,7 +98,7 @@ func TestSpaceRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// given a user (with her own space, but we'll ignore it in this test)
-	ownerSignup, ownerMUR := NewSignupRequest(t, awaitilities).
+	_, ownerMUR := NewSignupRequest(t, awaitilities).
 		Username("spaceowner").
 		Email("spaceowner@redhat.com").
 		ManuallyApprove().
@@ -122,7 +122,7 @@ func TestSpaceRoles(t *testing.T) {
 	require.NoError(t, err)
 	nsTmplSet, err = memberAwait.WaitForNSTmplSet(nsTmplSet.Name,
 		UntilNSTemplateSetHasSpaceRoles(
-			SpaceRole(appstudioTier.Spec.SpaceRoles["admin"].TemplateRef, ownerSignup.Name, ownerMUR.Name)),
+			SpaceRole(appstudioTier.Spec.SpaceRoles["admin"].TemplateRef, ownerMUR.Name)),
 	)
 	require.NoError(t, err)
 

--- a/testsupport/wait/diff_test.go
+++ b/testsupport/wait/diff_test.go
@@ -1,7 +1,6 @@
 package wait_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -31,7 +30,7 @@ func TestDiff(t *testing.T) {
 			LastTransitionTime: now,
 			LastUpdatedTime:    &now,
 		}
-		t.Log(fmt.Sprintf("expected conditions to match:\n%s", wait.Diff(expected, actual)))
+		t.Logf("expected conditions to match:\n%s", wait.Diff(expected, actual))
 	})
 
 	t.Run("on multiple conditions", func(t *testing.T) {
@@ -56,6 +55,6 @@ func TestDiff(t *testing.T) {
 				Reason: toolchainv1alpha1.MasterUserRecordNotificationCRCreatedReason,
 			},
 		}
-		t.Log(fmt.Sprintf("expected conditions to match:\n%s", wait.Diff(expected, actual)))
+		t.Logf("expected conditions to match:\n%s", wait.Diff(expected, actual))
 	})
 }

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -475,7 +475,7 @@ func UntilHasLastAppliedSpaceRoles(expected []toolchainv1alpha1.NSTemplateSetSpa
 			return string(expectedLastAppliedSpaceRoles) == lastAppliedSpaceRoles
 		},
 		Diff: func(actual *corev1.Namespace) string {
-			return fmt.Sprintf("expected namespace to be match annotation,\nExpected: %s\nActual annotations:%v", expectedLastAppliedSpaceRoles, actual.Annotations)
+			return fmt.Sprintf("expected namespace to match annotation,\nExpected: %s\nActual annotations:%v", expectedLastAppliedSpaceRoles, actual.Annotations)
 		},
 	}
 }


### PR DESCRIPTION
avoid flaky case where namespace already has the
'toolchain.dev.openshift.com/last-applied-space-roles' annotation but
its associated NSTemplateSet was retrieved too early and did not have
the corresponding space roles

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
