### PR TITLE
Use working set memory metric for perf testing

### DIFF
--- a/setup/cmd/root.go
+++ b/setup/cmd/root.go
@@ -318,7 +318,14 @@ func setup(cmd *cobra.Command, args []string) { // nolint:gocyclo
 	defer close(stopMetrics)
 	wg.Wait()
 	uip.Stop()
+
 	term.Infof("🏁 done provisioning users")
+
+	// continue gathering metrics for some time after creating all users and resources since memory usage was observed to continue changing
+	additionalMetricsDuration := 15 * time.Minute
+	term.Infof("Continuing to gather metrics for %s...", additionalMetricsDuration)
+	time.Sleep(additionalMetricsDuration)
+
 	term.Infof("\n📈 Results 📉")
 	term.Infof("Average Idler Update Time: %.2f s", AverageIdlerUpdateTime.Seconds()/float64(numberOfUsers))
 	term.Infof("Average Time Per User: %.2f s", AverageTimePerUser.Seconds()/float64(numberOfUsers))

--- a/setup/metrics/queries/query.go
+++ b/setup/metrics/queries/query.go
@@ -46,7 +46,7 @@ func QueryOpenshiftKubeAPIMemoryUtilisation(apiClient prometheus.API) *BaseQuery
 	return &BaseQuery{
 		apiClient:  apiClient,
 		name:       "openshift-kube-apiserver",
-		query:      `sum(container_memory_usage_bytes{namespace="openshift-kube-apiserver", pod=~"kube-apiserver-.*"})`,
+		query:      `sum(container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", cluster="", namespace="openshift-kube-apiserver", container!="", image!=""})`,
 		resultType: Memory,
 	}
 }


### PR DESCRIPTION
- Use `container_memory_working_set_bytes` because `container_memory_usage_bytes` includes the usage of all kinds of memory (including cache that can be evicted at any time) while container_memory_working_set_bytes  only includes the memory that cannot be evicted. So it's a better representation of the actual memory usage.
- Continue gathering metrics for 15m after provisioning users because memory continues to grow for some time after provisioning is completed