### PR TITLE
e2e test: Allow appstudio users to  create hacbs APIs

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1146,7 +1146,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		role, err := memberAwait.WaitForRole(ns, "appstudio-user-actions")
 		require.NoError(t, err)
-		assert.Len(t, role.Rules, 11)
+		assert.Len(t, role.Rules, 12)
 		expected := &rbacv1.Role{
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -1162,6 +1162,11 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				{
 					APIGroups: []string{"appstudio.redhat.com"},
 					Resources: []string{"applicationpromotionruns", "applicationsnapshotenvironmentbindings", "applicationsnapshots", "environments"},
+					Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
+				},
+				{
+					APIGroups: []string{"appstudio.redhat.com"},
+					Resources: []string{"enterprisecontractpolicies", "integrationtestscenarios", "releases", "releasestrategies", "releaselinks"},
 					Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 				},
 				{


### PR DESCRIPTION
This PR is paired with https://github.com/codeready-toolchain/host-operator/pull/664