### PR TITLE
Update imagestream in default user-workloads

### DIFF
--- a/setup/resources/user-workloads.yaml
+++ b/setup/resources/user-workloads.yaml
@@ -109,7 +109,7 @@ objects:
         app.kubernetes.io/name: nodejs
         app.kubernetes.io/part-of: sample-app
         app.openshift.io/runtime: nodejs
-        app.openshift.io/runtime-version: 12-ubi7
+        app.openshift.io/runtime-version: 16-ubi9-minimal
       name: nodejs-sample
     spec:
       failedBuildsHistoryLimit: 5
@@ -128,7 +128,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: nodejs:12-ubi7
+            name: nodejs:16-ubi9-minimal
             namespace: openshift
         type: Source
       successfulBuildsHistoryLimit: 5
@@ -159,7 +159,7 @@ objects:
         app.kubernetes.io/name: nodejs2
         app.kubernetes.io/part-of: sample-app2
         app.openshift.io/runtime: nodejs
-        app.openshift.io/runtime-version: 12-ubi7
+        app.openshift.io/runtime-version: 16-ubi9-minimal
       name: nodejs-sample2
     spec:
       failedBuildsHistoryLimit: 5
@@ -178,7 +178,7 @@ objects:
         sourceStrategy:
           from:
             kind: ImageStreamTag
-            name: nodejs:12-ubi7
+            name: nodejs:16-ubi9-minimal
             namespace: openshift
         type: Source
       successfulBuildsHistoryLimit: 5


### PR DESCRIPTION
Imagestream doesn't exists which leads to generation lot of events w.r.t. buildconfig.