### PR TITLE
test(webhook): more strict assertion on webhook configuration

### DIFF
--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -1830,29 +1830,27 @@ func (a *MemberAwaitility) verifyUsersRolebindingsWebhookConfig(ca []byte) {
 	assert.Equal(a.T, []string{"rolebindings"}, rolebindingRule.Resources)
 	assert.Equal(a.T, admv1.NamespacedScope, *rolebindingRule.Scope)
 
-	if len(actualValWbhConf.Webhooks) > 1 {
-		checlusterWebhook := actualValWbhConf.Webhooks[1]
-		assert.Equal(a.T, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
-		assert.Equal(a.T, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
-		assert.Equal(a.T, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
-		assert.Equal(a.T, int32(5), *checlusterWebhook.TimeoutSeconds)
-		assert.Equal(a.T, admv1.Ignore, *checlusterWebhook.FailurePolicy)
-		assert.Equal(a.T, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
-		assert.Equal(a.T, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
-		assert.Equal(a.T, ca, checlusterWebhook.ClientConfig.CABundle)
-		assert.Equal(a.T, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
-		assert.Equal(a.T, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
-		assert.Equal(a.T, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
-		assert.Equal(a.T, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
-		require.Len(a.T, checlusterWebhook.Rules, 1)
+	checlusterWebhook := actualValWbhConf.Webhooks[1]
+	assert.Equal(a.T, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
+	assert.Equal(a.T, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
+	assert.Equal(a.T, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
+	assert.Equal(a.T, int32(5), *checlusterWebhook.TimeoutSeconds)
+	assert.Equal(a.T, admv1.Ignore, *checlusterWebhook.FailurePolicy)
+	assert.Equal(a.T, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
+	assert.Equal(a.T, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(a.T, ca, checlusterWebhook.ClientConfig.CABundle)
+	assert.Equal(a.T, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
+	assert.Equal(a.T, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(a.T, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
+	assert.Equal(a.T, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
+	require.Len(a.T, checlusterWebhook.Rules, 1)
 
-		checlusterRule := checlusterWebhook.Rules[0]
-		assert.Equal(a.T, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
-		assert.Equal(a.T, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
-		assert.Equal(a.T, []string{"v2"}, checlusterRule.APIVersions)
-		assert.Equal(a.T, []string{"checlusters"}, checlusterRule.Resources)
-		assert.Equal(a.T, admv1.NamespacedScope, *checlusterRule.Scope)
-	}
+	checlusterRule := checlusterWebhook.Rules[0]
+	assert.Equal(a.T, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
+	assert.Equal(a.T, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
+	assert.Equal(a.T, []string{"v2"}, checlusterRule.APIVersions)
+	assert.Equal(a.T, []string{"checlusters"}, checlusterRule.Resources)
+	assert.Equal(a.T, admv1.NamespacedScope, *checlusterRule.Scope)
 
 }
 


### PR DESCRIPTION
This is a follow-up of #597 in which the assertion needed to be
permissive enough to accomodate with the migration tests.
Now that the new admission webhook for CheClusters has been deployed,
the assertion can be strict.

Fixes https://issues.redhat.com/browse/CRT-1586

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
