### PR TITLE
refactor(test): drop 'T' from awaitilities

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -259,9 +259,9 @@ func TestE2EFlow(t *testing.T) {
 			wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()),
 			wait.UntilToolchainStatusHasMurCount("external", originalMursPerDomainCount["external"]+9),
-			wait.UntilToolchainStatusHasUserAccountCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+7),
+			wait.UntilToolchainStatusHasUserAccountCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+8),
 			wait.UntilToolchainStatusHasUserAccountCount(targetedJohnMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[targetedJohnMur.Spec.UserAccounts[0].TargetCluster]+1),
-			wait.UntilToolchainStatusHasSpaceCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+7),
+			wait.UntilToolchainStatusHasSpaceCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+8),
 			wait.UntilToolchainStatusHasSpaceCount(targetedJohnMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[targetedJohnMur.Spec.UserAccounts[0].TargetCluster]+1),
 		)
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -253,12 +253,17 @@ func TestE2EFlow(t *testing.T) {
 		VerifyMultipleSignups(t, awaitilities, signups)
 
 		// check if the MUR and UA counts match
-		currentToolchainStatus := hostAwait.WaitForToolchainStatus(t,
+		originalUserAccountCounts := make(map[string]int, len(originalToolchainStatus.Status.Members))
+		for _, m := range originalToolchainStatus.Status.Members {
+			originalUserAccountCounts[m.ClusterName] = m.UserAccountCount
+		}
+		hostAwait.WaitForToolchainStatus(t,
 			wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()),
-			wait.UntilHasMurCount("external", originalMursPerDomainCount["external"]+9))
-		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 8)
-		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
+			wait.UntilToolchainStatusHasMurCount("external", originalMursPerDomainCount["external"]+9),
+			wait.UntilToolchainStatusHasUserAccountCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+8),
+			wait.UntilToolchainStatusHasUserAccountCount(targetedJohnMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[targetedJohnMur.Spec.UserAccounts[0].TargetCluster]+1),
+		)
 	})
 
 	t.Run("verify Space is not deleted if namespace is not deleted", func(t *testing.T) {
@@ -441,12 +446,17 @@ func TestE2EFlow(t *testing.T) {
 		VerifyResourcesProvisionedForSignup(t, awaitilities, johnExtraSignup, "deactivate30", "base")
 
 		// check if the MUR and UA counts match
-		currentToolchainStatus := hostAwait.WaitForToolchainStatus(t,
+		originalUserAccountCounts := make(map[string]int, len(originalToolchainStatus.Status.Members))
+		for _, m := range originalToolchainStatus.Status.Members {
+			originalUserAccountCounts[m.ClusterName] = m.UserAccountCount
+		}
+		hostAwait.WaitForToolchainStatus(t,
 			wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()),
-			wait.UntilHasMurCount("external", originalMursPerDomainCount["external"]+8))
-		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 8)
-		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
+			wait.UntilToolchainStatusHasMurCount("external", originalMursPerDomainCount["external"]+8),
+			wait.UntilToolchainStatusHasUserAccountCount(johnsmithMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[johnsmithMur.Spec.UserAccounts[0].TargetCluster]+7),
+			wait.UntilToolchainStatusHasUserAccountCount(targetedJohnMur.Spec.UserAccounts[0].TargetCluster, originalUserAccountCounts[targetedJohnMur.Spec.UserAccounts[0].TargetCluster]+1),
+		)
 	})
 
 	t.Run("deactivate UserSignup and ensure that all user and identity resources are deleted", func(t *testing.T) {

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -37,15 +37,13 @@ func TestCreateSocialEvent(t *testing.T) {
 		)
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		hostAwait.CreateWithCleanup(t, event)
 
 		// then
-		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 		}))
-		require.NoError(t, err)
 		assert.Equal(t, "deactivate30", event.Spec.UserTier)
 		assert.Equal(t, "base1ns", event.Spec.SpaceTier)
 		assert.Equal(t, start, event.Spec.StartTime.Time)
@@ -60,17 +58,15 @@ func TestCreateSocialEvent(t *testing.T) {
 			testsocialevent.WithSpaceTier("base1ns"))
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		hostAwait.CreateWithCleanup(t, event)
 
 		// then
-		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidUserTierReason,
 			Message: "UserTier 'invalid' not found",
 		}))
-		require.NoError(t, err)
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// given
@@ -81,11 +77,10 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))
-			require.NoError(t, err)
 		})
 	})
 
@@ -96,17 +91,15 @@ func TestCreateSocialEvent(t *testing.T) {
 			testsocialevent.WithSpaceTier("invalid"))
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		hostAwait.CreateWithCleanup(t, event)
 
 		// then
-		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidSpaceTierReason,
 			Message: "NSTemplateTier 'invalid' not found",
 		}))
-		require.NoError(t, err)
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// given
@@ -117,11 +110,10 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))
-			require.NoError(t, err)
 		})
 	})
 }

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -33,8 +33,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 			require.NoError(t, err)
 
 			// then
-			err = hostAwait.WaitUntilSpaceBindingDeleted(spaceBinding.Name)
-			require.NoError(t, err)
+			hostAwait.WaitUntilSpaceBindingDeleted(t, spaceBinding.Name)
 		})
 
 		t.Run("when mur is deleted", func(t *testing.T) {
@@ -43,15 +42,14 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 			// when
 			// deactivate the UserSignup so that the MUR will be deleted
-			userSignup, err := hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(us, true)
-			})
-			require.NoError(t, err)
+			userSignup = hostAwait.UpdateUserSignup(t, userSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(us, true)
+				})
 			t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
 			// then
-			err = hostAwait.WaitUntilSpaceBindingDeleted(spaceBinding.Name)
-			require.NoError(t, err)
+			hostAwait.WaitUntilSpaceBindingDeleted(t, spaceBinding.Name)
 		})
 	})
 
@@ -64,16 +62,13 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 		deletionThreshold := -30 * time.Second // space will only be deleted if at least 30 seconds has elapsed since it was created
 
 		// check that the spaces were provisioned before 30 seconds
-		space1, err := hostAwait.WaitForSpace(space1.Name, wait.UntilSpaceHasCreationTimestampOlderThan(deletionThreshold))
-		require.NoError(t, err)
-		space2, err := hostAwait.WaitForSpace(space2.Name, wait.UntilSpaceHasCreationTimestampOlderThan(deletionThreshold))
-		require.NoError(t, err)
+		space1 := hostAwait.WaitForSpace(t, space1.Name, wait.UntilSpaceHasCreationTimestampOlderThan(deletionThreshold))
+		space2 := hostAwait.WaitForSpace(t, space2.Name, wait.UntilSpaceHasCreationTimestampOlderThan(deletionThreshold))
 
 		t.Run("when space is provisioned for more than 30 seconds, then it should not delete the Space when SpaceBinding still exists", func(t *testing.T) {
 
 			// when
-			space, err := hostAwait.WaitForSpace(space1.Name)
-			require.NoError(t, err)
+			space := hostAwait.WaitForSpace(t, space1.Name)
 
 			// then
 			space, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
@@ -84,8 +79,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 				require.NoError(t, err)
 
 				// then
-				err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(space.Name)
-				require.NoError(t, err)
+				hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, space.Name)
 			})
 		})
 
@@ -95,10 +89,8 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 			require.NoError(t, err)
 
 			// then
-			err = hostAwait.WaitUntilSpaceBindingDeleted(binding2.Name)
-			require.NoError(t, err)
-			err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(space2.Name)
-			require.NoError(t, err)
+			hostAwait.WaitUntilSpaceBindingDeleted(t, binding2.Name)
+			hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, space2.Name)
 		})
 	})
 }
@@ -106,22 +98,19 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	space, owner, _ := CreateSpace(t, awaitilities, WithTierName("appstudio"), WithTargetCluster(targetMember.ClusterName), WithName(spaceName))
 	// at this point, just make sure the space exists so we can bind it to our user
-	userSignup, mur := NewSignupRequest(t, awaitilities).
+	userSignup, mur := NewSignupRequest(awaitilities).
 		Username(murName).
 		ManuallyApprove().
-		TargetCluster(targetMember).
+		TargetCluster(targetMember.ClusterName).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(t).Resources()
 	spaceBinding := CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
-	appstudioTier, err := awaitilities.Host().WaitForNSTemplateTier("appstudio")
-	require.NoError(t, err)
+	appstudioTier := awaitilities.Host().WaitForNSTemplateTier(t, "appstudio")
 	// make sure that the NSTemplateSet associated with the Space was updated after the space binding was created (new entry in the `spec.SpaceRoles`)
 	// before we can check the resources (roles and rolebindings)
-	_, err = targetMember.WaitForNSTmplSet(spaceName,
-		wait.UntilNSTemplateSetHasSpaceRoles(
-			wait.SpaceRole(appstudioTier.Spec.SpaceRoles["admin"].TemplateRef, owner.Name, murName)))
-	require.NoError(t, err)
+	targetMember.WaitForNSTmplSet(t, spaceName,
+		wait.UntilNSTemplateSetHasSpaceRoles(wait.SpaceRole(appstudioTier.Spec.SpaceRoles["admin"].TemplateRef, owner.Name, murName)))
 	// in particular, verify that there are role and rolebindings for all the users (the "default" one and the one referred as an argument of this func) in the space
 	VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name, wait.UntilSpaceHasStatusTargetCluster(targetMember.ClusterName))
 	return space, userSignup, spaceBinding

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -28,8 +28,7 @@ func TestToolchainClusterE2E(t *testing.T) {
 // in the target cluster type operator
 func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wait.Awaitility) {
 	// given
-	current, ok, err := await.GetToolchainCluster(otherAwait.Type, otherAwait.Namespace, nil)
-	require.NoError(t, err)
+	current, ok := await.GetToolchainCluster(t, otherAwait.Type, otherAwait.Namespace, nil)
 	require.True(t, ok, "ToolchainCluster should exist")
 
 	t.Run("create new ToolchainCluster with correct data and expect to be ready for cluster type "+string(await.Type), func(t *testing.T) {
@@ -55,12 +54,12 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 		// then the ToolchainCluster should be ready
 		require.NoError(t, err)
-		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, wait.ReadyToolchainCluster)
+		_, err = await.WaitForNamedToolchainClusterWithCondition(t, toolchainCluster.Name, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 		// other ToolchainCluster should be ready, too
-		_, err = await.WaitForToolchainClusterWithCondition(otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = await.WaitForToolchainClusterWithCondition(t, otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
-		_, err = otherAwait.WaitForToolchainClusterWithCondition(await.Type, await.Namespace, wait.ReadyToolchainCluster)
+		_, err = otherAwait.WaitForToolchainClusterWithCondition(t, await.Type, await.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 	})
 
@@ -86,15 +85,15 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		err := await.Client.Create(context.TODO(), toolchainCluster)
 		// then the ToolchainCluster should be offline
 		require.NoError(t, err)
-		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, &toolchainv1alpha1.ToolchainClusterCondition{
+		_, err = await.WaitForNamedToolchainClusterWithCondition(t, toolchainCluster.Name, &toolchainv1alpha1.ToolchainClusterCondition{
 			Type:   toolchainv1alpha1.ToolchainClusterOffline,
 			Status: corev1.ConditionTrue,
 		})
 		require.NoError(t, err)
 		// other ToolchainCluster should be ready, too
-		_, err = await.WaitForToolchainClusterWithCondition(otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = await.WaitForToolchainClusterWithCondition(t, otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
-		_, err = otherAwait.WaitForToolchainClusterWithCondition(await.Type, await.Namespace, wait.ReadyToolchainCluster)
+		_, err = otherAwait.WaitForToolchainClusterWithCondition(t, await.Type, await.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 	})
 }

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -90,8 +90,7 @@ func (s *userManagementTestSuite) TestVerifyUserTiers() {
 	}
 	for _, expectedTier := range expectedTiers {
 		s.T().Run(fmt.Sprintf("verify UserTier '%s'", expectedTier.name), func(t *testing.T) {
-			userTier, err := hostAwait.WaitForUserTier(expectedTier.name)
-			assert.NoError(t, err)
+			userTier := hostAwait.WaitForUserTier(t, expectedTier.name)
 			assert.Equal(t, expectedTier.deactivationTimeoutDays, userTier.Spec.DeactivationTimeoutDays)
 		})
 	}
@@ -101,34 +100,34 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
 	memberAwait2 := s.Member2()
-	hostAwait.UpdateToolchainConfig(
+	hostAwait.UpdateToolchainConfig(s.T(),
 		testconfig.AutomaticApproval().Enabled(false),
 		testconfig.Deactivation().DeactivatingNotificationDays(-1))
 
-	config := hostAwait.GetToolchainConfig()
+	config := hostAwait.GetToolchainConfig(s.T())
 	require.Equal(s.T(), -1, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
 	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
 
 		// User on member cluster 1
-		userSignupMember1, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember1, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate").
 			Email("usertodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// User on member cluster 2
-		userSignupMember2, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember2, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate2").
 			Email("usertodeactivate2@example.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait2).
+			TargetCluster(memberAwait2.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember1)
 		DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignupMember2)
@@ -142,49 +141,45 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
 
 		// User on member cluster 1
-		userNoEmail, _ := NewSignupRequest(t, s.Awaitilities).
+		userNoEmail, _ := NewSignupRequest(s.Awaitilities).
 			Username("usernoemail").
 			Email("usernoemail@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// Delete the user's email and set them to deactivated
-		userSignup, err := hostAwait.UpdateUserSignup(userNoEmail.Name, func(us *toolchainv1alpha1.UserSignup) {
+		userSignup := hostAwait.UpdateUserSignup(t, userNoEmail.Name, func(us *toolchainv1alpha1.UserSignup) {
 			delete(us.Annotations, toolchainv1alpha1.UserSignupUserEmailAnnotationKey)
 			states.SetDeactivated(us, true)
 		})
-		require.NoError(s.T(), err)
-		s.T().Logf("user signup '%s' set to deactivated", userSignup.Name)
+		t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
-		_, err = hostAwait.WaitForUserSignup(userSignup.Name,
+		hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), UserSignupMissingEmailAnnotation())...))
-		require.NoError(t, err)
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
 
-		_, murMember1 := NewSignupRequest(t, s.Awaitilities).
+		_, murMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usernodeactivate").
 			Email("usernodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// Get the tier that has deactivation disabled
-		deactivationDisabledTier, err := hostAwait.WaitForUserTier("nodeactivation")
-		require.NoError(t, err)
+		deactivationDisabledTier := hostAwait.WaitForUserTier(t, "nodeactivation")
 
 		// Move the user to the new tier without deactivation enabled
 		tiers.MoveMURToTier(t, hostAwait, murMember1.Name, deactivationDisabledTier.Name)
-		murMember1, err = hostAwait.WaitForMasterUserRecord(murMember1.Name,
+		murMember1 = hostAwait.WaitForMasterUserRecord(t, murMember1.Name,
 			wait.UntilMasterUserRecordHasCondition(Provisioned()),
 			wait.UntilMasterUserRecordHasTierName(deactivationDisabledTier.Name)) // ignore other conditions, such as notification sent, etc.
-		require.NoError(s.T(), err)
 
 		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
 		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
@@ -192,131 +187,117 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		manyManyDaysAgo := 999999999999999
 		durationDelta := time.Duration(manyManyDaysAgo) * time.Hour * 24
 		updatedProvisionedTime := &metav1.Time{Time: time.Now().Add(-durationDelta)}
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		murMember1 = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = updatedProvisionedTime
 		})
-		require.NoError(s.T(), err)
-		s.T().Logf("masteruserrecord '%s' provisioned time adjusted", murMember1.Name)
+		t.Logf("masteruserrecord '%s' provisioned time adjusted", murMember1.Name)
 
 		// The user should not be deactivated so the MUR should not be deleted, expect an error
-		err = hostAwait.WithRetryOptions(wait.TimeoutOption(3 * time.Second)).WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murMember1.Name)
-		require.Error(s.T(), err)
+		hostAwait.WithRetryOptions(wait.TimeoutOption(3*time.Second)).WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, murMember1.Name)
 
 		// The space should not be deleted either, expect an error
-		err = hostAwait.WithRetryOptions(wait.TimeoutOption(3 * time.Second)).WaitUntilSpaceAndSpaceBindingsDeleted(murMember1.Name)
-		require.Error(t, err)
+		hostAwait.WithRetryOptions(wait.TimeoutOption(3*time.Second)).WaitUntilSpaceAndSpaceBindingsDeleted(t, murMember1.Name)
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
-		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember1, murMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usertoautodeactivate").
 			Email("usertoautodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
 
-		deactivationExcludedUserSignupMember1, excludedMurMember1 := NewSignupRequest(t, s.Awaitilities).
+		deactivationExcludedUserSignupMember1, excludedMurMember1 := NewSignupRequest(s.Awaitilities).
 			Username("userdeactivationexcluded").
 			Email("userdeactivationexcluded@excluded.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
 
 		// Get the provisioned account's tier
-		baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
-		require.NoError(t, err)
+		baseUserTier := hostAwait.WaitForUserTier(t, "deactivate30")
 
 		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the provisioned time
 		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
 		// time should test the behaviour of the deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		murMember1 = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
-		require.NoError(s.T(), err)
 		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name, murMember1.Status.ProvisionedTime.String())
 
 		// Use the same method above to change the provisioned time for the excluded user
-		excludedMurMember1, err = hostAwait.UpdateMasterUserRecordStatus(excludedMurMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		excludedMurMember1 = hostAwait.UpdateMasterUserRecordStatus(t, excludedMurMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
-		require.NoError(s.T(), err)
 		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", excludedMurMember1.Name, excludedMurMember1.Status.ProvisionedTime.String())
 
 		// The non-excluded user should be deactivated
-		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murMember1.Name)
-		require.NoError(s.T(), err)
+		hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, murMember1.Name)
 
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(murMember1.Name)
-		require.NoError(t, err)
+		hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, murMember1.Name)
 
-		userSignupMember1, err = hostAwait.WaitForUserSignup(userSignupMember1.Name,
+		userSignupMember1 = hostAwait.WaitForUserSignup(t, userSignupMember1.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(ApprovedByAdmin(), Deactivated())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
-		require.NoError(s.T(), err)
 		require.True(t, states.Deactivated(userSignupMember1), "usersignup should be deactivated")
 
 		// The excluded user should still be active
-		_, err = hostAwait.WaitForMasterUserRecord(excludedMurMember1.Name)
-		require.NoError(s.T(), err)
-		deactivationExcludedUserSignupMember1, err = hostAwait.WaitForUserSignup(deactivationExcludedUserSignupMember1.Name,
+		hostAwait.WaitForMasterUserRecord(t, excludedMurMember1.Name)
+		deactivationExcludedUserSignupMember1 = hostAwait.WaitForUserSignup(t, deactivationExcludedUserSignupMember1.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-		require.NoError(s.T(), err)
 		require.False(t, states.Deactivated(deactivationExcludedUserSignupMember1), "deactivationExcludedUserSignup should not be deactivated")
 	})
 
 	s.T().Run("test deactivating state set OK", func(t *testing.T) {
 		// Reset configuration back to 3 days
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.AutomaticApproval().Enabled(false),
 			testconfig.Deactivation().DeactivatingNotificationDays(3))
 
-		config := hostAwait.GetToolchainConfig()
+		config := hostAwait.GetToolchainConfig(t)
 		require.Equal(s.T(), 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
-		userSignupMember1, murMember1 := NewSignupRequest(t, s.Awaitilities).
+		userSignupMember1, murMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usertostartdeactivating").
 			Email("usertostartdeactivating@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
 
 		// Get the provisioned account's tier
-		baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
-		require.NoError(t, err)
+		baseUserTier := hostAwait.WaitForUserTier(t, "deactivate30")
 
 		// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the
 		// provisioned time to a time far enough in the past to trigger the deactivation process. Subtracting the given
 		// period from the current time and setting this as the provisioned time should test the behaviour of the
 		// deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		murMember1 = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 		})
-		require.NoError(s.T(), err)
 		s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name,
 			murMember1.Status.ProvisionedTime.String())
 
 		// The user should be set to deactivating, but not deactivated
-		_, err = hostAwait.WaitForUserSignup(userSignupMember1.Name, wait.UntilUserSignupHasConditions(
+		hostAwait.WaitForUserSignup(t, userSignupMember1.Name, wait.UntilUserSignupHasConditions(
 			ConditionSet(Default(), ApprovedByAdmin(), Deactivating())...))
-		require.NoError(s.T(), err)
 
 		// Verify resources still exist
 		VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignupMember1, "deactivate30", "base")
@@ -324,53 +305,49 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("test full automatic user deactivation lifecycle", func(t *testing.T) {
 		// Set configuration to 3 days
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.AutomaticApproval().Enabled(true),
 			testconfig.Deactivation().DeactivatingNotificationDays(3))
 
-		hostConfig := hostAwait.GetToolchainConfig().Spec.Host
+		config := hostAwait.GetToolchainConfig(t)
+		hostConfig := config.Spec.Host
 		require.Equal(s.T(), 3, *hostConfig.Deactivation.DeactivatingNotificationDays)
 
 		// Create a new UserSignup
-		userSignup, mur := NewSignupRequest(t, s.Awaitilities).
+		userSignup, mur := NewSignupRequest(s.Awaitilities).
 			Username("fulldeactivationlifecycle").
 			Email("fulldeactivationlifecycle@redhat.com").
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, mur)
 
 		// Wait for the UserSignup to have the desired state
-		userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-		require.NoError(s.T(), err)
 
 		s.T().Run("user set to deactivating when provisioned time set in past", func(t *testing.T) {
 			// Get the provisioned account's tier
-			baseUserTier, err := hostAwait.WaitForUserTier("deactivate30")
-			require.NoError(t, err)
+			baseUserTier := hostAwait.WaitForUserTier(t, "deactivate30")
 
-			mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
-			require.NoError(t, err)
+			mur := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 
 			// We cannot wait days for testing deactivation so for the purposes of the e2e tests we use a hack to change the
 			// provisioned time to a time far enough in the past to trigger the deactivation process. Subtracting the given
 			// period from the current time and setting this as the provisioned time should test the behaviour of the
 			// deactivation controller reconciliation.
 			tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-			mur, err = hostAwait.UpdateMasterUserRecordStatus(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur = hostAwait.UpdateMasterUserRecordStatus(t, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 				mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 			})
-			require.NoError(s.T(), err)
 			s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
 				mur.Status.ProvisionedTime.String())
 
 			// The user should be set to deactivating, but not deactivated
-			userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(
+			userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name, wait.UntilUserSignupHasConditions(
 				ConditionSet(Default(), ApprovedAutomatically(), Deactivating())...))
-			require.NoError(s.T(), err)
 
 			// Verify resources have been provisioned
 			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "deactivate30", "base")
@@ -378,11 +355,10 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
 				tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+4) * time.Hour * 24
-				mur, err = hostAwait.UpdateMasterUserRecordStatus(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+				mur = hostAwait.UpdateMasterUserRecordStatus(t, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
 				})
 				murName := mur.Name
-				require.NoError(s.T(), err)
 				s.T().Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
 					mur.Status.ProvisionedTime.String())
 
@@ -418,86 +394,78 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 				require.NoError(t, hostAwait.Client.Status().Update(context.TODO(), userSignup))
 
 				// Trigger a reconciliation of the deactivation controller by updating the MUR annotation
-				_, err := hostAwait.UpdateMasterUserRecordSpec(murName, func(mur *toolchainv1alpha1.MasterUserRecord) {
+				hostAwait.UpdateMasterUserRecordSpec(t, murName, func(mur *toolchainv1alpha1.MasterUserRecord) {
 					if mur.Annotations == nil {
 						mur.Annotations = map[string]string{}
 					}
 					mur.Annotations["update-from-e2e-tests"] = "trigger"
 				})
-				if err != nil {
-					// the mur might already be deleted, so we can continue as long as the error is the mur was not found
-					require.EqualError(t, err, `masteruserrecords.toolchain.dev.openshift.com "fulldeactivationlifecycle" not found`)
-				}
+				// if err != nil {
+				// 	// the mur might already be deleted, so we can continue as long as the error is the mur was not found
+				// 	require.EqualError(t, err, `masteruserrecords.toolchain.dev.openshift.com "fulldeactivationlifecycle" not found`)
+				// }
 
 				// The user should now be set to deactivated
-				userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+				userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 					wait.UntilUserSignupHasConditions(ConditionSet(ApprovedAutomatically(), Deactivated())...))
-				require.NoError(s.T(), err)
 
 				// The MUR should also be deleted
-				err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(murName)
-				require.NoError(s.T(), err)
+				hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, murName)
 
-				err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(murName)
-				require.NoError(t, err)
+				hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, murName)
 			})
 		})
 	})
 
 	s.T().Run("reactivated but unverified user reverted back to deactivated after timeout", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and wait for it to be provisioned
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertoreactivate").
 			Email("usertoreactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// Wait for the UserSignup to have the desired state
-		userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-		require.NoError(s.T(), err)
 
 		// Now deactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		userSignup = hostAwait.UpdateUserSignup(t, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
-		require.NoError(s.T(), err)
 
-		userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), DeactivatedWithoutPreDeactivation())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
-		require.NoError(t, err)
 		require.True(t, states.Deactivated(userSignup), "usersignup should be deactivated")
 
 		// Set the unverified retention days to 0
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.Deactivation().UserSignupUnverifiedRetentionDays(0))
 
 		// Reactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		userSignup = hostAwait.UpdateUserSignup(t, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivating(us, false)
 			states.SetDeactivated(us, false)
 			states.SetApprovedManually(us, true)
 			states.SetVerificationRequired(us, true)
 		})
-		require.NoError(t, err)
 		t.Logf("user signup '%s' reactivated", userSignup.Name)
 
 		// Since the config for retention days is set to 0, the account should be deactivated again immediately
-		userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), DeactivatedWithoutNotification())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
-		require.NoError(t, err)
 		require.True(t, states.Deactivated(userSignup), "usersignup should be deactivated")
 
 		// Set the unverified retention days to 7
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.Deactivation().UserSignupUnverifiedRetentionDays(7))
 	})
 }
@@ -507,39 +475,36 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
 		hostAwait := s.Host()
 		memberAwait := s.Member1()
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("banprovisioned").
 			Email("banprovisioned@test.com").
 			ManuallyApprove().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// Create the BannedUser
-		CreateBannedUser(s.T(), s.Host(), userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
+		CreateBannedUser(t, s.Host(), userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 		// Confirm the user is banned
-		_, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(userSignup.Name,
+		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...))
-		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
-		_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(userSignup.Spec.Username)
-		require.Error(s.T(), err)
+		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForMasterUserRecord(t, userSignup.Spec.Username)
 		// confirm usersignup
-		_, err = hostAwait.WaitForUserSignup(userSignup.Name,
+		hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
-		require.NoError(s.T(), err)
 	})
 
 	s.T().Run("manually created usersignup with preexisting banneduser", func(t *testing.T) {
 		hostAwait := s.Host()
 		memberAwait := s.Member1()
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
 		email := "testuser" + id + "@test.com"
@@ -551,26 +516,22 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		userSignup.Spec.TargetCluster = memberAwait.ClusterName
 
 		// Create the UserSignup via the Kubernetes API
-		err := hostAwait.CreateWithCleanup(context.TODO(), userSignup)
-		require.NoError(s.T(), err)
+		hostAwait.CreateWithCleanup(t, userSignup)
 		s.T().Logf("user signup '%s' created", userSignup.Name)
 
 		// Check the UserSignup is created
-		userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name)
-		require.NoError(s.T(), err)
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name)
 
 		// Confirm that the user is banned
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueBanned, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
-		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted("testuser" + id)
-		require.NoError(s.T(), err)
+		hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, "testuser"+id)
 
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted("testuser" + id)
-		require.NoError(t, err)
+		hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, "testuser"+id)
 	})
 
 	s.T().Run("register new user with preexisting ban", func(t *testing.T) {
 		hostAwait := s.Host()
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 		id := uuid.Must(uuid.NewV4()).String()
 		email := "testuser" + id + "@test.com"
@@ -608,53 +569,47 @@ func (s *userManagementTestSuite) TestUserBanning() {
 	s.T().Run("ban provisioned usersignup", func(t *testing.T) {
 		hostAwait := s.Host()
 		memberAwait := s.Member1()
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
-		userSignup, mur := NewSignupRequest(t, s.Awaitilities).
+		userSignup, mur := NewSignupRequest(s.Awaitilities).
 			Username("banandunban").
 			Email("banandunban@test.com").
 			EnsureMUR().
 			ManuallyApprove().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// Create the BannedUser
 		bannedUser := CreateBannedUser(s.T(), s.Host(), userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 		// Confirm the user is banned
-		_, err := hostAwait.WaitForUserSignup(userSignup.Name,
+		hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...))
-		require.NoError(s.T(), err)
 
 		// Confirm that a MasterUserRecord is deleted
-		_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(userSignup.Spec.Username)
-		require.Error(s.T(), err)
+		hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForMasterUserRecord(t, userSignup.Spec.Username)
 		// confirm usersignup
-		userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+		userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
-		require.NoError(s.T(), err)
 
 		t.Run("unban the banned user", func(t *testing.T) {
 			// Unban the user
-			err = hostAwait.Client.Delete(context.TODO(), bannedUser)
+			err := hostAwait.Client.Delete(context.TODO(), bannedUser)
 			require.NoError(s.T(), err)
 
 			// Confirm the BannedUser is deleted
-			err = hostAwait.WaitUntilBannedUserDeleted(bannedUser.Name)
-			require.NoError(s.T(), err)
+			hostAwait.WaitUntilBannedUserDeleted(t, bannedUser.Name)
 
 			// Confirm the user is provisioned
-			userSignup, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(userSignup.Name,
+			userSignup = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForUserSignup(t, userSignup.Name,
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
 
 			// Confirm the MUR is created
-			_, err = hostAwait.WaitForMasterUserRecord(mur.Name)
-			require.NoError(s.T(), err)
+			hostAwait.WaitForMasterUserRecord(t, mur.Name)
 		})
 	})
 }
@@ -662,41 +617,38 @@ func (s *userManagementTestSuite) TestUserBanning() {
 func (s *userManagementTestSuite) TestUserDisabled() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup
-	userSignup, mur := NewSignupRequest(s.T(), s.Awaitilities).
+	userSignup, mur := NewSignupRequest(s.Awaitilities).
 		Username("janedoe").
 		EnsureMUR().
 		ManuallyApprove().
-		TargetCluster(memberAwait).
+		TargetCluster(memberAwait.ClusterName).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(s.T()).Resources()
 
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 
 	// Disable MUR
-	mur, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+	mur = hostAwait.UpdateMasterUserRecordSpec(s.T(), mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 		mur.Spec.Disabled = true
 	})
-	require.NoError(s.T(), err)
 
 	// Wait until the UserAccount status is disabled
-	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
+	userAccount := memberAwait.WaitForUserAccount(s.T(), mur.Name,
 		wait.UntilUserAccountHasConditions(Disabled()))
-	require.NoError(s.T(), err)
 
 	// Wait until the MUR status is disabled
-	mur, err = hostAwait.WaitForMasterUserRecord(userSignup.Spec.Username,
+	mur = hostAwait.WaitForMasterUserRecord(s.T(), userSignup.Spec.Username,
 		wait.UntilMasterUserRecordHasConditions(Disabled(), ProvisionedNotificationCRCreated()))
-	require.NoError(s.T(), err)
 
 	// Check that the UserAccount is now set to disabled
 	require.True(s.T(), userAccount.Spec.Disabled)
 
 	// Check the User is deleted
 	user := &userv1.User{}
-	err = hostAwait.Client.Get(context.TODO(), types.NamespacedName{Name: userAccount.Namespace}, user)
+	err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{Name: userAccount.Namespace}, user)
 	require.Error(s.T(), err)
 	assert.True(s.T(), apierrors.IsNotFound(err))
 
@@ -708,11 +660,9 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	s.Run("re-enabled mur", func() {
 		// Re-enable MUR
-		mur, err = hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		mur = hostAwait.UpdateMasterUserRecordSpec(s.T(), mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Spec.Disabled = false
 		})
-		require.NoError(s.T(), err)
-
 		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 	})
 }
@@ -724,35 +674,33 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 
 	s.T().Run("test returning user provisioned to same cluster", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 		clustersToTest := []*wait.MemberAwaitility{memberAwait, memberAwait2}
 
 		for i, initialTargetCluster := range clustersToTest {
 			// when
 			t.Run(fmt.Sprintf("cluster %s: user activated->deactivated->reactivated", initialTargetCluster.ClusterName), func(t *testing.T) {
 				// given
-				userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+				userSignup, _ := NewSignupRequest(s.Awaitilities).
 					Username(fmt.Sprintf("returninguser%d", i)).
 					Email(fmt.Sprintf("returninguser%d@redhat.com", i)).
 					EnsureMUR().
 					ManuallyApprove().
-					TargetCluster(initialTargetCluster). // use TargetCluster initially to force user to provision to the expected cluster
+					TargetCluster(initialTargetCluster.ClusterName). // use TargetCluster initially to force user to provision to the expected cluster
 					RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-					Execute().Resources()
+					Execute(t).Resources()
 
 				// when
 				DeactivateAndCheckUser(s.T(), s.Awaitilities, userSignup)
 				// If TargetCluster is set it will override the last cluster annotation so remove TargetCluster
-				userSignup, err := s.Host().UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+				userSignup = s.Host().UpdateUserSignup(t, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 					us.Spec.TargetCluster = ""
 				})
-				require.NoError(t, err)
 
 				userSignup = ReactivateAndCheckUser(s.T(), s.Awaitilities, userSignup)
-				mur2, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
+				mur2 := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername, wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
 
 				// then
-				require.NoError(t, err)
 				secondSignupCluster := GetMurTargetMember(t, s.Awaitilities, mur2)
 				require.Equal(t, initialTargetCluster.ClusterName, secondSignupCluster.ClusterName)
 			})

--- a/test/e2e/user_rolebindings_test.go
+++ b/test/e2e/user_rolebindings_test.go
@@ -32,13 +32,13 @@ func TestUserCreatingRoleBindings(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and approve a sandbox user
-	testsupport.NewSignupRequest(t, awaitilities).
+	testsupport.NewSignupRequest(awaitilities).
 		Username("harleyquinn").
 		ManuallyApprove().
-		TargetCluster(memberAwait).
+		TargetCluster(memberAwait.ClusterName).
 		EnsureMUR().
 		RequireConditions(testsupport.ConditionSet(testsupport.Default(), testsupport.ApprovedByAdmin())...).
-		Execute()
+		Execute(t)
 
 	//create a non-sandbox user
 	nonsandboxUser := userv1.User{

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -35,74 +34,72 @@ func (s *userSignupIntegrationTest) TearDownTest() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
 	memberAwait2 := s.Member2()
-	hostAwait.Clean()
-	memberAwait.Clean()
-	memberAwait2.Clean()
+	hostAwait.Clean(s.T())
+	memberAwait.Clean(s.T())
+	memberAwait2.Clean(s.T())
 }
 
 func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	// given
 	hostAwait := s.Host()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when & then
-	NewSignupRequest(s.T(), s.Awaitilities).
+	NewSignupRequest(s.Awaitilities).
 		Username("automatic1").
 		Email("automatic1@redhat.com").
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
-		Execute()
+		Execute(s.T())
 
 	s.T().Run("set low capacity threshold and expect that user won't be approved nor provisioned", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).ResourceCapacityThreshold(1))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).ResourceCapacityThreshold(1))
 
 		// when
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("automatic2").
 			Email("automatic2@redhat.com").
 			RequireConditions(ConditionSet(Default(), PendingApproval(), PendingApprovalNoCluster())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
 
 		t.Run("reset the threshold and expect the user will be provisioned", func(t *testing.T) {
 			// when
-			hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).ResourceCapacityThreshold(80))
+			hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).ResourceCapacityThreshold(80))
 
 			// then
-			userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+			userSignup := hostAwait.WaitForUserSignup(t, userSignup.Name,
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
 	s.T().Run("set low max number of users and expect that user won't be approved nor provisioned but added on waiting list", func(t *testing.T) {
 		// given
-		toolchainStatus, err := hostAwait.WaitForToolchainStatus(
+		toolchainStatus := hostAwait.WaitForToolchainStatus(t,
 			wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()))
-		require.NoError(t, err)
 		originalMursPerDomainCount := toolchainStatus.Status.Metrics[toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey]
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(originalMursPerDomainCount["internal"] + originalMursPerDomainCount["external"]))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(originalMursPerDomainCount["internal"]+originalMursPerDomainCount["external"]))
 
 		// when
-		userSignup1, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup1, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist1").
 			Email("waitinglist1@redhat.com").
 			RequireConditions(ConditionSet(Default(), PendingApproval(), PendingApprovalNoCluster())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
-		userSignup2, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup2, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist2").
 			Email("waitinglist2@redhat.com").
 			RequireConditions(ConditionSet(Default(), PendingApproval(), PendingApprovalNoCluster())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// then
 		s.userIsNotProvisioned(t, userSignup1)
@@ -110,26 +107,24 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 
 		t.Run("increment the max number of users and expect the first unapproved user will be provisioned", func(t *testing.T) {
 			// when
-			hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(originalMursPerDomainCount["internal"] + originalMursPerDomainCount["external"] + 1))
+			hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(originalMursPerDomainCount["internal"]+originalMursPerDomainCount["external"]+1))
 
 			// then
-			userSignup, err := hostAwait.WaitForUserSignup(userSignup1.Name,
+			userSignup := hostAwait.WaitForUserSignup(t, userSignup1.Name,
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
 
 			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 			s.userIsNotProvisioned(t, userSignup2)
 
 			t.Run("reset the max number and expect the second user will be provisioned as well", func(t *testing.T) {
 				// when
-				hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000))
+				hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000))
 
 				// then
-				userSignup, err := hostAwait.WaitForUserSignup(userSignup2.Name,
+				userSignup := hostAwait.WaitForUserSignup(t, userSignup2.Name,
 					wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...),
 					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-				require.NoError(s.T(), err)
 
 				VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 			})
@@ -144,10 +139,9 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 	s.T().Run("set per member clusters max number of users for both members and expect that users will be provisioned to the other member when one is full", func(t *testing.T) {
 		// given
 		var memberLimits []testconfig.PerMemberClusterOptionInt
-		toolchainStatus, err := hostAwait.WaitForToolchainStatus(
+		toolchainStatus := hostAwait.WaitForToolchainStatus(t,
 			wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()))
-		require.NoError(t, err)
 		for _, m := range toolchainStatus.Status.Members {
 			if memberAwait.ClusterName == m.ClusterName {
 				memberLimits = append(memberLimits, testconfig.PerMemberCluster(memberAwait.ClusterName, m.UserAccountCount+1))
@@ -157,33 +151,33 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 		}
 		require.Len(s.T(), memberLimits, 2)
 
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(0, memberLimits...))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(0, memberLimits...))
 
 		// when
-		_, mur1 := NewSignupRequest(t, s.Awaitilities).
+		_, mur1 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-1").
 			Email("multi1@redhat.com").
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
-		_, mur2 := NewSignupRequest(t, s.Awaitilities).
+		_, mur2 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-2").
 			Email("multi2@redhat.com").
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// then
 		require.NotEqual(s.T(), mur1.Spec.UserAccounts[0].TargetCluster, mur2.Spec.UserAccounts[0].TargetCluster)
 
 		t.Run("after both members are full then new signups won't be approved nor provisioned", func(t *testing.T) {
 			// when
-			userSignupPending, _ := NewSignupRequest(t, s.Awaitilities).
+			userSignupPending, _ := NewSignupRequest(s.Awaitilities).
 				Username("multimember-3").
 				Email("multi3@redhat.com").
 				RequireConditions(ConditionSet(Default(), PendingApproval(), PendingApprovalNoCluster())...).
-				Execute().Resources()
+				Execute(t).Resources()
 
 			// then
 			s.userIsNotProvisioned(t, userSignupPending)
@@ -193,9 +187,8 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *toolchainv1alpha1.UserSignup) {
 	hostAwait := s.Host()
-	hostAwait.CheckMasterUserRecordIsDeleted(userSignup.Spec.Username)
-	currentUserSignup, err := hostAwait.WaitForUserSignup(userSignup.Name)
-	require.NoError(t, err)
+	hostAwait.CheckMasterUserRecordIsDeleted(t, userSignup.Spec.Username)
+	currentUserSignup := hostAwait.WaitForUserSignup(t, userSignup.Name)
 	assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValuePending, currentUserSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 }
 
@@ -203,27 +196,27 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 	hostAwait := s.Host()
 	s.T().Run("default approval config - manual", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
-			userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+			userSignup, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual1").
 				Email("manual1@redhat.com").
 				ManuallyApprove().
 				EnsureMUR().
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-				Execute().Resources()
+				Execute(t).Resources()
 
 			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
-			userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+			userSignup, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual2").
 				Email("manual2@redhat.com").
 				RequireConditions(ConditionSet(Default(), PendingApproval())...).
-				Execute().Resources()
+				Execute(t).Resources()
 
 			// then
 			s.userIsNotProvisioned(t, userSignup)
@@ -236,89 +229,87 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
 	// given
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
 	// when & then
-	NewSignupRequest(s.T(), s.Awaitilities).
+	NewSignupRequest(s.Awaitilities).
 		Username("manualwithcapacity1").
 		Email("manualwithcapacity1@redhat.com").
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute()
+		Execute(s.T())
 
 	s.T().Run("set low capacity threshold and expect that user won't provisioned even when is approved manually", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).ResourceCapacityThreshold(1))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).ResourceCapacityThreshold(1))
 
 		// when
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity2").
 			Email("manualwithcapacity2@redhat.com").
 			ManuallyApprove().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin(), ApprovedByAdminNoCluster())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
 
 		t.Run("reset the threshold and expect the user will be provisioned", func(t *testing.T) {
 			// when
-			hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).ResourceCapacityThreshold(80))
+			hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).ResourceCapacityThreshold(80))
 
 			// then
-			userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+			userSignup := hostAwait.WaitForUserSignup(t, userSignup.Name,
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
 	s.T().Run("set low max number of users and expect that user won't be provisioned even when is approved manually", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1))
 
 		// when
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity3").
 			Email("manualwithcapacity3@redhat.com").
 			ManuallyApprove().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin(), ApprovedByAdminNoCluster())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
 
 		t.Run("reset the max number and expect the user will be provisioned", func(t *testing.T) {
 			// when
-			hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000))
+			hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000))
 
 			// then
-			userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+			userSignup := hostAwait.WaitForUserSignup(t, userSignup.Name,
 				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
 			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 		})
 	})
 
 	s.T().Run("when approved and set target cluster manually, then the limits will be ignored", func(t *testing.T) {
 		// given
-		hostAwait.UpdateToolchainConfig(
+		hostAwait.UpdateToolchainConfig(s.T(),
 			testconfig.AutomaticApproval().Enabled(false).
 				ResourceCapacityThreshold(1).
 				MaxNumberOfUsers(1))
 
 		// when & then
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+		userSignup, _ := NewSignupRequest(s.Awaitilities).
 			Username("withtargetcluster").
 			Email("withtargetcluster@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(t).Resources()
 
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
@@ -327,7 +318,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
 	hostAwait := s.Host()
 	s.T().Run("automatic approval with verification required", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
+		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
 		t.Run("verification required set to true", func(t *testing.T) {
 			s.createUserSignupVerificationRequiredAndAssertNotProvisioned()
@@ -338,16 +329,14 @@ func (s *userSignupIntegrationTest) TestUserSignupVerificationRequired() {
 func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	hostAwait := s.Host()
 	// Create user signup
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(1000).ResourceCapacityThreshold(80))
 
 	userSignup := NewUserSignup(hostAwait.Namespace, "reginald@alpha.com", "reginald@alpha.com")
-	err := hostAwait.CreateWithCleanup(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
+	hostAwait.CreateWithCleanup(s.T(), userSignup)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
 	// Check the UserSignup is approved now
-	userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name, wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...))
-	require.NoError(s.T(), err)
+	userSignup = hostAwait.WaitForUserSignup(s.T(), userSignup.Name, wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedAutomatically())...))
 
 	// Confirm the MUR was created and target cluster was set
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -355,70 +344,70 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 
 func (s *userSignupIntegrationTest) TestTransformUsername() {
 	// Create UserSignup with a username that we don't need to transform
-	userSignup, _ := NewSignupRequest(s.T(), s.Awaitilities).
+	userSignup, _ := NewSignupRequest(s.Awaitilities).
 		Username("paul-no-need-to-transform").
 		Email("paulnoneedtotransform@hotel.com").
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(s.T()).Resources()
 
 	require.Equal(s.T(), "paul-no-need-to-transform", userSignup.Status.CompliantUsername)
 
 	// Create UserSignup with a username to transform
-	userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+	userSignup, _ = NewSignupRequest(s.Awaitilities).
 		Username("paul@hotel.com").
 		Email("paul@hotel.com").
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(s.T()).Resources()
 
 	require.Equal(s.T(), "paul", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignup with the original username matching the transformed username of the existing signup
-	userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+	userSignup, _ = NewSignupRequest(s.Awaitilities).
 		Username("paul").
 		Email("paulathotel@hotel.com").
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(s.T()).Resources()
 
 	require.Equal(s.T(), "paul-2", userSignup.Status.CompliantUsername)
 
 	// Create another UserSignups with a forbidden prefix
 	for _, prefix := range []string{"kube", "openshift", "default", "redhat", "sandbox"} {
 		// prefix with hyphen
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username(prefix + "-paul").
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("crt-%s-paul", prefix), userSignup.Status.CompliantUsername)
 
 		// prefix without delimiter
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username(prefix + "paul").
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("crt-%spaul", prefix), userSignup.Status.CompliantUsername)
 
 		// prefix as a name
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username(prefix).
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("crt-%s", prefix), userSignup.Status.CompliantUsername)
 	}
@@ -426,35 +415,35 @@ func (s *userSignupIntegrationTest) TestTransformUsername() {
 	// Create another UserSignups with a forbidden suffix
 	for _, suffix := range []string{"admin"} {
 		// suffix with hyphen
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username("paul-" + suffix).
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("paul-%s-crt", suffix), userSignup.Status.CompliantUsername)
 
 		// suffix without delimiter
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username("paul" + suffix).
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("paul%s-crt", suffix), userSignup.Status.CompliantUsername)
 
 		// suffix as a name
-		userSignup, _ = NewSignupRequest(s.T(), s.Awaitilities).
+		userSignup, _ = NewSignupRequest(s.Awaitilities).
 			Username(suffix).
 			Email("paul@hotel.com").
 			ManuallyApprove().
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().Resources()
+			Execute(s.T()).Resources()
 
 		require.Equal(s.T(), fmt.Sprintf("%s-crt", suffix), userSignup.Status.CompliantUsername)
 	}
@@ -475,38 +464,35 @@ func (s *userSignupIntegrationTest) createUserSignupVerificationRequiredAndAsser
 	// Set verification required
 	states.SetVerificationRequired(userSignup, true)
 
-	err := hostAwait.CreateWithCleanup(context.TODO(), userSignup)
-	require.NoError(s.T(), err)
+	hostAwait.CreateWithCleanup(s.T(), userSignup)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
 	// Check the UserSignup is pending approval now
-	userSignup, err = hostAwait.WaitForUserSignup(userSignup.Name,
+	userSignup = hostAwait.WaitForUserSignup(s.T(), userSignup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), VerificationRequired())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))
-	require.NoError(s.T(), err)
 
 	// Confirm the CompliantUsername has NOT been set
 	require.Empty(s.T(), userSignup.Status.CompliantUsername)
 
 	// Confirm that a MasterUserRecord wasn't created
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second * 10)).WaitForMasterUserRecord(username)
-	require.Error(s.T(), err)
+	hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*10)).WaitForMasterUserRecord(s.T(), username)
 	return userSignup
 }
 
 func (s *userSignupIntegrationTest) TestSkipSpaceCreation() {
 	// given
 	hostAwait := s.Host()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(true))
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _ := NewSignupRequest(s.T(), s.Awaitilities).
+	userSignup, _ := NewSignupRequest(s.Awaitilities).
 		Username("nospace").
 		Email("nospace@redhat.com").
 		NoSpace().
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedAutomatically())...).
-		Execute().
+		Execute(s.T()).
 		Resources()
 
 	// then

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -27,7 +27,7 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -37,51 +37,48 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 		username := fmt.Sprintf("user-%04d", i)
 
 		// Create UserSignup
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
-			TargetCluster(memberAwait2).
+			TargetCluster(memberAwait2.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                                                            // all signups
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all activated
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)                                                    // all activated
-	metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 0)                                                 // none deactivated
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // none activated on member-1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 2, "cluster_name", memberAwait2.ClusterName)                 // all activated on member-2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 2, "cluster_name", memberAwait2.ClusterName) // 2 spaces created on member-2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 2)                                                            // all signups
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all activated
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 2)                                                    // all activated
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsDeactivatedMetric, 0)                                                 // none deactivated
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // none activated on member-1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 2, "cluster_name", memberAwait2.ClusterName)                 // all activated on member-2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 2, "cluster_name", memberAwait2.ClusterName) // 2 spaces created on member-2
 
 	// when deactivating the users
 	for username, usersignup := range usersignups {
-		_, err := hostAwait.UpdateUserSignup(usersignup.Name, func(usersignup *toolchainv1alpha1.UserSignup) {
+		hostAwait.UpdateUserSignup(t, usersignup.Name, func(usersignup *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(usersignup, true)
 		})
-		require.NoError(t, err)
 
-		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(username)
-		require.NoError(t, err)
+		hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
 
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(username)
-		require.NoError(t, err)
+		hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, username)
 	}
 
 	// then verify the value of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                                                            // all signups (even if deactivated)
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all deactivated (but this metric is never decremented)
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)                                                    // all deactivated (but counters are never decremented)
-	metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 2)                                                 // all deactivated
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // all deactivated on member-1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)                 // all deactivated on member-2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName) // 2 spaces deleted from member-2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 2)                                                            // all signups (even if deactivated)
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all deactivated (but this metric is never decremented)
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 2)                                                    // all deactivated (but counters are never decremented)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsDeactivatedMetric, 2)                                                 // all deactivated
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // all deactivated on member-1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)                 // all deactivated on member-2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName) // 2 spaces deleted from member-2
 
 }
 
@@ -94,7 +91,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -105,48 +102,45 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		username := fmt.Sprintf("user-%04d", i)
 
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
-			_, err := hostAwait.UpdateUserSignup(usersignups[username].Name, func(usersignup *toolchainv1alpha1.UserSignup) {
+			hostAwait.UpdateUserSignup(t, usersignups[username].Name, func(usersignup *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(usersignup, true)
 			})
-			require.NoError(t, err)
 
-			err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(username)
-			require.NoError(t, err)
+			hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
 
-			err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(username)
-			require.NoError(t, err)
+			hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, username)
 
 			// reactivate the user
-			usersignups[username], _ = NewSignupRequest(t, awaitilities).
+			usersignups[username], _ = NewSignupRequest(awaitilities).
 				IdentityID(uuid.Must(uuid.FromString(usersignups[username].Spec.Userid))).
 				Username(username).
 				ManuallyApprove().
-				TargetCluster(memberAwait).
+				TargetCluster(memberAwait.ClusterName).
 				EnsureMUR().
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-				Execute().
+				Execute(t).
 				Resources()
 		}
 	}
 
 	// then verify the value of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "1", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "2", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "3", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "1", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "2", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "3", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
 
 	t.Run("restart host-operator pod and verify that metrics are still available", func(t *testing.T) {
 		// given
@@ -158,15 +152,15 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 		// then check how much time it takes to restart and process all existing resources
 		require.NoError(t, err)
 		// host metrics should become available again at this point
-		_, err = hostAwait.WaitForRouteToBeAvailable(hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
+		_, err = hostAwait.WaitForRouteToBeAvailable(t, hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
 		require.NoError(t, err, "failed while setting up or waiting for the route to the 'host-operator-metrics-service' service to be available")
 		// also verify that the metric values "survived" the restart
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // user-0001 was 1 time (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "external") // user-0002 was 2 times (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "external") // user-0003 was 3 times (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // user-0001 was 1 time (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "external") // user-0002 was 2 times (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "external") // user-0003 was 3 times (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
 	})
 }
 
@@ -176,7 +170,7 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -185,12 +179,12 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
-			TargetCluster(memberAwait).
+			TargetCluster(memberAwait.ClusterName).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 
@@ -200,13 +194,11 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for space to be deleted
-	err = hostAwait.WaitUntilUserSignupDeleted(usersignups["user-0001"].GetName())
-	require.NoError(t, err)
-	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(usersignups["user-0001"].GetName())
-	require.NoError(t, err)
+	hostAwait.WaitUntilUserSignupDeleted(t, usersignups["user-0001"].GetName())
+	hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, usersignups["user-0001"].GetName())
 
 	// and verify that the values of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // user-0001 and user-0002 have been provisioned
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // user-0001 and user-0002 have been provisioned
 
 	// when deleting user "user-0002"
 	err = hostAwait.Client.Delete(context.TODO(), usersignups["user-0002"])
@@ -215,13 +207,11 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for space to be deleted
-	err = hostAwait.WaitUntilUserSignupDeleted(usersignups["user-0002"].GetName())
-	require.NoError(t, err)
-	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(usersignups["user-0002"].GetName())
-	require.NoError(t, err)
+	hostAwait.WaitUntilUserSignupDeleted(t, usersignups["user-0002"].GetName())
+	hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, usersignups["user-0002"].GetName())
 
 	// and verify that the values of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // same offset as above: users has been deleted but metric remains unchanged
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // same offset as above: users has been deleted but metric remains unchanged
 }
 
 // TestMetricsWhenUsersBanned verifies that the relevant gauges are decreased when a user is banned, and increased again when unbanned
@@ -238,63 +228,59 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	// given
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
-	userSignup, _ := NewSignupRequest(t, awaitilities).
+	userSignup, _ := NewSignupRequest(awaitilities).
 		Username("metricsbanprovisioned").
 		Email("metricsbanprovisioned@test.com").
 		ManuallyApprove().
 		EnsureMUR().
-		TargetCluster(memberAwait).
+		TargetCluster(memberAwait.ClusterName).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(t).Resources()
 
 	// when creating the BannedUser resource
 	bannedUser := banUser(t, hostAwait, userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 	// then
 	// confirm the user is banned
-	_, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(userSignup.Name,
+	hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(t, userSignup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...))
-	require.NoError(t, err)
 	// verify the metrics
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 1)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)  // no user on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)  // no user on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
 
 	t.Run("unban the banned user", func(t *testing.T) {
 		// given
 		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// when unbaning the user
-		err = hostAwait.Client.Delete(context.TODO(), bannedUser)
+		err := hostAwait.Client.Delete(context.TODO(), bannedUser)
 		require.NoError(t, err)
 
 		// then
 		// confirm the BannedUser resource is deleted
-		err = hostAwait.WaitUntilBannedUserDeleted(bannedUser.GetName())
-		require.NoError(t, err)
+		hostAwait.WaitUntilBannedUserDeleted(t, bannedUser.GetName())
 		// wait for space to be deleted
-		err = hostAwait.WaitUntilUserSignupDeleted(bannedUser.GetName())
-		require.NoError(t, err)
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(bannedUser.GetName())
-		require.NoError(t, err)
+		hostAwait.WaitUntilUserSignupDeleted(t, bannedUser.GetName())
+		hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, bannedUser.GetName())
 		// verify the metrics
-		metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 0)         // unchanged: user signup already existed
-		metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // user approved
-		metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)   // unchanged: banneduser already existed
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user provisioned on member1
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space provisioned on member1
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no spaces on member2
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 0)         // unchanged: user signup already existed
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // user approved
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)   // unchanged: banneduser already existed
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user provisioned on member1
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space provisioned on member1
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no spaces on member2
 	})
 }
 
@@ -305,71 +291,69 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 	// Create UserSignup
-	_, mur := NewSignupRequest(t, awaitilities).
+	_, mur := NewSignupRequest(awaitilities).
 		Username("janedoe").
 		ManuallyApprove().
-		TargetCluster(memberAwait).
+		TargetCluster(memberAwait.ClusterName).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().
+		Execute(t).
 		Resources()
 
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // approved
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space present on member1
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // approved
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space present on member1
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
 
 	// when disabling MUR
-	_, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+	hostAwait.UpdateMasterUserRecordSpec(t, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 		mur.Spec.Disabled = true
 	})
-	require.NoError(t, err)
 
 	// then
 	// verify the metrics
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // still approved even though (temporarily) disabled
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space is on member1
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // still approved even though (temporarily) disabled
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space is on member1
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
 
 	t.Run("re-enabled mur", func(t *testing.T) {
 		// given
 		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// When re-enabling MUR
-		mur, err = hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+		mur = hostAwait.UpdateMasterUserRecordSpec(t, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Spec.Disabled = false
 		})
-		require.NoError(t, err)
 
 		// then
 		// verify the metrics
-		metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 0)         // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 0) // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external") // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName) // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 0)         // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 0) // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external") // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName) // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
 
 	})
 }
@@ -387,7 +371,6 @@ func banUser(t *testing.T, hostAwait *wait.HostAwaitility, email string) *toolch
 			Email: email,
 		},
 	}
-	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
-	require.NoError(t, err)
+	hostAwait.CreateWithCleanup(t, bannedUser)
 	return bannedUser
 }

--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -12,11 +12,10 @@ func TestSetupMigration(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 
 	runner := migration.SetupMigrationRunner{
-		T:            t,
 		Awaitilities: awaitilities,
 		WithCleanup:  false,
 	}
 
-	runner.Run()
+	runner.Run(t)
 
 }

--- a/test/perf/perf_test.go
+++ b/test/perf/perf_test.go
@@ -51,20 +51,18 @@ func TestPerformance(t *testing.T) {
 			require.NoError(t, err)
 
 			// host metrics should become available again at this point
-			_, err = hostAwait.WaitForRouteToBeAvailable(hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
+			_, err = hostAwait.WaitForRouteToBeAvailable(t, hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
 			require.NoError(t, err, "failed while setting up or waiting for the route to the 'host-operator-metrics' service to be available")
 
 			start := time.Now()
 			// measure time it takes to have an empty queue on the master-user-records
-			err = hostAwait.WaitUntilMetricHasValueOrMore("controller_runtime_reconcile_total", float64(config.GetUserCount()), "controller", "usersignup", "result", "success")
+			err = hostAwait.WaitUntilMetricHasValueOrMore(t, "controller_runtime_reconcile_total", float64(config.GetUserCount()), "controller", "usersignup", "result", "success")
 			assert.NoError(t, err, "failed to reach the expected number of reconcile loops")
-			err = hostAwait.WaitUntilMetricHasValueOrLess("workqueue_depth", 0, "name", "usersignup")
+			err = hostAwait.WaitUntilMetricHasValueOrLess(t, "workqueue_depth", 0, "name", "usersignup")
 			assert.NoError(t, err, "failed to reach the expected queue depth")
 			end := time.Now()
-			hostOperatorPod, err := hostAwait.GetHostOperatorPod()
-			require.NoError(t, err)
-			hostOperatorPodMemory, err := hostAwait.GetMemoryUsage(hostOperatorPod.Name, hostAwait.Namespace)
-			require.NoError(t, err)
+			hostOperatorPod := hostAwait.GetHostOperatorPod(t)
+			hostOperatorPodMemory := hostAwait.GetMemoryUsage(t, hostOperatorPod.Name, hostAwait.Namespace)
 			logger.Info("done processing resources",
 				"host_operator_pod_restart_duration_ms", end.Sub(start).Milliseconds(),
 				"host_operator_pod_memory_usage_kb", hostOperatorPodMemory)
@@ -80,16 +78,13 @@ func TestPerformance(t *testing.T) {
 
 			start := time.Now()
 			// measure time it takes to have an empty queue on the master-user-records
-			err = memberAwait.WaitUntilMetricHasValueOrMore("controller_runtime_reconcile_total", float64(2*config.GetUserCount()), "controller", "useraccount", "result", "success")
+			err = memberAwait.WaitUntilMetricHasValueOrMore(t, "controller_runtime_reconcile_total", float64(2*config.GetUserCount()), "controller", "useraccount", "result", "success")
 			assert.NoError(t, err, "failed to reach the expected number of reconcile loops")
-			err = memberAwait.WaitUntilMetricHasValueOrLess("workqueue_depth", 0, "name", "useraccount")
+			err = memberAwait.WaitUntilMetricHasValueOrLess(t, "workqueue_depth", 0, "name", "useraccount")
 			assert.NoError(t, err, "failed to reach the expected queue depth")
 			end := time.Now()
-			memberOperatorPod, err := memberAwait.GetMemberOperatorPod()
-			require.NoError(t, err)
-			memberOperatorPodMemory, err := memberAwait.GetMemoryUsage(memberOperatorPod.Name, memberAwait.Namespace)
-			require.NoError(t, err)
-
+			memberOperatorPod := memberAwait.GetMemberOperatorPod(t)
+			memberOperatorPodMemory := memberAwait.GetMemoryUsage(t, memberOperatorPod.Name, memberAwait.Namespace)
 			logger.Info("done processing resources",
 				"member_operator_pod_restart_duration_ms", end.Sub(start).Milliseconds(),
 				"member_operator_pod_memory_usage_kb", memberOperatorPodMemory)
@@ -148,34 +143,26 @@ func createSignupsByBatch(t *testing.T, hostAwait *HostAwaitility, config Config
 			userSignup := NewUserSignup(hostAwait.Namespace, name, fmt.Sprintf("multiple-signup-testuser-%d@test.com", n))
 			states.SetApprovedManually(userSignup, true)
 			userSignup.Spec.TargetCluster = memberAwait.ClusterName
-			err := hostAwait.CreateWithCleanup(context.TODO(), userSignup)
-			hostAwait.T.Logf("created usersignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)
-			require.NoError(t, err)
+			hostAwait.CreateWithCleanup(t, userSignup)
+			t.Logf("created usersignup with username: '%s' and resource name: '%s'", userSignup.Spec.Username, userSignup.Name)
 			signups[i] = *userSignup
 		}
 
 		t.Logf("Waiting for all users to be processed")
-		err := hostAwait.WaitUntilMetricHasValueOrLess("workqueue_depth", 0, "name", "masteruserrecord")
+		err := hostAwait.WaitUntilMetricHasValueOrLess(t, "workqueue_depth", 0, "name", "masteruserrecord")
 		require.NoError(t, err)
 
 		for _, signup := range signups {
-			hostAwait.T.Logf("waiting for user %s ('%s') to be ready", signup.Name, signup.Spec.Username)
-			mur, err := hostAwait.WaitForMasterUserRecord(signup.Spec.Username, UntilMasterUserRecordHasCondition(Provisioned()))
-			require.NoError(t, err)
+			t.Logf("waiting for user %s ('%s') to be ready", signup.Name, signup.Spec.Username)
+			mur := hostAwait.WaitForMasterUserRecord(t, signup.Spec.Username, UntilMasterUserRecordHasCondition(Provisioned()))
 			// now, run a pod (with the `sleep 28800` command in each namespace)
-			userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
+			memberAwait.WaitForUserAccount(t, mur.Name,
 				UntilUserAccountHasConditions(Provisioned()))
-			require.NoError(t, err)
 
-			nsTemplateSet, err := memberAwait.WaitForNSTmplSet(signup.Status.CompliantUsername, UntilNSTemplateSetHasTier(mur.Spec.TierName))
-			if err != nil {
-				t.Logf("getting NSTemplateSet '%s' failed with: %s", signup.Status.CompliantUsername, err)
-			}
-			require.NoError(t, err, "Failing \nUserSignup: %+v \nUserAccount: %+v \nNSTemplateSet: %+v", signup, userAccount, nsTemplateSet)
+			nsTemplateSet := memberAwait.WaitForNSTmplSet(t, signup.Status.CompliantUsername, UntilNSTemplateSetHasTier(mur.Spec.TierName))
 
 			for _, templateRef := range nsTemplateSet.Spec.Namespaces {
-				ns, err := memberAwait.WaitForNamespace(mur.Name, templateRef.TemplateRef, nsTemplateSet.Spec.TierName, UntilNamespaceIsActive())
-				require.NoError(t, err)
+				ns := memberAwait.WaitForNamespace(t, mur.Name, templateRef.TemplateRef, nsTemplateSet.Spec.TierName, UntilNamespaceIsActive())
 				if ns.Labels["toolchain.dev.openshift.com/type"] != "stage" {
 					// skip pod creation if the namespace is not "stage", otherwise, we may run out of capacity of pods on the nodes
 					continue
@@ -213,15 +200,10 @@ func createSignupsByBatch(t *testing.T, hostAwait *HostAwaitility, config Config
 		t.Logf("sleeping for %ds...", int(config.GetUserBatchPause().Seconds()))
 		time.Sleep(config.GetUserBatchPause())
 
-		hostOperatorPod, err := hostAwait.GetHostOperatorPod()
-		require.NoError(t, err)
-		hostOperatorPodMemory, err := hostAwait.GetMemoryUsage(hostOperatorPod.Name, hostAwait.Namespace)
-		require.NoError(t, err)
-
-		memberOperatorPod, err := memberAwait.GetMemberOperatorPod()
-		require.NoError(t, err)
-		memberOperatorPodMemory, err := memberAwait.GetMemoryUsage(memberOperatorPod.Name, memberAwait.Namespace)
-		require.NoError(t, err)
+		hostOperatorPod := hostAwait.GetHostOperatorPod(t)
+		hostOperatorPodMemory := hostAwait.GetMemoryUsage(t, hostOperatorPod.Name, hostAwait.Namespace)
+		memberOperatorPod := memberAwait.GetMemberOperatorPod(t)
+		memberOperatorPodMemory := memberAwait.GetMemoryUsage(t, memberOperatorPod.Name, memberAwait.Namespace)
 
 		logger.Info("done provisioning resources",
 			"user_count", config.GetUserBatchSize(),

--- a/testsupport/banneduser.go
+++ b/testsupport/banneduser.go
@@ -1,14 +1,12 @@
 package testsupport
 
 import (
-	"context"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/gofrs/uuid"
-	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,8 +14,7 @@ import (
 // CreateBannedUser creates the BannedUser resource
 func CreateBannedUser(t *testing.T, hostAwait *wait.HostAwaitility, email string) *toolchainv1alpha1.BannedUser {
 	bannedUser := NewBannedUser(hostAwait, email)
-	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
-	require.NoError(t, err)
+	hostAwait.CreateWithCleanup(t, bannedUser)
 
 	t.Logf("BannedUser '%s' created", bannedUser.Spec.Email)
 	return bannedUser

--- a/testsupport/cleanup/clean.go
+++ b/testsupport/cleanup/clean.go
@@ -40,12 +40,11 @@ var cleaning = &cleanManager{
 
 type AwaitilityInt interface {
 	GetClient() client.Client
-	GetT() *testing.T
 }
 
 // AddCleanTasks adds cleaning tasks for the given objects that will be automatically performed at the end of the test execution
-func AddCleanTasks(a AwaitilityInt, objects ...client.Object) {
-	cleaning.addCleanTasks(a.GetT(), a.GetClient(), objects...)
+func AddCleanTasks(t *testing.T, a AwaitilityInt, objects ...client.Object) {
+	cleaning.addCleanTasks(t, a.GetClient(), objects...)
 }
 
 func (c *cleanManager) addCleanTasks(t *testing.T, cl client.Client, objects ...client.Object) {
@@ -60,12 +59,12 @@ func (c *cleanManager) addCleanTasks(t *testing.T, cl client.Client, objects ...
 }
 
 // ExecuteAllCleanTasks triggers cleanup of all resources that were marked to be cleaned before that
-func ExecuteAllCleanTasks(a AwaitilityInt) {
-	cleaning.clean(a.GetT())()
+func ExecuteAllCleanTasks(t *testing.T) {
+	cleaning.clean(t)()
 }
 
 func (c *cleanManager) clean(t *testing.T) func() {
-	return func() {
+	return func() { // TODO: why do we need to wrap into a func?
 		c.Lock()
 		defer c.Unlock()
 		var wg sync.WaitGroup

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -8,21 +8,19 @@ import (
 
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/stretchr/testify/require"
 )
 
 // MetricsAssertionHelper stores baseline metric values when initialized and has convenient functions for metrics assertions
 type MetricsAssertionHelper struct {
 	await          metricsProvider
 	baselineValues map[string]float64
-	t              *testing.T
 }
 
 type metricsProvider interface {
-	GetMetricValue(family string, labels ...string) float64
-	GetMetricValueOrZero(family string, labels ...string) float64
-	WaitForTestResourcesCleanup(initialDelay time.Duration) error
-	WaitUntiltMetricHasValue(family string, expectedValue float64, labels ...string)
+	GetMetricValue(t *testing.T, family string, labels ...string) float64
+	GetMetricValueOrZero(t *testing.T, family string, labels ...string) float64
+	WaitForTestResourcesCleanup(t *testing.T, initialDelay time.Duration)
+	WaitUntiltMetricHasValue(t *testing.T, family string, expectedValue float64, labels ...string)
 }
 
 // metric constants
@@ -45,66 +43,63 @@ const (
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
 func InitMetricsAssertion(t *testing.T, awaitilities wait.Awaitilities) *MetricsAssertionHelper {
 	// Wait for pending usersignup deletions before capturing baseline values so that test assertions are stable
-	err := awaitilities.Host().WaitForTestResourcesCleanup(10 * time.Second)
-	require.NoError(t, err)
+	awaitilities.Host().WaitForTestResourcesCleanup(t, 10*time.Second)
 	// wait for toolchainstatus metrics to be updated
-	_, err = awaitilities.Host().WaitForToolchainStatus(
+	awaitilities.Host().WaitForToolchainStatus(t,
 		wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 		wait.UntilToolchainStatusUpdatedAfter(time.Now()))
-	require.NoError(t, err)
 
 	// Capture baseline values
 	m := &MetricsAssertionHelper{
 		await:          awaitilities.Host(),
 		baselineValues: make(map[string]float64),
-		t:              t,
 	}
-	m.captureBaselineValues(awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
+	m.captureBaselineValues(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
 	t.Logf("captured baselines:\n%s", spew.Sdump(m.baselineValues))
 	return m
 }
 
-func (m *MetricsAssertionHelper) captureBaselineValues(memberClusterNames ...string) {
-	m.baselineValues[UserSignupsMetric] = m.await.GetMetricValue(UserSignupsMetric)
-	m.baselineValues[UserSignupsApprovedMetric] = m.await.GetMetricValue(UserSignupsApprovedMetric)
-	m.baselineValues[UserSignupsDeactivatedMetric] = m.await.GetMetricValue(UserSignupsDeactivatedMetric)
-	m.baselineValues[UserSignupsAutoDeactivatedMetric] = m.await.GetMetricValue(UserSignupsAutoDeactivatedMetric)
-	m.baselineValues[UserSignupsBannedMetric] = m.await.GetMetricValue(UserSignupsBannedMetric)
+func (m *MetricsAssertionHelper) captureBaselineValues(t *testing.T, memberClusterNames ...string) {
+	m.baselineValues[UserSignupsMetric] = m.await.GetMetricValue(t, UserSignupsMetric)
+	m.baselineValues[UserSignupsApprovedMetric] = m.await.GetMetricValue(t, UserSignupsApprovedMetric)
+	m.baselineValues[UserSignupsDeactivatedMetric] = m.await.GetMetricValue(t, UserSignupsDeactivatedMetric)
+	m.baselineValues[UserSignupsAutoDeactivatedMetric] = m.await.GetMetricValue(t, UserSignupsAutoDeactivatedMetric)
+	m.baselineValues[UserSignupsBannedMetric] = m.await.GetMetricValue(t, UserSignupsBannedMetric)
 	for _, name := range memberClusterNames { // sum of gauge value of all member clusters
-		userAccountKey := m.baselineKey(UserAccountsMetric, "cluster_name", name)
-		m.baselineValues[userAccountKey] += m.await.GetMetricValue(UserAccountsMetric, "cluster_name", name)
+		userAccountKey := m.baselineKey(t, UserAccountsMetric, "cluster_name", name)
+		m.baselineValues[userAccountKey] += m.await.GetMetricValue(t, UserAccountsMetric, "cluster_name", name)
 
-		spacesKey := m.baselineKey(SpacesMetric, "cluster_name", name)
-		m.baselineValues[spacesKey] += m.await.GetMetricValue(SpacesMetric, "cluster_name", name)
+		spacesKey := m.baselineKey(t, SpacesMetric, "cluster_name", name)
+		m.baselineValues[spacesKey] += m.await.GetMetricValue(t, SpacesMetric, "cluster_name", name)
 	}
 	// capture `sandbox_users_per_activations_and_domain` with "activations" from `1` to `10` and `internal`/`external` domains
 	for i := 1; i <= 10; i++ {
 		for _, domain := range []string{"internal", "external"} {
-			key := m.baselineKey(UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
-			m.baselineValues[key] = m.await.GetMetricValueOrZero(UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
+			key := m.baselineKey(t, UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
+			m.baselineValues[key] = m.await.GetMetricValueOrZero(t, UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
 		}
 	}
 	for _, domain := range []string{"internal", "external"} {
-		key := m.baselineKey(MasterUserRecordsPerDomainMetric, "domain", domain)
-		m.baselineValues[key] = m.await.GetMetricValueOrZero(MasterUserRecordsPerDomainMetric, "domain", domain)
+		key := m.baselineKey(t, MasterUserRecordsPerDomainMetric, "domain", domain)
+		m.baselineValues[key] = m.await.GetMetricValueOrZero(t, MasterUserRecordsPerDomainMetric, "domain", domain)
 	}
 }
 
 // WaitForMetricDelta waits for the metric value to reach the adjusted value. The adjusted value is the delta value combined with the baseline value.
-func (m *MetricsAssertionHelper) WaitForMetricDelta(family string, delta float64, labels ...string) {
+func (m *MetricsAssertionHelper) WaitForMetricDelta(t *testing.T, family string, delta float64, labels ...string) {
 	// The delta is relative to the starting value, eg. If there are 3 usersignups when a test is started and we are waiting
 	// for 2 more usersignups to be created (delta is +2) then the actual metric value (adjustedValue) we're waiting for is 5
-	key := m.baselineKey(string(family), labels...)
+	key := m.baselineKey(t, string(family), labels...)
 	adjustedValue := m.baselineValues[key] + delta
-	m.await.WaitUntiltMetricHasValue(string(family), adjustedValue, labels...)
+	m.await.WaitUntiltMetricHasValue(t, string(family), adjustedValue, labels...)
 }
 
 // generates a key to retain the baseline metric value, by joining the metric name and its labels.
 // Note: there are probably more sophisticated ways to combine the name and the labels, but for now
 // this simple concatenation should be enough to make the keys unique
-func (m *MetricsAssertionHelper) baselineKey(name string, labelAndValues ...string) string {
+func (m *MetricsAssertionHelper) baselineKey(t *testing.T, name string, labelAndValues ...string) string {
 	if len(labelAndValues)%2 != 0 {
-		m.t.Fatal("`labelAndValues` must be pairs of labels and values")
+		t.Fatal("`labelAndValues` must be pairs of labels and values")
 	}
 	return strings.Join(append([]string{name}, labelAndValues...), ",")
 }

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -10,13 +10,13 @@ import (
 // VerifyHostMetricsService verifies that there is a service called `host-operator-metrics-service`
 // in the host namespace.
 func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
-	_, err := hostAwait.WaitForMetricsService("host-operator-metrics-service")
+	_, err := hostAwait.WaitForMetricsService(t, "host-operator-metrics-service")
 	require.NoError(t, err, "failed while waiting for 'host-operator-metrics-service' service")
 }
 
 // VerifyMemberMetricsService verifies that there is a service called `member-operator-metrics-service`
 // in the member namespace.
 func VerifyMemberMetricsService(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	_, err := memberAwait.WaitForMetricsService("member-operator-metrics-service")
+	_, err := memberAwait.WaitForMetricsService(t, "member-operator-metrics-service")
 	require.NoError(t, err, "failed while waiting for 'member-operator-metrics-service' service")
 }

--- a/testsupport/spacebinding.go
+++ b/testsupport/spacebinding.go
@@ -13,20 +13,17 @@ import (
 
 // VerifySpaceBinding waits until a spacebinding with the given mur and space name exists and then verifies the contents are correct
 func VerifySpaceBinding(t *testing.T, hostAwait *wait.HostAwaitility, murName, spaceName, spaceRole string) *toolchainv1alpha1.SpaceBinding {
-	spaceBinding, err := hostAwait.WaitForSpaceBinding(murName, spaceName,
+	return hostAwait.WaitForSpaceBinding(t, murName, spaceName,
 		wait.UntilSpaceBindingHasMurName(murName),
 		wait.UntilSpaceBindingHasSpaceName(spaceName),
 		wait.UntilSpaceBindingHasSpaceRole(spaceRole),
 	)
-	require.NoError(t, err)
-	return spaceBinding
 }
 
 // CreateSpaceBinding creates SpaceBinding resource for the given MUR & Space with the given space role
 func CreateSpaceBinding(t *testing.T, hostAwait *wait.HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, spaceRole string) *toolchainv1alpha1.SpaceBinding {
 	spaceBinding := NewSpaceBinding(mur, space, spaceRole)
-	err := hostAwait.CreateWithCleanup(context.TODO(), spaceBinding)
-	require.NoError(t, err)
+	hostAwait.CreateWithCleanup(t, spaceBinding)
 	return spaceBinding
 }
 

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -18,6 +18,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1057,10 +1058,14 @@ func count(resource corev1.ResourceName) corev1.ResourceName {
 func numberOfToolchainRoles(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		roles := &rbacv1.RoleList{}
-		memberAwait.WaitForExpectedNumberOfResources(t, "Roles", number, func() (int, error) {
+		memberAwait.WaitForExpectedNumberOfResources(t, "Roles", number, func(t *testing.T) []runtime.Object {
 			err := memberAwait.Client.List(context.TODO(), roles, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
-			return len(roles.Items), err
+			objs := make([]runtime.Object, len(roles.Items))
+			for i := range roles.Items {
+				objs[i] = &roles.Items[i]
+			}
+			return objs
 		})
 	}
 }
@@ -1068,43 +1073,59 @@ func numberOfToolchainRoles(number int) spaceRoleObjectsCheck {
 func numberOfToolchainRoleBindings(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		roleBindings := &rbacv1.RoleBindingList{}
-		memberAwait.WaitForExpectedNumberOfResources(t, "RoleBindings", number, func() (int, error) {
+		memberAwait.WaitForExpectedNumberOfResources(t, "RoleBindings", number, func(t *testing.T) []runtime.Object {
 			err := memberAwait.Client.List(context.TODO(), roleBindings, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
-			return len(roleBindings.Items), err
+			objs := make([]runtime.Object, len(roleBindings.Items))
+			for i := range roleBindings.Items {
+				objs[i] = &roleBindings.Items[i]
+			}
+			return objs
 		})
 	}
 }
 
 func numberOfToolchainServiceAccounts(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		memberAwait.WaitForExpectedNumberOfResources(t, "ServiceAccounts", number, func() (int, error) {
+		memberAwait.WaitForExpectedNumberOfResources(t, "ServiceAccounts", number, func(t *testing.T) []runtime.Object {
 			serviceAccounts := &corev1.ServiceAccountList{}
 			err := memberAwait.Client.List(context.TODO(), serviceAccounts, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
-			return len(serviceAccounts.Items), err
+			objs := make([]runtime.Object, len(serviceAccounts.Items))
+			for i := range serviceAccounts.Items {
+				objs[i] = &serviceAccounts.Items[i]
+			}
+			return objs
 		})
 	}
 }
 
 func numberOfLimitRanges(number int) namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		memberAwait.WaitForExpectedNumberOfResources(t, "LimitRanges", number, func() (int, error) {
+		memberAwait.WaitForExpectedNumberOfResources(t, "LimitRanges", number, func(t *testing.T) []runtime.Object {
 			limitRanges := &corev1.LimitRangeList{}
 			err := memberAwait.Client.List(context.TODO(), limitRanges, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
-			return len(limitRanges.Items), err
+			objs := make([]runtime.Object, len(limitRanges.Items))
+			for i := range limitRanges.Items {
+				objs[i] = &limitRanges.Items[i]
+			}
+			return objs
 		})
 	}
 }
 
 func numberOfNetworkPolicies(number int) namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		memberAwait.WaitForExpectedNumberOfResources(t, "NetworkPolicies", number, func() (int, error) {
+		memberAwait.WaitForExpectedNumberOfResources(t, "NetworkPolicies", number, func(t *testing.T) []runtime.Object {
 			nps := &netv1.NetworkPolicyList{}
 			err := memberAwait.Client.List(context.TODO(), nps, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
-			return len(nps.Items), err
+			objs := make([]runtime.Object, len(nps.Items))
+			for i := range nps.Items {
+				objs[i] = &nps.Items[i]
+			}
+			return objs
 		})
 	}
 }
@@ -1112,7 +1133,7 @@ func numberOfNetworkPolicies(number int) namespaceObjectsCheck {
 func numberOfClusterResourceQuotas(number int) clusterObjectsCheckCreator {
 	return func() clusterObjectsCheck {
 		return func(t *testing.T, memberAwait *wait.MemberAwaitility, userName, tierLabel string) {
-			memberAwait.WaitForExpectedNumberOfClusterResources(t, "ClusterResourceQuotas", number, func() (int, error) {
+			memberAwait.WaitForExpectedNumberOfClusterResources(t, "ClusterResourceQuotas", number, func(t *testing.T) []runtime.Object {
 				quotas := &quotav1.ClusterResourceQuotaList{}
 				matchingLabels := client.MatchingLabels(map[string]string{ // make sure we only list the ClusterResourceQuota resources associated with the given "userName"
 					"toolchain.dev.openshift.com/provider": "codeready-toolchain",
@@ -1120,7 +1141,11 @@ func numberOfClusterResourceQuotas(number int) clusterObjectsCheckCreator {
 				})
 				err := memberAwait.Client.List(context.TODO(), quotas, matchingLabels)
 				require.NoError(t, err)
-				return len(quotas.Items), err
+				objs := make([]runtime.Object, len(quotas.Items))
+				for i := range quotas.Items {
+					objs[i] = &quotas.Items[i]
+				}
+				return objs
 			})
 		}
 	}

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -1,9 +1,10 @@
 package tiers
 
 import (
+	"testing"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	"github.com/stretchr/testify/require"
 )
 
 // TemplateRefs the templateRefs in a given NSTemplateTier or NSTemplateSet
@@ -14,9 +15,8 @@ type TemplateRefs struct {
 }
 
 // GetTemplateRefs returns the expected templateRefs for all the namespace templates and the optional cluster resources template for the given tier
-func GetTemplateRefs(hostAwait *wait.HostAwaitility, tierName string) TemplateRefs { // nolint:unparam // false positive on unused return param `0`??
-	templateTier, err := hostAwait.WaitForNSTemplateTier(tierName, wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
-	require.NoError(hostAwait.T, err)
+func GetTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility, tierName string) TemplateRefs { // nolint:unparam // false positive on unused return param `0`??
+	templateTier := hostAwait.WaitForNSTemplateTier(t, tierName, wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
 	nsRefs := make([]string, 0, len(templateTier.Spec.Namespaces))
 	for _, ns := range templateTier.Spec.Namespaces {
 		nsRefs = append(nsRefs, ns.TemplateRef)

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -8,7 +8,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint:revive
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,11 +29,11 @@ type CustomNSTemplateTier struct {
 
 type CustomNSTemplateTierModifier func(*HostAwaitility, *CustomNSTemplateTier) error
 
-func WithClusterResources(otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
+func WithClusterResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
 	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.ClusterResourcesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
-		tmplRef, err := duplicateTierTemplate(hostAwait, otherTier.Namespace, tier.Name, otherTier.Spec.ClusterResources.TemplateRef)
+		tmplRef, err := duplicateTierTemplate(t, hostAwait, otherTier.Namespace, tier.Name, otherTier.Spec.ClusterResources.TemplateRef)
 		if err != nil {
 			return err
 		}
@@ -45,13 +44,13 @@ func WithClusterResources(otherTier *toolchainv1alpha1.NSTemplateTier) CustomNST
 	}
 }
 
-func WithNamespaceResources(otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
+func WithNamespaceResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
 	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.NamespaceResourcesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
 		tier.Spec.Namespaces = make([]toolchainv1alpha1.NSTemplateTierNamespace, len(otherTier.Spec.Namespaces))
 		for i, def := range otherTier.Spec.Namespaces {
-			tmplRef, err := duplicateTierTemplate(hostAwait, otherTier.Namespace, tier.Name, def.TemplateRef)
+			tmplRef, err := duplicateTierTemplate(t, hostAwait, otherTier.Namespace, tier.Name, def.TemplateRef)
 			if err != nil {
 				return err
 			}
@@ -61,13 +60,13 @@ func WithNamespaceResources(otherTier *toolchainv1alpha1.NSTemplateTier) CustomN
 	}
 }
 
-func WithSpaceRoles(otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
+func WithSpaceRoles(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
 	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.SpaceRolesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
 		tier.Spec.SpaceRoles = make(map[string]toolchainv1alpha1.NSTemplateTierSpaceRole, len(otherTier.Spec.SpaceRoles))
 		for name, def := range otherTier.Spec.SpaceRoles {
-			tmplRef, err := duplicateTierTemplate(hostAwait, otherTier.Namespace, tier.Name, def.TemplateRef)
+			tmplRef, err := duplicateTierTemplate(t, hostAwait, otherTier.Namespace, tier.Name, def.TemplateRef)
 			if err != nil {
 				return err
 			}
@@ -94,9 +93,9 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, name st
 	}
 	// add default values before custom values...
 	modifiers = append([]CustomNSTemplateTierModifier{
-		WithClusterResources(baseTier),
-		WithNamespaceResources(baseTier),
-		WithSpaceRoles(baseTier),
+		WithClusterResources(t, baseTier),
+		WithNamespaceResources(t, baseTier),
+		WithSpaceRoles(t, baseTier),
 	}, modifiers...)
 
 	// ... and apply
@@ -104,8 +103,7 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, name st
 		err := modify(hostAwait, tier)
 		require.NoError(t, err)
 	}
-	err := hostAwait.CreateWithCleanup(context.TODO(), tier.NSTemplateTier)
-	require.NoError(t, err)
+	hostAwait.CreateWithCleanup(t, tier.NSTemplateTier)
 	return tier
 }
 
@@ -113,20 +111,19 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, name st
 // returns the latest version of the NSTemplateTier
 func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *CustomNSTemplateTier, modifiers ...CustomNSTemplateTierModifier) *CustomNSTemplateTier {
 	// reload the underlying NSTemplateTier resource before modifying it
-	tmplTier, err := hostAwait.WaitForNSTemplateTier(tier.Name)
-	require.NoError(t, err)
+	tmplTier := hostAwait.WaitForNSTemplateTier(t, tier.Name)
 	tier.NSTemplateTier = tmplTier
 	// make sure we have the very latest version of the given tier (to avoid the update conflict on the server-side)
 	for _, modify := range modifiers {
 		err := modify(hostAwait, tier)
 		require.NoError(t, err)
 	}
-	err = hostAwait.Client.Update(context.TODO(), tier.NSTemplateTier)
+	err := hostAwait.Client.Update(context.TODO(), tier.NSTemplateTier)
 	require.NoError(t, err)
 	return tier
 }
 
-func duplicateTierTemplate(hostAwait *HostAwaitility, namespace, tierName, origTemplateRef string) (string, error) {
+func duplicateTierTemplate(t *testing.T, hostAwait *HostAwaitility, namespace, tierName, origTemplateRef string) (string, error) {
 	origTierTemplate := &toolchainv1alpha1.TierTemplate{}
 	if err := hostAwait.Client.Get(context.TODO(), test.NamespacedName(hostAwait.Namespace, origTemplateRef), origTierTemplate); err != nil {
 		return "", err
@@ -140,32 +137,26 @@ func duplicateTierTemplate(hostAwait *HostAwaitility, namespace, tierName, origT
 		Spec: origTierTemplate.Spec,
 	}
 	newTierTemplate.Spec.TierName = tierName
-	if err := hostAwait.CreateWithCleanup(context.TODO(), newTierTemplate); err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return "", err
-		}
-	}
+	hostAwait.CreateWithCleanup(t, newTierTemplate)
 	return newTierTemplate.Name, nil
 }
 
 func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierName string) {
 	t.Logf("moving space '%s' to space tier '%s'", spacename, tierName)
-	_, err := hostAwait.WaitForSpace(spacename)
-	require.NoError(t, err)
+	hostAwait.WaitForSpace(t, spacename)
 
-	_, err = hostAwait.UpdateSpace(spacename, func(s *toolchainv1alpha1.Space) {
-		s.Spec.TierName = tierName
-	})
-	require.NoError(t, err)
+	hostAwait.UpdateSpace(t, spacename,
+		func(s *toolchainv1alpha1.Space) {
+			s.Spec.TierName = tierName
+		})
 }
 
 func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {
 	t.Logf("moving masteruserrecord '%s' to user tier '%s'", username, tierName)
-	mur, err := hostAwait.WaitForMasterUserRecord(username)
-	require.NoError(t, err)
+	mur := hostAwait.WaitForMasterUserRecord(t, username)
 
-	_, err = hostAwait.UpdateMasterUserRecord(false, mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
-		mur.Spec.TierName = tierName
-	})
-	require.NoError(t, err)
+	hostAwait.UpdateMasterUserRecord(t, false, mur.Name,
+		func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Spec.TierName = tierName
+		})
 }

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -13,22 +13,20 @@ import (
 )
 
 func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility, expectedURL string) {
-	err := memberAwait.WaitForMemberStatus(
+	memberAwait.WaitForMemberStatus(t,
 		wait.UntilMemberStatusHasConditions(ToolchainStatusReady()),
 		wait.UntilMemberStatusHasUsageSet(),
 		wait.UntilMemberStatusHasConsoleURLSet(expectedURL, RoutesAvailable()))
-	require.NoError(t, err, "failed while waiting for MemberStatus")
 }
 
 func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility) {
-	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
-	require.NoError(t, err)
+	memberCluster, found := hostAwait.GetToolchainCluster(t, cluster.Member, memberAwait.Namespace, nil)
 	require.True(t, found)
-	_, err = hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
+	hostAwait.WaitForToolchainStatus(t,
+		wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 		wait.UntilAllMembersHaveUsageSet(),
 		wait.UntilAllMembersHaveAPIEndpoint(memberCluster.Spec.APIEndpoint),
 		wait.UntilProxyURLIsPresent(hostAwait.APIProxyURL))
-	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }
 
 func VerifyIncreaseOfUserAccountCount(t *testing.T, previous, current *toolchainv1alpha1.ToolchainStatus, memberClusterName string, increase int) {

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,25 +25,4 @@ func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility, memberA
 		wait.UntilAllMembersHaveUsageSet(),
 		wait.UntilAllMembersHaveAPIEndpoint(memberCluster.Spec.APIEndpoint),
 		wait.UntilProxyURLIsPresent(hostAwait.APIProxyURL))
-}
-
-func VerifyIncreaseOfUserAccountCount(t *testing.T, previous, current *toolchainv1alpha1.ToolchainStatus, memberClusterName string, increase int) {
-	found := false
-CurrentMembers:
-	for _, currentMemberStatus := range current.Status.Members {
-		for _, previousMemberStatus := range previous.Status.Members {
-			if previousMemberStatus.ClusterName == currentMemberStatus.ClusterName {
-				if currentMemberStatus.ClusterName == memberClusterName {
-					assert.Equal(t, previousMemberStatus.UserAccountCount+increase, currentMemberStatus.UserAccountCount)
-					found = true
-				}
-				continue CurrentMembers
-			}
-		}
-		if currentMemberStatus.ClusterName == memberClusterName {
-			assert.Equal(t, increase, currentMemberStatus.UserAccountCount)
-			found = true
-		}
-	}
-	assert.True(t, found, "There is a missing UserAccount count for member cluster '%s'", memberClusterName)
 }

--- a/testsupport/toolchainconfig_assertions.go
+++ b/testsupport/toolchainconfig_assertions.go
@@ -4,16 +4,12 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
-	"github.com/stretchr/testify/require"
 )
 
 func VerifyToolchainConfig(t *testing.T, hostAwait *wait.HostAwaitility, criteria ...wait.ToolchainConfigWaitCriterion) {
-	_, err := hostAwait.WaitForToolchainConfig(criteria...)
-	require.NoError(t, err, "failed while waiting for ToolchainConfig to meet the required criteria")
+	hostAwait.WaitForToolchainConfig(t, criteria...)
 }
 
 func VerifyMemberOperatorConfig(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, criteria ...wait.MemberOperatorConfigWaitCriterion) {
-	_, err := memberAwait.WaitForMemberOperatorConfig(hostAwait, criteria...)
-	require.NoError(t, err, "failed while waiting for MemberOperatorConfig to meet the required criteria")
+	memberAwait.WaitForMemberOperatorConfig(t, hostAwait, criteria...)
 }

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -15,7 +15,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,37 +33,33 @@ func VerifyResourcesProvisionedForSignupWithoutSpace(t *testing.T, awaitilities 
 	VerifyUserRelatedResources(t, awaitilities, signup, userTierName)
 
 	// verify space does not exist
-	space, err := awaitilities.Host().WithRetryOptions(wait.TimeoutOption(3 * time.Second)).WaitForSpace(signup.Status.CompliantUsername)
-	require.Error(t, err)
+	space := awaitilities.Host().WithRetryOptions(wait.TimeoutOption(3*time.Second)).WaitForSpace(t, signup.Status.CompliantUsername)
 	require.Nil(t, space)
 }
 
-func VerifyUserRelatedResources(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup, tierName string) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.MasterUserRecord) {
+func VerifyUserRelatedResources(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup, tierName string) {
 
 	hostAwait := awaitilities.Host()
 	// Get the latest signup version, wait for usersignup to have the approved label and wait for the complete status to
 	// ensure the compliantusername is available
-	userSignup, err := hostAwait.WaitForUserSignup(signup.Name,
+	userSignup := hostAwait.WaitForUserSignup(t, signup.Name,
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved),
 		wait.ContainsCondition(Complete()))
-	require.NoError(t, err)
 
 	// First, wait for the MasterUserRecord to exist, no matter what status
-	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername,
+	mur := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasTierName(tierName),
 		wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
-	require.NoError(t, err)
 
 	memberAwait := GetMurTargetMember(t, awaitilities, mur)
 
 	// Then wait for the associated UserAccount to be provisioned
-	userAccount, err := memberAwait.WaitForUserAccount(mur.Name,
+	userAccount := memberAwait.WaitForUserAccount(t, mur.Name,
 		wait.UntilUserAccountHasConditions(Provisioned()),
 		wait.UntilUserAccountHasSpec(ExpectedUserAccount(userSignup.Spec.Userid, userSignup.Spec.OriginalSub)),
 		wait.UntilUserAccountHasLabelWithValue(toolchainv1alpha1.TierLabelKey, mur.Spec.TierName),
 		wait.UntilUserAccountHasAnnotation(toolchainv1alpha1.UserEmailAnnotationKey, signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]),
-		wait.UntilUserAccountMatchesMur(hostAwait))
-	require.NoError(t, err)
+		wait.UntilUserAccountMatchesMur(t, hostAwait))
 	require.NotNil(t, userAccount)
 
 	// Verify last target cluster annotation is set
@@ -78,49 +73,42 @@ func VerifyUserRelatedResources(t *testing.T, awaitilities wait.Awaitilities, si
 		originalSubIdentityName = identitypkg.NewIdentityNamingStandard(userAccount.Spec.OriginalSub, "rhd").IdentityName()
 	}
 
-	memberConfiguration := memberAwait.GetMemberOperatorConfig()
+	memberConfiguration := memberAwait.GetMemberOperatorConfig(t)
 
 	// Verify User and Identity if SkipUserCreation is not set or it is set to false
 	if memberConfiguration.Spec.SkipUserCreation == nil || !*memberConfiguration.Spec.SkipUserCreation {
 		// Verify provisioned User
-		_, err = memberAwait.WaitForUser(userAccount.Name,
+		memberAwait.WaitForUser(t, userAccount.Name,
 			wait.UntilUserHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 			wait.UntilUserHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name),
 			wait.UntilUserHasAnnotation(toolchainv1alpha1.UserEmailAnnotationKey, signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]))
-		assert.NoError(t, err, fmt.Sprintf("no user with name '%s' found", userAccount.Name))
 
 		// Verify provisioned Identity
 		identityName := identitypkg.NewIdentityNamingStandard(userAccount.Spec.UserID, "rhd").IdentityName()
 
-		_, err = memberAwait.WaitForIdentity(identityName,
+		memberAwait.WaitForIdentity(t, identityName,
 			wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 			wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
-		assert.NoError(t, err, fmt.Sprintf("no identity with name '%s' found", identityName))
 
 		// Verify the second identity
 		if originalSubIdentityName != "" {
-			_, err = memberAwait.WaitForIdentity(identityName,
+			memberAwait.WaitForIdentity(t, identityName,
 				wait.UntilIdentityHasLabel(toolchainv1alpha1.ProviderLabelKey, toolchainv1alpha1.ProviderLabelValue),
 				wait.UntilIdentityHasLabel(toolchainv1alpha1.OwnerLabelKey, userAccount.Name))
-			assert.NoError(t, err, fmt.Sprintf("no encoded identity with name '%s' found", identityName))
 		}
 	} else {
 		// we don't expect User nor Identity resources to be present for AppStudio tier
 		// This can be removed as soon as we don't create UserAccounts in AppStudio environment.
-		err := memberAwait.WaitUntilUserDeleted(userAccount.Name)
-		assert.NoError(t, err)
-		err = memberAwait.WaitUntilIdentityDeleted(identitypkg.NewIdentityNamingStandard(userAccount.Spec.UserID, "rhd").IdentityName())
-		assert.NoError(t, err)
+		memberAwait.WaitUntilUserDeleted(t, userAccount.Name)
+		memberAwait.WaitUntilIdentityDeleted(t, identitypkg.NewIdentityNamingStandard(userAccount.Spec.UserID, "rhd").IdentityName())
 		// Verify the second identity
 		if originalSubIdentityName != "" {
-			err = memberAwait.WaitUntilIdentityDeleted(originalSubIdentityName)
-			assert.NoError(t, err)
+			memberAwait.WaitUntilIdentityDeleted(t, originalSubIdentityName)
 		}
 	}
 
 	// Get member cluster to verify that it was used to provision user accounts
-	memberCluster, ok, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
-	require.NoError(t, err)
+	memberCluster, ok := hostAwait.GetToolchainCluster(t, cluster.Member, memberAwait.Namespace, nil)
 	require.True(t, ok)
 
 	// Then finally check again the MasterUserRecord with the expected (embedded) UserAccount status, on top of the other criteria
@@ -128,52 +116,45 @@ func VerifyUserRelatedResources(t *testing.T, awaitilities wait.Awaitilities, si
 		Cluster: toolchainv1alpha1.Cluster{
 			Name:        mur.Spec.UserAccounts[0].TargetCluster,
 			APIEndpoint: memberCluster.Spec.APIEndpoint,
-			ConsoleURL:  memberAwait.GetConsoleURL(),
+			ConsoleURL:  memberAwait.GetConsoleURL(t),
 		},
 		UserAccountStatus: userAccount.Status,
 	}
-	mur, err = hostAwait.WaitForMasterUserRecord(mur.Name,
+	hostAwait.WaitForMasterUserRecord(t, mur.Name,
 		wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()),
 		wait.UntilMasterUserRecordHasUserAccountStatuses(expectedEmbeddedUaStatus))
-	assert.NoError(t, err)
 
-	return userSignup, mur
 }
 
 func VerifySpaceRelatedResources(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup, spaceTierName string) {
 
 	hostAwait := awaitilities.Host()
 
-	userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+	userSignup = hostAwait.WaitForUserSignup(t, userSignup.Name,
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved),
 		wait.ContainsCondition(Complete()))
-	require.NoError(t, err)
 
-	mur, err := hostAwait.WaitForMasterUserRecord(userSignup.Status.CompliantUsername,
+	mur := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasConditions(Provisioned(), ProvisionedNotificationCRCreated()))
-	require.NoError(t, err)
 
-	tier, err := hostAwait.WaitForNSTemplateTier(spaceTierName)
-	require.NoError(t, err)
+	tier := hostAwait.WaitForNSTemplateTier(t, spaceTierName)
 	hash, err := testtier.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
 	require.NoError(t, err)
 
-	space, err := hostAwait.WaitForSpace(mur.Name,
+	space := hostAwait.WaitForSpace(t, mur.Name,
 		wait.UntilSpaceHasTier(spaceTierName),
 		wait.UntilSpaceHasLabelWithValue(toolchainv1alpha1.SpaceCreatorLabelKey, userSignup.Name),
 		wait.UntilSpaceHasLabelWithValue(fmt.Sprintf("toolchain.dev.openshift.com/%s-tier-hash", spaceTierName), hash),
 		wait.UntilSpaceHasConditions(Provisioned()),
 		wait.UntilSpaceHasStateLabel(toolchainv1alpha1.SpaceStateLabelValueClusterAssigned),
 		wait.UntilSpaceHasStatusTargetCluster(mur.Spec.UserAccounts[0].TargetCluster))
-	require.NoError(t, err)
 
 	VerifySpaceBinding(t, hostAwait, mur.Name, space.Name, "admin")
 
-	bindings, err := hostAwait.ListSpaceBindings(space.Name)
-	require.NoError(t, err)
+	bindings := hostAwait.ListSpaceBindings(t, space.Name)
 	memberAwait := GetMurTargetMember(t, awaitilities, mur)
 	// Verify provisioned NSTemplateSet
-	nsTemplateSet, err := memberAwait.WaitForNSTmplSet(space.Name,
+	nsTemplateSet := memberAwait.WaitForNSTmplSet(t, space.Name,
 		wait.UntilNSTemplateSetHasTier(tier.Name),
 		wait.UntilNSTemplateSetHasSpaceRolesFromBindings(tier, bindings),
 	)
@@ -205,7 +186,7 @@ func GetMurTargetMember(t *testing.T, awaitilities wait.Awaitilities, mur *toolc
 }
 
 func DeletedRoleAndAwaitRecreation(t *testing.T, memberAwait *wait.MemberAwaitility, ns corev1.Namespace, role string) {
-	userRole, err := memberAwait.WaitForRole(&ns, role)
+	userRole, err := memberAwait.WaitForRole(t, &ns, role)
 	require.NoError(t, err)
 	require.NotEmpty(t, userRole)
 	require.Contains(t, userRole.Labels, "toolchain.dev.openshift.com/owner")
@@ -215,23 +196,21 @@ func DeletedRoleAndAwaitRecreation(t *testing.T, memberAwait *wait.MemberAwaitil
 	require.NoError(t, err)
 
 	// then verify role is recreated
-	userRole, err = memberAwait.WaitForRole(&ns, role)
+	userRole, err = memberAwait.WaitForRole(t, &ns, role)
 	require.NoError(t, err)
 	require.NotEmpty(t, userRole)
 }
 
 func DeleteRoleBindingAndAwaitRecreation(t *testing.T, memberAwait *wait.MemberAwaitility, ns corev1.Namespace, rolebinding string) {
-	userRoleBinding, err := memberAwait.WaitForRoleBinding(&ns, rolebinding)
-	require.NoError(t, err)
+	userRoleBinding := memberAwait.WaitForRoleBinding(t, &ns, rolebinding)
 	require.NotEmpty(t, userRoleBinding)
 	require.Contains(t, userRoleBinding.Labels, "toolchain.dev.openshift.com/owner")
 
 	//when rolebinding deleted
-	err = memberAwait.Client.Delete(context.TODO(), userRoleBinding)
+	err := memberAwait.Client.Delete(context.TODO(), userRoleBinding)
 	require.NoError(t, err)
 
 	// then verify role is recreated
-	userRoleBinding, err = memberAwait.WaitForRoleBinding(&ns, rolebinding)
-	require.NoError(t, err)
+	userRoleBinding = memberAwait.WaitForRoleBinding(t, &ns, rolebinding)
 	require.NotEmpty(t, userRoleBinding)
 }

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -31,12 +31,12 @@ func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			continue
 		}
 		// Create an approved UserSignup resource
-		signups[i], _ = NewSignupRequest(t, awaitilities).
+		signups[i], _ = NewSignupRequest(awaitilities).
 			Username(name).
 			Email(fmt.Sprintf("multiple-signup-testuser-%d@test.com", i)).
 			ManuallyApprove().
-			TargetCluster(targetCluster).
-			Execute().
+			TargetCluster(targetCluster.ClusterName).
+			Execute(t).
 			Resources()
 	}
 	return signups

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -45,7 +45,6 @@ const (
 )
 
 type Awaitility struct {
-	T             *testing.T
 	Client        client.Client
 	RestConfig    *rest.Config
 	ClusterName   string
@@ -58,16 +57,6 @@ type Awaitility struct {
 
 func (a *Awaitility) GetClient() client.Client {
 	return a.Client
-}
-
-func (a *Awaitility) GetT() *testing.T {
-	return a.T
-}
-
-func (a *Awaitility) ForTest(t *testing.T) *Awaitility {
-	await := a.copy()
-	await.T = t
-	return await
 }
 
 func (a *Awaitility) copy() *Awaitility {
@@ -115,8 +104,8 @@ func (o TimeoutOption) apply(a *Awaitility) {
 }
 
 // WaitForMetricsService waits until there's a service with the given name in the current namespace
-func (a *Awaitility) WaitForMetricsService(name string) (corev1.Service, error) {
-	a.T.Logf("waiting for Service '%s' in namespace '%s'", name, a.Namespace)
+func (a *Awaitility) WaitForMetricsService(t *testing.T, name string) (corev1.Service, error) {
+	t.Logf("waiting for Service '%s' in namespace '%s'", name, a.Namespace)
 	var metricsSvc *corev1.Service
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		metricsSvc = &corev1.Service{}
@@ -141,8 +130,8 @@ func (a *Awaitility) WaitForMetricsService(name string) (corev1.Service, error) 
 // WaitForToolchainClusterWithCondition waits until there is a ToolchainCluster representing a operator of the given type
 // and running in the given expected namespace. If the given condition is not nil, then it also checks
 // if the CR has the ClusterCondition
-func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
-	a.T.Logf("waiting for ToolchainCluster for cluster type '%s' in namespace '%s'", clusterType, namespace)
+func (a *Awaitility) WaitForToolchainClusterWithCondition(t *testing.T, clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
+	t.Logf("waiting for ToolchainCluster for cluster type '%s' in namespace '%s'", clusterType, namespace)
 	timeout := a.Timeout
 	if condition != nil {
 		timeout = ToolchainClusterConditionTimeout
@@ -150,7 +139,7 @@ func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Ty
 	var c toolchainv1alpha1.ToolchainCluster
 	err := wait.Poll(a.RetryInterval, timeout, func() (done bool, err error) {
 		var ready bool
-		if c, ready, err = a.GetToolchainCluster(clusterType, namespace, condition); ready {
+		if c, ready = a.GetToolchainCluster(t, clusterType, namespace, condition); ready {
 			return true, nil
 		}
 		return false, err
@@ -160,8 +149,8 @@ func (a *Awaitility) WaitForToolchainClusterWithCondition(clusterType cluster.Ty
 
 // WaitForNamedToolchainClusterWithCondition waits until there is a ToolchainCluster with the given name
 // and with the given ClusterCondition (if it the condition is nil, then it skips this check)
-func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(name string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
-	a.T.Logf("waiting for ToolchainCluster '%s' in namespace '%s' to have condition '%v'", name, a.Namespace, condition)
+func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(t *testing.T, name string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, error) {
+	t.Logf("waiting for ToolchainCluster '%s' in namespace '%s' to have condition '%v'", name, a.Namespace, condition)
 	timeout := a.Timeout
 	if condition != nil {
 		timeout = ToolchainClusterConditionTimeout
@@ -183,24 +172,23 @@ func (a *Awaitility) WaitForNamedToolchainClusterWithCondition(name string, cond
 // GetToolchainCluster retrieves and returns a ToolchainCluster representing a operator of the given type
 // and running in the given expected namespace. If the given condition is not nil, then it also checks
 // if the CR has the ClusterCondition
-func (a *Awaitility) GetToolchainCluster(clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, bool, error) {
+func (a *Awaitility) GetToolchainCluster(t *testing.T, clusterType cluster.Type, namespace string, condition *toolchainv1alpha1.ToolchainClusterCondition) (toolchainv1alpha1.ToolchainCluster, bool) {
 	clusters := &toolchainv1alpha1.ToolchainClusterList{}
-	if err := a.Client.List(context.TODO(), clusters, client.InNamespace(a.Namespace), client.MatchingLabels{
+	err := a.Client.List(context.TODO(), clusters, client.InNamespace(a.Namespace), client.MatchingLabels{
 		"namespace": namespace,
 		"type":      string(clusterType),
-	}); err != nil {
-		return toolchainv1alpha1.ToolchainCluster{}, false, err
-	}
+	})
+	require.NoError(t, err)
 	if len(clusters.Items) == 0 {
-		a.T.Logf("no toolchaincluster resource with expected labels: namespace='%s', type='%s'", namespace, string(clusterType))
+		t.Logf("no toolchaincluster resource with expected labels: namespace='%s', type='%s'", namespace, string(clusterType))
 	}
 	// assume there is zero or 1 match only
 	for _, cl := range clusters.Items {
 		if containsClusterCondition(cl.Status.Conditions, condition) {
-			return cl, true, nil
+			return cl, true
 		}
 	}
-	return toolchainv1alpha1.ToolchainCluster{}, false, nil
+	return toolchainv1alpha1.ToolchainCluster{}, false
 }
 
 func containsClusterCondition(conditions []toolchainv1alpha1.ToolchainClusterCondition, contains *toolchainv1alpha1.ToolchainClusterCondition) bool {
@@ -218,9 +206,9 @@ func containsClusterCondition(conditions []toolchainv1alpha1.ToolchainClusterCon
 // SetupRouteForService if needed, creates a route for the given service (with the same namespace/name)
 // It waits until the route is available (or returns an error) by first checking the resource status
 // and then making a call to the given endpoint
-func (a *Awaitility) SetupRouteForService(serviceName, endpoint string) (routev1.Route, error) {
-	a.T.Logf("setting up route for service '%s' with endpoint '%s'", serviceName, endpoint)
-	service, err := a.WaitForMetricsService(serviceName)
+func (a *Awaitility) SetupRouteForService(t *testing.T, serviceName, endpoint string) (routev1.Route, error) {
+	t.Logf("setting up route for service '%s' with endpoint '%s'", serviceName, endpoint)
+	service, err := a.WaitForMetricsService(t, serviceName)
 	if err != nil {
 		return routev1.Route{}, err
 	}
@@ -231,7 +219,7 @@ func (a *Awaitility) SetupRouteForService(serviceName, endpoint string) (routev1
 		Namespace: service.Namespace,
 		Name:      service.Name,
 	}, &route); err != nil {
-		require.True(a.T, apierrors.IsNotFound(err), "failed to get route to access the '%s' service: %s", service.Name, err.Error())
+		require.True(t, apierrors.IsNotFound(err), "failed to get route to access the '%s' service: %s", service.Name, err.Error())
 		route = routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: service.Namespace,
@@ -254,13 +242,13 @@ func (a *Awaitility) SetupRouteForService(serviceName, endpoint string) (routev1
 			return route, err
 		}
 	}
-	return a.WaitForRouteToBeAvailable(route.Namespace, route.Name, endpoint)
+	return a.WaitForRouteToBeAvailable(t, route.Namespace, route.Name, endpoint)
 }
 
 // WaitForRouteToBeAvailable waits until the given route is available, ie, it has an Ingress with a host configured
 // and the endpoint is reachable (with a `200 OK` status response)
-func (a *Awaitility) WaitForRouteToBeAvailable(ns, name, endpoint string) (routev1.Route, error) {
-	a.T.Logf("waiting for route '%s' in namespace '%s'", name, ns)
+func (a *Awaitility) WaitForRouteToBeAvailable(t *testing.T, ns, name, endpoint string) (routev1.Route, error) {
+	t.Logf("waiting for route '%s' in namespace '%s'", name, ns)
 	route := routev1.Route{}
 	// retrieve the route for the registration service
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
@@ -324,17 +312,17 @@ func (a *Awaitility) WaitForRouteToBeAvailable(ns, name, endpoint string) (route
 
 // GetMetricValue gets the value of the metric with the given family and label key-value pair
 // fails if the metric with the given labelAndValues does not exist
-func (a *Awaitility) GetMetricValue(family string, labelAndValues ...string) float64 {
+func (a *Awaitility) GetMetricValue(t *testing.T, family string, labelAndValues ...string) float64 {
 	value, err := metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labelAndValues)
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	return value
 }
 
 // GetMetricValue gets the value of the metric with the given family and label key-value pair
 // return 0 if the metric with the given labelAndValues does not exist
-func (a *Awaitility) GetMetricValueOrZero(family string, labelAndValues ...string) float64 {
+func (a *Awaitility) GetMetricValueOrZero(t *testing.T, family string, labelAndValues ...string) float64 {
 	if len(labelAndValues)%2 != 0 {
-		a.T.Fatal("`labelAndValues` must be pairs of labels and values")
+		t.Fatal("`labelAndValues` must be pairs of labels and values")
 	}
 	if value, err := metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labelAndValues); err == nil {
 		return value
@@ -344,8 +332,8 @@ func (a *Awaitility) GetMetricValueOrZero(family string, labelAndValues ...strin
 
 // WaitUntiltMetricHasValue asserts that the exposed metric with the given family
 // and label key-value pair reaches the expected value
-func (a *Awaitility) WaitUntiltMetricHasValue(family string, expectedValue float64, labels ...string) {
-	a.T.Logf("waiting for metric '%s{%v}' to reach '%v'", family, labels, expectedValue)
+func (a *Awaitility) WaitUntiltMetricHasValue(t *testing.T, family string, expectedValue float64, labels ...string) {
+	t.Logf("waiting for metric '%s{%v}' to reach '%v'", family, labels, expectedValue)
 	var value float64
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		value, err := metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labels)
@@ -353,13 +341,13 @@ func (a *Awaitility) WaitUntiltMetricHasValue(family string, expectedValue float
 		// unless the expected value is `0`, in which case the metric is bot exposed (value==0 and err!= nil), but it's fine too.
 		return (value == expectedValue && err == nil) || (expectedValue == 0 && value == 0), nil
 	})
-	require.NoError(a.T, err, "waited for metric '%s{%v}' to reach '%v'. Current value: %v", family, labels, expectedValue, value)
+	require.NoError(t, err, "waited for metric '%s{%v}' to reach '%v'. Current value: %v", family, labels, expectedValue, value)
 }
 
 // WaitUntilMetricHasValueOrMore waits until the exposed metric with the given family
 // and label key-value pair has reached the expected value (or more)
-func (a *Awaitility) WaitUntilMetricHasValueOrMore(family string, expectedValue float64, labels ...string) error {
-	a.T.Logf("waiting for metric '%s{%v}' to reach '%v' or more", family, labels, expectedValue)
+func (a *Awaitility) WaitUntilMetricHasValueOrMore(t *testing.T, family string, expectedValue float64, labels ...string) error {
+	t.Logf("waiting for metric '%s{%v}' to reach '%v' or more", family, labels, expectedValue)
 	var value float64
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		value, err = metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labels)
@@ -367,15 +355,15 @@ func (a *Awaitility) WaitUntilMetricHasValueOrMore(family string, expectedValue 
 		return value >= expectedValue && err == nil, nil
 	})
 	if err != nil {
-		a.T.Logf("waited for metric '%s{%v}' to reach '%v' or more. Current value: %v", family, labels, expectedValue, value)
+		t.Logf("waited for metric '%s{%v}' to reach '%v' or more. Current value: %v", family, labels, expectedValue, value)
 	}
 	return err
 }
 
 // WaitUntilMetricHasValueOrLess waits until the exposed metric with the given family
 // and label key-value pair has reached the expected value (or less)
-func (a *Awaitility) WaitUntilMetricHasValueOrLess(family string, expectedValue float64, labels ...string) error {
-	a.T.Logf("waiting for metric '%s{%v}' to reach '%v' or less", family, labels, expectedValue)
+func (a *Awaitility) WaitUntilMetricHasValueOrLess(t *testing.T, family string, expectedValue float64, labels ...string) error {
+	t.Logf("waiting for metric '%s{%v}' to reach '%v' or less", family, labels, expectedValue)
 	var value float64
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		value, err = metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labels)
@@ -383,7 +371,7 @@ func (a *Awaitility) WaitUntilMetricHasValueOrLess(family string, expectedValue 
 		return value <= expectedValue && err == nil, nil
 	})
 	if err != nil {
-		a.T.Logf("waited for metric '%s{%v}' to reach '%v' or less. Current value: %v", family, labels, expectedValue, value)
+		t.Logf("waited for metric '%s{%v}' to reach '%v' or less. Current value: %v", family, labels, expectedValue, value)
 	}
 	return err
 }
@@ -404,9 +392,9 @@ func (a *Awaitility) DeletePods(criteria ...client.ListOption) error {
 }
 
 // GetMemoryUsage retrieves the memory usage (in KB) of a given the pod
-func (a *Awaitility) GetMemoryUsage(podname, ns string) (int64, error) {
+func (a *Awaitility) GetMemoryUsage(t *testing.T, podname, ns string) int64 {
 	var containerMetrics k8smetrics.ContainerMetrics
-	if err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		podMetrics := k8smetrics.PodMetrics{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{
 			Namespace: ns,
@@ -421,23 +409,22 @@ func (a *Awaitility) GetMemoryUsage(podname, ns string) (int64, error) {
 			}
 		}
 		return false, nil // keep waiting
-	}); err != nil {
-		return -1, err
-	}
+	})
+	require.NoError(t, err)
 	// the pod contains multiple
-	return containerMetrics.Usage.Memory().ScaledValue(resource.Kilo), nil
+	return containerMetrics.Usage.Memory().ScaledValue(resource.Kilo)
 }
 
 // CreateNamespace creates a namespace with the given name and waits until it gets active
 // it also adds a deletion of the namespace at the end of the test
-func (a *Awaitility) CreateNamespace(name string) {
+func (a *Awaitility) CreateNamespace(t *testing.T, name string) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 	}
 	err := a.Client.Create(context.TODO(), ns)
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	err = wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		ns := &corev1.Namespace{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, ns); err != nil && apierrors.IsNotFound(err) {
@@ -447,17 +434,17 @@ func (a *Awaitility) CreateNamespace(name string) {
 		}
 		return ns.Status.Phase == corev1.NamespaceActive, nil
 	})
-	require.NoError(a.T, err)
-	a.T.Cleanup(func() {
+	require.NoError(t, err)
+	t.Cleanup(func() {
 		if err := a.Client.Delete(context.TODO(), ns); err != nil && !apierrors.IsNotFound(err) {
-			require.NoError(a.T, err)
+			require.NoError(t, err)
 		}
 	})
 }
 
 // WaitForDeploymentToGetReady waits until the deployment with the given name is ready together with the given number of replicas
-func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int, criteria ...DeploymentCriteria) *appsv1.Deployment {
-	a.T.Logf("waiting until deployment '%s' in namespace '%s' is ready", name, a.Namespace)
+func (a *Awaitility) WaitForDeploymentToGetReady(t *testing.T, name string, replicas int, criteria ...DeploymentCriteria) *appsv1.Deployment {
+	t.Logf("waiting until deployment '%s' in namespace '%s' is ready", name, a.Namespace)
 	deployment := &appsv1.Deployment{}
 	err := wait.Poll(a.RetryInterval, 6*a.Timeout, func() (done bool, err error) {
 		deploymentConditions := status.GetDeploymentStatusConditions(a.Client, name, a.Namespace)
@@ -465,12 +452,12 @@ func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int, crit
 			return false, nil // nolint:nilerr
 		}
 		deployment = &appsv1.Deployment{}
-		require.NoError(a.T, a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, name), deployment))
+		require.NoError(t, a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, name), deployment))
 		if int(deployment.Status.AvailableReplicas) != replicas {
 			return false, nil
 		}
 		pods := &corev1.PodList{}
-		require.NoError(a.T, a.Client.List(context.TODO(), pods, client.InNamespace(a.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)))
+		require.NoError(t, a.Client.List(context.TODO(), pods, client.InNamespace(a.Namespace), client.MatchingLabels(deployment.Spec.Selector.MatchLabels)))
 		if len(pods.Items) != replicas {
 			return false, nil
 		}
@@ -486,7 +473,7 @@ func (a *Awaitility) WaitForDeploymentToGetReady(name string, replicas int, crit
 		}
 		return true, nil
 	})
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	return deployment
 }
 
@@ -504,21 +491,19 @@ func DeploymentHasContainerWithImage(containerName, image string) DeploymentCrit
 }
 
 // CreateWithCleanup creates the given object via client.Client.Create() and schedules the cleanup of the object at the end of the current test
-func (a *Awaitility) CreateWithCleanup(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if err := a.Client.Create(ctx, obj, opts...); err != nil {
-		return err
-	}
-	cleanup.AddCleanTasks(a, obj)
-	return nil
+func (a *Awaitility) CreateWithCleanup(t *testing.T, obj client.Object, opts ...client.CreateOption) {
+	err := a.Client.Create(context.TODO(), obj, opts...)
+	require.NoError(t, err)
+	cleanup.AddCleanTasks(t, a, obj)
 }
 
 // Clean triggers cleanup of all resources that were marked to be cleaned before that
-func (a *Awaitility) Clean() {
-	cleanup.ExecuteAllCleanTasks(a)
+func (a *Awaitility) Clean(t *testing.T) {
+	cleanup.ExecuteAllCleanTasks(t)
 }
 
-func (a *Awaitility) listAndPrint(resourceKind, namespace string, list client.ObjectList, additionalOptions ...client.ListOption) {
-	a.T.Logf(a.listAndReturnContent(resourceKind, namespace, list, additionalOptions...))
+func (a *Awaitility) listAndPrint(t *testing.T, resourceKind, namespace string, list client.ObjectList, additionalOptions ...client.ListOption) {
+	t.Logf(a.listAndReturnContent(resourceKind, namespace, list, additionalOptions...))
 }
 
 func (a *Awaitility) listAndReturnContent(resourceKind, namespace string, list client.ObjectList, additionalOptions ...client.ListOption) string {

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -77,7 +77,7 @@ func (a *HostAwaitility) sprintAllResources() string {
 		for _, r := range all {
 			y, _ := yaml.Marshal(r)
 			buf.Write(y)
-			buf.WriteString("\n")
+			buf.WriteString("\n---\n")
 		}
 	}
 	return buf.String()
@@ -101,6 +101,15 @@ func (a *HostAwaitility) allResources() ([]runtime.Object, error) {
 		return nil, err
 	}
 	for _, i := range masteruserrecords.Items {
+		copy := i
+		all = append(all, &copy)
+	}
+	// spaces
+	spaces := &toolchainv1alpha1.SpaceList{}
+	if err := a.Client.List(context.TODO(), spaces, client.InNamespace(a.Namespace)); err != nil {
+		return nil, err
+	}
+	for _, i := range spaces.Items {
 		copy := i
 		all = append(all, &copy)
 	}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -915,7 +915,7 @@ func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(t *testing.T, na
 	// now, check that the `templateRef` field is set for each namespace and clusterResources (if applicable)
 	// and that there's a TierTemplate resource with the same name
 	for i, ns := range tier.Spec.Namespaces {
-		require.NotEmpty(t, ns.TemplateRef == "", "missing 'templateRef' in namespace #%d in NSTemplateTier '%s'", i, tier.Name)
+		require.NotEmpty(t, ns.TemplateRef, "missing 'templateRef' in namespace #%d in NSTemplateTier '%s'", i, tier.Name)
 		a.WaitForTierTemplate(t, ns.TemplateRef)
 	}
 	if tier.Spec.ClusterResources != nil {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1905,26 +1906,24 @@ func (a *MemberAwaitility) verifyAutoscalingBufferDeployment(t *testing.T) {
 }
 
 // WaitForExpectedNumberOfResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list func() (int, error)) {
+func (a *MemberAwaitility) WaitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list listObjects) {
 	a.waitForExpectedNumberOfResources(t, kind, expected, list)
 }
 
 // WaitForExpectedNumberOfClusterResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(t *testing.T, kind string, expected int, list func() (int, error)) {
+func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(t *testing.T, kind string, expected int, list listObjects) {
 	a.waitForExpectedNumberOfResources(t, kind, expected, list)
 }
 
-func (a *MemberAwaitility) waitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list func() (int, error)) {
-	var actual int
+type listObjects func(t *testing.T) []runtime.Object
+
+func (a *MemberAwaitility) waitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list listObjects) {
+	var objs []runtime.Object
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		a, err := list()
-		if err != nil {
-			return false, err
-		}
-		actual = a
-		return actual == expected, nil
+		objs = list(t)
+		return len(objs) == expected, nil
 	})
-	require.NoError(t, err, "expected number of resources of kind '%s' to be %d but it was %d", kind, expected, actual)
+	require.NoError(t, err, "expected number of resources of kind '%s' to be %d but it was %d: %s", kind, expected, len(objs), spew.Sdump(objs))
 }
 
 func (a *MemberAwaitility) UpdatePod(t *testing.T, namespace, podName string, modifyPod func(pod *corev1.Pod)) *corev1.Pod {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1903,27 +1902,6 @@ func (a *MemberAwaitility) verifyAutoscalingBufferDeployment(t *testing.T) {
 	assert.True(t, container.Resources.Limits.Memory().Equal(expectedMemory))
 
 	a.WaitForDeploymentToGetReady(t, "autoscaling-buffer", 2)
-}
-
-// WaitForExpectedNumberOfResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list listObjects) {
-	a.waitForExpectedNumberOfResources(t, kind, expected, list)
-}
-
-// WaitForExpectedNumberOfClusterResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(t *testing.T, kind string, expected int, list listObjects) {
-	a.waitForExpectedNumberOfResources(t, kind, expected, list)
-}
-
-type listObjects func(t *testing.T) []runtime.Object
-
-func (a *MemberAwaitility) waitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list listObjects) {
-	var objs []runtime.Object
-	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		objs = list(t)
-		return len(objs) == expected, nil
-	})
-	require.NoError(t, err, "expected number of resources of kind '%s' to be %d but it was %d: %s", kind, expected, len(objs), spew.Sdump(objs))
 }
 
 func (a *MemberAwaitility) UpdatePod(t *testing.T, namespace, podName string, modifyPod func(pod *corev1.Pod)) *corev1.Pod {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -53,24 +53,17 @@ type MemberAwaitility struct {
 	*Awaitility
 }
 
-func NewMemberAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns, clusterName string) *MemberAwaitility {
+func NewMemberAwaitility(cfg *rest.Config, cl client.Client, ns, clusterName string) *MemberAwaitility {
 	return &MemberAwaitility{
 		Awaitility: &Awaitility{
 			Client:        cl,
 			RestConfig:    cfg,
 			ClusterName:   clusterName,
-			T:             t,
 			Namespace:     ns,
 			Type:          cluster.Member,
 			RetryInterval: DefaultRetryInterval,
 			Timeout:       DefaultTimeout,
 		},
-	}
-}
-
-func (a *MemberAwaitility) ForTest(t *testing.T) *MemberAwaitility {
-	return &MemberAwaitility{
-		Awaitility: a.Awaitility.ForTest(t),
 	}
 }
 
@@ -95,7 +88,7 @@ func matchUserAccountWaitCriterion(actual *toolchainv1alpha1.UserAccount, criter
 	return true
 }
 
-func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(actual *toolchainv1alpha1.UserAccount, criteria ...UserAccountWaitCriterion) {
+func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.UserAccount, criteria ...UserAccountWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find UserAccount\n")
@@ -115,7 +108,7 @@ func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(actual *toolchainv
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilUserAccountHasLabelWithValue returns a `UserAccountWaitCriterion` which checks that the given
@@ -163,21 +156,15 @@ func UntilUserAccountHasSpec(expected toolchainv1alpha1.UserAccountSpec) UserAcc
 
 // UntilUserAccountMatchesMur returns a `UserAccountWaitCriterion` which loads the existing MUR
 // and compares the first UserAccountSpecEmbedded in the MUR with the actual UserAccount spec
-func UntilUserAccountMatchesMur(hostAwaitility *HostAwaitility) UserAccountWaitCriterion {
+func UntilUserAccountMatchesMur(t *testing.T, hostAwaitility *HostAwaitility) UserAccountWaitCriterion {
 	return UserAccountWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.UserAccount) bool {
-			mur, err := hostAwaitility.GetMasterUserRecord(actual.Name)
-			if err != nil {
-				return false
-			}
+			mur := hostAwaitility.GetMasterUserRecord(t, actual.Name)
 			return actual.Spec.UserID == mur.Spec.UserID &&
 				actual.Spec.Disabled == mur.Spec.Disabled
 		},
 		Diff: func(actual *toolchainv1alpha1.UserAccount) string {
-			mur, err := hostAwaitility.GetMasterUserRecord(actual.Name)
-			if err != nil {
-				return fmt.Sprintf("could not find mur for user account '%s'", actual.Name)
-			}
+			mur := hostAwaitility.GetMasterUserRecord(t, actual.Name)
 			return fmt.Sprintf("expected mur to match with useraccount:\n\tUserID: %s/%s\n\tDisabled: %t/%t\n", actual.Spec.UserID, mur.Spec.UserID, actual.Spec.Disabled, mur.Spec.Disabled)
 		},
 	}
@@ -232,7 +219,7 @@ func UntilUserAccountIsCreatedAfter(timestamp metav1.Time) UserAccountWaitCriter
 }
 
 // WaitForUserAccount waits until there is a UserAccount available with the given name, expected spec and the set of status conditions
-func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccountWaitCriterion) (*toolchainv1alpha1.UserAccount, error) {
+func (a *MemberAwaitility) WaitForUserAccount(t *testing.T, name string, criteria ...UserAccountWaitCriterion) *toolchainv1alpha1.UserAccount {
 	var userAccount *toolchainv1alpha1.UserAccount
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.UserAccount{}
@@ -247,9 +234,10 @@ func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccou
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printUserAccountWaitCriterionDiffs(userAccount, criteria...)
+		a.printUserAccountWaitCriterionDiffs(t, userAccount, criteria...)
 	}
-	return userAccount, err
+	require.NoError(t, err)
+	return userAccount
 }
 
 // NSTemplateSetWaitCriterion a struct to compare with a given NSTemplateSet
@@ -267,7 +255,7 @@ func matchNSTemplateSetWaitCriterion(actual *toolchainv1alpha1.NSTemplateSet, cr
 	return true
 }
 
-func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(actual *toolchainv1alpha1.NSTemplateSet, criteria ...NSTemplateSetWaitCriterion) {
+func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.NSTemplateSet, criteria ...NSTemplateSetWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find NSTemplateSet at all\n")
@@ -287,7 +275,7 @@ func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(actual *toolchai
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilNSTemplateSetHasNoOwnerReferences returns a `NSTemplateSetWaitCriterion` which checks that the given
@@ -390,8 +378,8 @@ func UntilNSTemplateSetHasTier(expected string) NSTemplateSetWaitCriterion {
 }
 
 // WaitForNSTmplSet wait until the NSTemplateSet with the given name and conditions exists
-func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateSetWaitCriterion) (*toolchainv1alpha1.NSTemplateSet, error) {
-	a.T.Logf("waiting for NSTemplateSet '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForNSTmplSet(t *testing.T, name string, criteria ...NSTemplateSetWaitCriterion) *toolchainv1alpha1.NSTemplateSet {
+	t.Logf("waiting for NSTemplateSet '%s' to match criteria", name)
 	var nsTmplSet *toolchainv1alpha1.NSTemplateSet
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.NSTemplateSet{}
@@ -406,15 +394,16 @@ func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateS
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNSTemplateSetWaitCriterionDiffs(nsTmplSet, criteria...)
+		a.printNSTemplateSetWaitCriterionDiffs(t, nsTmplSet, criteria...)
 	}
-	return nsTmplSet, err
+	require.NoError(t, err)
+	return nsTmplSet
 }
 
 // WaitUntilNSTemplateSetDeleted waits until the NSTemplateSet with the given name is deleted (ie, is not found)
-func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(name string) error {
-	a.T.Logf("waiting for until NSTemplateSet '%s' in namespace '%s' is deleted", name, a.Namespace)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(t *testing.T, name string) {
+	t.Logf("waiting for until NSTemplateSet '%s' in namespace '%s' is deleted", name, a.Namespace)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		nsTmplSet := &toolchainv1alpha1.NSTemplateSet{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, nsTmplSet); err != nil {
 			if errors.IsNotFound(err) {
@@ -424,6 +413,7 @@ func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(name string) error {
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
 type NamespaceWaitCriterion struct {
@@ -490,11 +480,9 @@ func matchNamespaceWaitCriteria(actual *corev1.Namespace, criteria ...NamespaceW
 }
 
 // WaitForNamespace waits until a namespace with the given owner (username), type, revision and tier labels exists
-func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, criteria ...NamespaceWaitCriterion) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespace(t *testing.T, owner, tmplRef, tierName string, criteria ...NamespaceWaitCriterion) *corev1.Namespace {
 	_, kind, _, err := Split(tmplRef)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 	labels := map[string]string{
 		"toolchain.dev.openshift.com/owner":       owner,
 		"toolchain.dev.openshift.com/templateref": tmplRef,
@@ -502,7 +490,7 @@ func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, cri
 		"toolchain.dev.openshift.com/type":        kind,
 		"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 	}
-	a.T.Logf("waiting for namespace with custom criteria and labels %v", labels)
+	t.Logf("waiting for namespace with custom criteria and labels %v", labels)
 	var ns *corev1.Namespace
 	err = wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		nss := &corev1.NamespaceList{}
@@ -517,25 +505,25 @@ func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, cri
 		return matchNamespaceWaitCriteria(ns, criteria...), nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for namespace with labels: %v", labels)
+		t.Logf("failed to wait for namespace with labels: %v", labels)
 		opts := client.MatchingLabels(map[string]string{
 			"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 		})
-		a.listAndPrint("Namespaces", "", &corev1.NamespaceList{}, opts)
+		a.listAndPrint(t, "Namespaces", "", &corev1.NamespaceList{}, opts)
 		if ns == nil {
-			a.T.Logf("a namespace with the following labels was not found: %v", labels)
-			return nil, err
+			t.Logf("a namespace with the following labels was not found: %v", labels)
+		} else {
+			for _, c := range criteria {
+				t.Logf(c.Diff(ns))
+			}
 		}
-		for _, c := range criteria {
-			a.T.Logf(c.Diff(ns))
-		}
-		return nil, err
 	}
-	return ns, nil
+	require.NoError(t, err)
+	return ns
 }
 
 // WaitForNamespaceWithName waits until a namespace with the given name
-func (a *MemberAwaitility) WaitForNamespaceWithName(name string, criteria ...LabelWaitCriterion) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespaceWithName(t *testing.T, name string, criteria ...LabelWaitCriterion) *corev1.Namespace {
 	ns := &corev1.Namespace{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Namespace{}
@@ -549,11 +537,11 @@ func (a *MemberAwaitility) WaitForNamespaceWithName(name string, criteria ...Lab
 		return matchLabelWaitCriteria(ns.ObjectMeta, criteria...), nil
 	})
 	if err != nil {
-		a.T.Log("failed to wait for namespace")
-		a.printNamespaceLabelCriterionDiffs(ns, criteria...)
-		return nil, err
+		t.Log("failed to wait for namespace")
+		a.printNamespaceLabelCriterionDiffs(t, ns, criteria...)
 	}
-	return ns, nil
+	require.NoError(t, err)
+	return ns
 }
 
 func matchLabelWaitCriteria(actual metav1.ObjectMeta, criteria ...LabelWaitCriterion) bool {
@@ -565,7 +553,7 @@ func matchLabelWaitCriteria(actual metav1.ObjectMeta, criteria ...LabelWaitCrite
 	return true
 }
 
-func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(actual *corev1.Namespace, criteria ...LabelWaitCriterion) {
+func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(t *testing.T, actual *corev1.Namespace, criteria ...LabelWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Namespace\n")
@@ -585,11 +573,11 @@ func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(actual *corev1.Name
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForNamespaceInTerminating waits until a namespace with the given name has a deletion timestamp and in Terminating Phase
-func (a *MemberAwaitility) WaitForNamespaceInTerminating(nsName string) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespaceInTerminating(t *testing.T, nsName string) *corev1.Namespace {
 	ns := &corev1.Namespace{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Namespace{}
@@ -603,15 +591,15 @@ func (a *MemberAwaitility) WaitForNamespaceInTerminating(nsName string) (*corev1
 		return obj.DeletionTimestamp != nil && obj.Status.Phase == corev1.NamespaceTerminating, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for namespace '%s' to be in 'Terminating' phase", nsName)
-		return nil, err
+		t.Logf("failed to wait for namespace '%s' to be in 'Terminating' phase", nsName)
 	}
-	return ns, nil
+	require.NoError(t, err)
+	return ns
 }
 
 // WaitForRoleBinding waits until a RoleBinding with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForRoleBinding(namespace *corev1.Namespace, name string) (*rbacv1.RoleBinding, error) {
-	a.T.Logf("waiting for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForRoleBinding(t *testing.T, namespace *corev1.Namespace, name string) *rbacv1.RoleBinding {
+	t.Logf("waiting for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
 	roleBinding := &rbacv1.RoleBinding{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &rbacv1.RoleBinding{}
@@ -629,16 +617,16 @@ func (a *MemberAwaitility) WaitForRoleBinding(namespace *corev1.Namespace, name 
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
-		return nil, err
+		t.Logf("failed to wait for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
 	}
-	return roleBinding, err
+	require.NoError(t, err)
+	return roleBinding
 }
 
 // WaitUntilRoleBindingDeleted waits until a RoleBinding with the given name does not exist anymore in the given namespace
-func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(namespace *corev1.Namespace, name string) error {
-	a.T.Logf("waiting for RoleBinding '%s' in namespace '%s' to be deleted", name, namespace.Name)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(t *testing.T, namespace *corev1.Namespace, name string) {
+	t.Logf("waiting for RoleBinding '%s' in namespace '%s' to be deleted", name, namespace.Name)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		roleBinding := &rbacv1.RoleBinding{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, roleBinding); err != nil {
 			if errors.IsNotFound(err) {
@@ -648,10 +636,11 @@ func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(namespace *corev1.Namespa
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
-func (a *MemberAwaitility) WaitForServiceAccount(namespace string, name string) (*corev1.ServiceAccount, error) {
-	a.T.Logf("waiting for ServiceAccount '%s' in namespace '%s'", name, namespace)
+func (a *MemberAwaitility) WaitForServiceAccount(t *testing.T, namespace string, name string) *corev1.ServiceAccount {
+	t.Logf("waiting for ServiceAccount '%s' in namespace '%s'", name, namespace)
 	serviceAccount := &corev1.ServiceAccount{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ServiceAccount{}
@@ -665,15 +654,15 @@ func (a *MemberAwaitility) WaitForServiceAccount(namespace string, name string) 
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for ServiceAccount '%s' in namespace '%s'.", name, namespace)
-		return nil, err
+		t.Logf("failed to wait for ServiceAccount '%s' in namespace '%s'.", name, namespace)
 	}
-	return serviceAccount, err
+	require.NoError(t, err)
+	return serviceAccount
 }
 
 // WaitForLimitRange waits until a LimitRange with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForLimitRange(namespace *corev1.Namespace, name string) (*corev1.LimitRange, error) {
-	a.T.Logf("waiting for LimitRange '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForLimitRange(t *testing.T, namespace *corev1.Namespace, name string) *corev1.LimitRange {
+	t.Logf("waiting for LimitRange '%s' in namespace '%s'", name, namespace.Name)
 	lr := &corev1.LimitRange{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.LimitRange{}
@@ -691,14 +680,15 @@ func (a *MemberAwaitility) WaitForLimitRange(namespace *corev1.Namespace, name s
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for LimitRange '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for LimitRange '%s' in namespace '%s'", name, namespace.Name)
 	}
-	return lr, err
+	require.NoError(t, err)
+	return lr
 }
 
 // WaitForNetworkPolicy waits until a NetworkPolicy with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForNetworkPolicy(namespace *corev1.Namespace, name string) (*netv1.NetworkPolicy, error) {
-	a.T.Logf("waiting for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForNetworkPolicy(t *testing.T, namespace *corev1.Namespace, name string) (*netv1.NetworkPolicy, error) {
+	t.Logf("waiting for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
 	np := &netv1.NetworkPolicy{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &netv1.NetworkPolicy{}
@@ -716,14 +706,14 @@ func (a *MemberAwaitility) WaitForNetworkPolicy(namespace *corev1.Namespace, nam
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
 	}
 	return np, err
 }
 
 // WaitForRole waits until a Role with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForRole(namespace *corev1.Namespace, name string) (*rbacv1.Role, error) {
-	a.T.Logf("waiting for Role '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForRole(t *testing.T, namespace *corev1.Namespace, name string) (*rbacv1.Role, error) {
+	t.Logf("waiting for Role '%s' in namespace '%s'", name, namespace.Name)
 	role := &rbacv1.Role{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &rbacv1.Role{}
@@ -741,14 +731,14 @@ func (a *MemberAwaitility) WaitForRole(namespace *corev1.Namespace, name string)
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for Role '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for Role '%s' in namespace '%s'", name, namespace.Name)
 	}
 	return role, err
 }
 
 // WaitUntilRoleDeleted waits until a Role with the given name does not exist anymore in the given namespace
-func (a *MemberAwaitility) WaitUntilRoleDeleted(namespace *corev1.Namespace, name string) error {
-	a.T.Logf("waiting for Role '%s' in namespace '%s' to be deleted", name, namespace.Name)
+func (a *MemberAwaitility) WaitUntilRoleDeleted(t *testing.T, namespace *corev1.Namespace, name string) error {
+	t.Logf("waiting for Role '%s' in namespace '%s' to be deleted", name, namespace.Name)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		role := &rbacv1.Role{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, role); err != nil {
@@ -776,7 +766,7 @@ func matchClusterResourceQuotaWaitCriteria(actual *quotav1.ClusterResourceQuota,
 	return true
 }
 
-func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(actual *quotav1.ClusterResourceQuota, criteria ...ClusterResourceQuotaWaitCriterion) {
+func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(t *testing.T, actual *quotav1.ClusterResourceQuota, criteria ...ClusterResourceQuotaWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find ClusterResourceQuota\n")
@@ -796,12 +786,12 @@ func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(actual *q
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForClusterResourceQuota waits until a ClusterResourceQuota with the given name exists
-func (a *MemberAwaitility) WaitForClusterResourceQuota(name string, criteria ...ClusterResourceQuotaWaitCriterion) (*quotav1.ClusterResourceQuota, error) {
-	a.T.Logf("waiting for ClusterResourceQuota '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForClusterResourceQuota(t *testing.T, name string, criteria ...ClusterResourceQuotaWaitCriterion) (*quotav1.ClusterResourceQuota, error) {
+	t.Logf("waiting for ClusterResourceQuota '%s' to match criteria", name)
 	quota := &quotav1.ClusterResourceQuota{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &quotav1.ClusterResourceQuota{}
@@ -821,7 +811,7 @@ func (a *MemberAwaitility) WaitForClusterResourceQuota(name string, criteria ...
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printClusterResourceQuotaWaitCriterionDiffs(quota, criteria...)
+		a.printClusterResourceQuotaWaitCriterionDiffs(t, quota, criteria...)
 	}
 	return quota, err
 }
@@ -841,7 +831,7 @@ func matchResourceQuotaWaitCriteria(actual *corev1.ResourceQuota, criteria ...Re
 	return true
 }
 
-func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(actual *corev1.ResourceQuota, criteria ...ResourceQuotaWaitCriterion) {
+func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(t *testing.T, actual *corev1.ResourceQuota, criteria ...ResourceQuotaWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find ResourceQuota\n")
@@ -861,12 +851,12 @@ func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(actual *corev1.R
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForResourceQuota waits until a ResourceQuota with the given name exists
-func (a *MemberAwaitility) WaitForResourceQuota(namespace, name string, criteria ...ResourceQuotaWaitCriterion) (*corev1.ResourceQuota, error) {
-	a.T.Logf("waiting for ResourceQuota '%s' in %s to match criteria", name, namespace)
+func (a *MemberAwaitility) WaitForResourceQuota(t *testing.T, namespace, name string, criteria ...ResourceQuotaWaitCriterion) (*corev1.ResourceQuota, error) {
+	t.Logf("waiting for ResourceQuota '%s' in %s to match criteria", name, namespace)
 	quota := &corev1.ResourceQuota{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ResourceQuota{}
@@ -881,7 +871,7 @@ func (a *MemberAwaitility) WaitForResourceQuota(namespace, name string, criteria
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printResourceQuotaWaitCriterionDiffs(quota, criteria...)
+		a.printResourceQuotaWaitCriterionDiffs(t, quota, criteria...)
 	}
 	return quota, err
 }
@@ -902,7 +892,7 @@ func matchIdlerWaitCriteria(actual *toolchainv1alpha1.Idler, criteria ...IdlerWa
 	return true
 }
 
-func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(actual *toolchainv1alpha1.Idler, criteria ...IdlerWaitCriterion) {
+func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(t *testing.T, actual *toolchainv1alpha1.Idler, criteria ...IdlerWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Idler\n")
@@ -924,7 +914,7 @@ func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(actual *toolchainv1alpha1
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // IdlerConditions returns a `IdlerWaitCriterion` which checks that the given
@@ -965,8 +955,8 @@ func IdlerHasTier(expected string) IdlerWaitCriterion {
 }
 
 // WaitForIdler waits until an Idler with the given name exists
-func (a *MemberAwaitility) WaitForIdler(name string, criteria ...IdlerWaitCriterion) (*toolchainv1alpha1.Idler, error) {
-	a.T.Logf("waiting for Idler '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForIdler(t *testing.T, name string, criteria ...IdlerWaitCriterion) (*toolchainv1alpha1.Idler, error) {
+	t.Logf("waiting for Idler '%s' to match criteria", name)
 	idler := &toolchainv1alpha1.Idler{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Idler{}
@@ -981,13 +971,13 @@ func (a *MemberAwaitility) WaitForIdler(name string, criteria ...IdlerWaitCriter
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printIdlerWaitCriteriaDiffs(idler, criteria...)
+		a.printIdlerWaitCriteriaDiffs(t, idler, criteria...)
 	}
 	return idler, err
 }
 
 // UpdateIdlerSpec tries to update the Idler.Spec until success
-func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*toolchainv1alpha1.Idler, error) {
+func (a *MemberAwaitility) UpdateIdlerSpec(t *testing.T, idler *toolchainv1alpha1.Idler) (*toolchainv1alpha1.Idler, error) {
 	var result *toolchainv1alpha1.Idler
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Idler{}
@@ -996,7 +986,7 @@ func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*too
 		}
 		obj.Spec = idler.Spec
 		if err := a.Client.Update(context.TODO(), obj); err != nil {
-			a.T.Logf("trying to update Idler %s. Error: %s. Will try to update again.", idler.Name, err.Error())
+			t.Logf("trying to update Idler %s. Error: %s. Will try to update again.", idler.Name, err.Error())
 			return false, nil
 		}
 		result = obj
@@ -1008,7 +998,7 @@ func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*too
 // UpdateNSTemplateSet tries to update the Spec of the given NSTemplateSet
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated NSTemplateSet
-func (a *MemberAwaitility) UpdateNSTemplateSet(spaceName string, modifyNSTemplateSet func(nsTmplSet *toolchainv1alpha1.NSTemplateSet)) (*toolchainv1alpha1.NSTemplateSet, error) {
+func (a *MemberAwaitility) UpdateNSTemplateSet(t *testing.T, spaceName string, modifyNSTemplateSet func(nsTmplSet *toolchainv1alpha1.NSTemplateSet)) *toolchainv1alpha1.NSTemplateSet {
 	var nsTmplSet *toolchainv1alpha1.NSTemplateSet
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshNSTmplSet := &toolchainv1alpha1.NSTemplateSet{}
@@ -1017,25 +1007,27 @@ func (a *MemberAwaitility) UpdateNSTemplateSet(spaceName string, modifyNSTemplat
 		}
 		modifyNSTemplateSet(freshNSTmplSet)
 		if err := a.Client.Update(context.TODO(), freshNSTmplSet); err != nil {
-			a.T.Logf("error updating NSTemplateSet '%s': %s. Will retry again...", spaceName, err.Error())
+			t.Logf("error updating NSTemplateSet '%s': %s. Will retry again...", spaceName, err.Error())
 			return false, nil
 		}
 		nsTmplSet = freshNSTmplSet
 		return true, nil
 	})
-	return nsTmplSet, err
+	require.NoError(t, err)
+	return nsTmplSet
 }
 
 // Create tries to create the object until success
 // Workaround for https://github.com/kubernetes/kubernetes/issues/67761
-func (a *MemberAwaitility) Create(obj client.Object) error {
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) Create(t *testing.T, obj client.Object) {
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		if err := a.Client.Create(context.TODO(), obj); err != nil {
-			a.T.Logf("trying to create %+v. Error: %s. Will try to create again.", obj, err.Error())
+			t.Logf("trying to create %+v. Error: %s. Will try to create again.", obj, err.Error())
 			return false, nil
 		}
 		return true, nil
 	})
+	require.NoError(t, err)
 }
 
 // PodWaitCriterion a struct to compare with a given Pod
@@ -1053,7 +1045,7 @@ func matchPodWaitCriterion(actual *corev1.Pod, criteria ...PodWaitCriterion) boo
 	return true
 }
 
-func (a *MemberAwaitility) printPodWaitCriterionDiffs(actual *corev1.Pod, ns string, criteria ...PodWaitCriterion) {
+func (a *MemberAwaitility) printPodWaitCriterionDiffs(t *testing.T, actual *corev1.Pod, ns string, criteria ...PodWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Pod\n")
@@ -1067,12 +1059,12 @@ func (a *MemberAwaitility) printPodWaitCriterionDiffs(actual *corev1.Pod, ns str
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForPod waits until a pod with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForPod(namespace, name string, criteria ...PodWaitCriterion) (*corev1.Pod, error) {
-	a.T.Logf("waiting for Pod '%s' in namespace '%s' with matching criteria", name, namespace)
+func (a *MemberAwaitility) WaitForPod(t *testing.T, namespace, name string, criteria ...PodWaitCriterion) *corev1.Pod {
+	t.Logf("waiting for Pod '%s' in namespace '%s' with matching criteria", name, namespace)
 	var pod *corev1.Pod
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Pod{}
@@ -1092,14 +1084,15 @@ func (a *MemberAwaitility) WaitForPod(namespace, name string, criteria ...PodWai
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printPodWaitCriterionDiffs(pod, namespace, criteria...)
+		a.printPodWaitCriterionDiffs(t, pod, namespace, criteria...)
 	}
-	return pod, err
+	require.NoError(t, err)
+	return pod
 }
 
 // WaitForConfigMap waits until a ConfigMap with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
-	a.T.Logf("waiting for ConfigMap '%s' in namespace '%s'", name, namespace)
+func (a *MemberAwaitility) WaitForConfigMap(t *testing.T, namespace, name string) *corev1.ConfigMap {
+	t.Logf("waiting for ConfigMap '%s' in namespace '%s'", name, namespace)
 	var cm *corev1.ConfigMap
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ConfigMap{}
@@ -1117,12 +1110,13 @@ func (a *MemberAwaitility) WaitForConfigMap(namespace, name string) (*corev1.Con
 		cm = obj
 		return true, nil
 	})
-	return cm, err
+	require.NoError(t, err)
+	return cm
 }
 
 // WaitForPods waits until "n" number of pods exist in the given namespace
-func (a *MemberAwaitility) WaitForPods(namespace string, n int, criteria ...PodWaitCriterion) ([]corev1.Pod, error) {
-	a.T.Logf("waiting for Pods in namespace '%s' with matching criteria", namespace)
+func (a *MemberAwaitility) WaitForPods(t *testing.T, namespace string, n int, criteria ...PodWaitCriterion) []corev1.Pod {
+	t.Logf("waiting for Pods in namespace '%s' with matching criteria", namespace)
 	pods := make([]corev1.Pod, 0, n)
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		pds := make([]corev1.Pod, 0, n)
@@ -1145,13 +1139,14 @@ func (a *MemberAwaitility) WaitForPods(namespace string, n int, criteria ...PodW
 		pods = pds
 		return true, nil
 	})
-	return pods, err
+	require.NoError(t, err)
+	return pods
 }
 
 // WaitUntilPodsDeleted waits until the pods are deleted from the given namespace
-func (a *MemberAwaitility) WaitUntilPodsDeleted(namespace string, criteria ...PodWaitCriterion) error {
-	a.T.Logf("waiting until Pods with matching criteria in namespace '%s' are deleted", namespace)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilPodsDeleted(t *testing.T, namespace string, criteria ...PodWaitCriterion) {
+	t.Logf("waiting until Pods with matching criteria in namespace '%s' are deleted", namespace)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		foundPods := &corev1.PodList{}
 		if err := a.Client.List(context.TODO(), foundPods, &client.ListOptions{Namespace: namespace}); err != nil {
 			return false, err
@@ -1167,12 +1162,13 @@ func (a *MemberAwaitility) WaitUntilPodsDeleted(namespace string, criteria ...Po
 		}
 		return true, nil
 	})
+	require.NoError(t, err)
 }
 
 // WaitUntilPodDeleted waits until the pod with the given name is deleted from the given namespace
-func (a *MemberAwaitility) WaitUntilPodDeleted(namespace, name string) error {
-	a.T.Logf("waiting until Pod '%s' in namespace '%s' is deleted", name, namespace)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilPodDeleted(t *testing.T, namespace, name string) {
+	t.Logf("waiting until Pod '%s' in namespace '%s' is deleted", name, namespace)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Pod{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, obj); err != nil {
 			if errors.IsNotFound(err) {
@@ -1185,6 +1181,7 @@ func (a *MemberAwaitility) WaitUntilPodDeleted(namespace, name string) error {
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
 // PodRunning checks if the Pod in the running phase
@@ -1256,9 +1253,9 @@ func checkPriorityClass(pod *corev1.Pod, name string, priority int) bool {
 }
 
 // WaitUntilNamespaceDeleted waits until the namespace with the given name is deleted (ie, is not found)
-func (a *MemberAwaitility) WaitUntilNamespaceDeleted(username, typeName string) error {
-	a.T.Logf("waiting until namespace for user '%s' and type '%s' is deleted", username, typeName)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilNamespaceDeleted(t *testing.T, username, typeName string) {
+	t.Logf("waiting until namespace for user '%s' and type '%s' is deleted", username, typeName)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{
 			"toolchain.dev.openshift.com/owner": username,
 			"toolchain.dev.openshift.com/type":  typeName,
@@ -1273,6 +1270,7 @@ func (a *MemberAwaitility) WaitUntilNamespaceDeleted(username, typeName string) 
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
 // UserWaitCriterion a struct to compare with a given User
@@ -1290,7 +1288,7 @@ func matchUserWaitCriterion(actual *userv1.User, criteria ...UserWaitCriterion) 
 	return true
 }
 
-func (a *MemberAwaitility) printUserWaitCriterionDiffs(actual *userv1.User, criteria ...UserWaitCriterion) {
+func (a *MemberAwaitility) printUserWaitCriterionDiffs(t *testing.T, actual *userv1.User, criteria ...UserWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find User\n")
@@ -1304,12 +1302,12 @@ func (a *MemberAwaitility) printUserWaitCriterionDiffs(actual *userv1.User, crit
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForUser waits until there is a User with the given name available
-func (a *MemberAwaitility) WaitForUser(name string, criteria ...UserWaitCriterion) (*userv1.User, error) {
-	a.T.Logf("waiting for User '%s'", name)
+func (a *MemberAwaitility) WaitForUser(t *testing.T, name string, criteria ...UserWaitCriterion) *userv1.User {
+	t.Logf("waiting for User '%s'", name)
 	user := &userv1.User{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		user = &userv1.User{}
@@ -1328,9 +1326,10 @@ func (a *MemberAwaitility) WaitForUser(name string, criteria ...UserWaitCriterio
 		return false, nil
 	})
 	if err != nil {
-		a.printUserWaitCriterionDiffs(user, criteria...)
+		a.printUserWaitCriterionDiffs(t, user, criteria...)
 	}
-	return user, err
+	require.NoError(t, err)
+	return user
 }
 
 // UntilUserHasLabel checks if the User has the expected label
@@ -1374,8 +1373,8 @@ func matchIdentityWaitCriterion(actual *userv1.Identity, criteria ...IdentityWai
 }
 
 // WaitForIdentity waits until there is an Identity with the given name available
-func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWaitCriterion) (*userv1.Identity, error) {
-	a.T.Logf("waiting for Identity '%s'", name)
+func (a *MemberAwaitility) WaitForIdentity(t *testing.T, name string, criteria ...IdentityWaitCriterion) *userv1.Identity {
+	t.Logf("waiting for Identity '%s'", name)
 	identity := &userv1.Identity{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		identity = &userv1.Identity{}
@@ -1394,16 +1393,17 @@ func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWait
 		return false, nil
 	})
 	if err != nil {
-		a.printIdentities(name)
+		a.printIdentities(t, name)
 	}
-	return identity, err
+	require.NoError(t, err)
+	return identity
 }
 
-func (a *MemberAwaitility) printIdentities(expectedName string) {
+func (a *MemberAwaitility) printIdentities(t *testing.T, expectedName string) {
 	buf := &strings.Builder{}
 	buf.WriteString(fmt.Sprintf("failed to find Identity '%s'\n", expectedName))
 	buf.WriteString(a.listAndReturnContent("Identity", "", &userv1.IdentityList{}))
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilIdentityHasLabel checks if the Identity has the expected label
@@ -1419,9 +1419,9 @@ func UntilIdentityHasLabel(key, value string) IdentityWaitCriterion {
 }
 
 // WaitUntilUserAccountDeleted waits until the UserAccount with the given name is not found
-func (a *MemberAwaitility) WaitUntilUserAccountDeleted(name string) error {
-	a.T.Logf("waiting until UserAccount '%s' in namespace '%s' is deleted", name, a.Namespace)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilUserAccountDeleted(t *testing.T, name string) {
+	t.Logf("waiting until UserAccount '%s' in namespace '%s' is deleted", name, a.Namespace)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		ua := &toolchainv1alpha1.UserAccount{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, ua); err != nil {
 			if errors.IsNotFound(err) {
@@ -1431,12 +1431,13 @@ func (a *MemberAwaitility) WaitUntilUserAccountDeleted(name string) error {
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
 // WaitUntilUserDeleted waits until the User with the given name is not found
-func (a *MemberAwaitility) WaitUntilUserDeleted(name string) error {
-	a.T.Logf("waiting until User is deleted '%s'", name)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilUserDeleted(t *testing.T, name string) {
+	t.Logf("waiting until User is deleted '%s'", name)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		user := &userv1.User{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, user); err != nil {
 			if errors.IsNotFound(err) {
@@ -1449,12 +1450,13 @@ func (a *MemberAwaitility) WaitUntilUserDeleted(name string) error {
 		}
 		return true, nil
 	})
+	require.NoError(t, err)
 }
 
 // WaitUntilIdentityDeleted waits until the Identity with the given name is not found
-func (a *MemberAwaitility) WaitUntilIdentityDeleted(name string) error {
-	a.T.Logf("waiting until Identity is deleted '%s'", name)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilIdentityDeleted(t *testing.T, name string) {
+	t.Logf("waiting until Identity is deleted '%s'", name)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		identity := &userv1.Identity{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, identity); err != nil {
 			if errors.IsNotFound(err) {
@@ -1467,21 +1469,22 @@ func (a *MemberAwaitility) WaitUntilIdentityDeleted(name string) error {
 		}
 		return true, nil
 	})
+	require.NoError(t, err)
 }
 
 // GetConsoleURL retrieves Web Console Route and returns its URL
-func (a *MemberAwaitility) GetConsoleURL() string {
+func (a *MemberAwaitility) GetConsoleURL(t *testing.T) string {
 	route := &routev1.Route{}
 	namespacedName := types.NamespacedName{Namespace: "openshift-console", Name: "console"}
 	err := a.Client.Get(context.TODO(), namespacedName, route)
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	return fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
 }
 
 // WaitUntilClusterResourceQuotasDeleted waits until all ClusterResourceQuotas with the given owner label are deleted (ie, none is found)
-func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(username string) error {
-	a.T.Logf("waiting for deletion of ClusterResourceQuotas for user '%s'", username)
-	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
+func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(t *testing.T, username string) {
+	t.Logf("waiting for deletion of ClusterResourceQuotas for user '%s'", username)
+	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{"toolchain.dev.openshift.com/owner": username}
 		opts := client.MatchingLabels(labels)
 		quotaList := &quotav1.ClusterResourceQuotaList{}
@@ -1493,6 +1496,7 @@ func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(username string
 		}
 		return false, nil
 	})
+	require.NoError(t, err)
 }
 
 // MemberStatusWaitCriterion a struct to compare with a given MemberStatus
@@ -1510,7 +1514,7 @@ func matchMemberStatusWaitCriterion(actual *toolchainv1alpha1.MemberStatus, crit
 	return true
 }
 
-func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(actual *toolchainv1alpha1.MemberStatus, criteria ...MemberStatusWaitCriterion) {
+func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.MemberStatus, criteria ...MemberStatusWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find MemberStatus\n")
@@ -1531,7 +1535,7 @@ func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(actual *toolchain
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilMemberStatusHasConditions returns a `MemberStatusWaitCriterion` which checks that the given
@@ -1583,9 +1587,9 @@ func UntilMemberStatusHasConsoleURLSet(expectedURL string, expectedCondition too
 }
 
 // WaitForMemberStatus waits until the MemberStatus is available with the provided criteria, if any
-func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCriterion) error {
+func (a *MemberAwaitility) WaitForMemberStatus(t *testing.T, criteria ...MemberStatusWaitCriterion) {
 	name := "toolchain-member-status"
-	a.T.Logf("waiting for MemberStatus '%s' to match criteria", name)
+	t.Logf("waiting for MemberStatus '%s' to match criteria", name)
 	// there should only be one member status with the name toolchain-member-status
 	var memberStatus *toolchainv1alpha1.MemberStatus
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
@@ -1607,19 +1611,19 @@ func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCrite
 		return matchMemberStatusWaitCriterion(obj, criteria...), nil
 	})
 	if err != nil {
-		a.printMemberStatusWaitCriterionDiffs(memberStatus, criteria...)
+		a.printMemberStatusWaitCriterionDiffs(t, memberStatus, criteria...)
 	}
-	return err
+	require.NoError(t, err)
 }
 
 // GetMemberOperatorConfig returns MemberOperatorConfig instance, nil if not found
-func (a *MemberAwaitility) GetMemberOperatorConfig() *toolchainv1alpha1.MemberOperatorConfig {
+func (a *MemberAwaitility) GetMemberOperatorConfig(t *testing.T) *toolchainv1alpha1.MemberOperatorConfig {
 	config := &toolchainv1alpha1.MemberOperatorConfig{}
 	if err := a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, "config"), config); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		require.NoError(a.T, err)
+		require.NoError(t, err)
 	}
 	return config
 }
@@ -1636,10 +1640,10 @@ func UntilMemberConfigMatches(expectedMemberOperatorConfigSpec toolchainv1alpha1
 }
 
 // WaitForMemberOperatorConfig waits until the MemberOperatorConfig is available with the provided criteria, if any
-func (a *MemberAwaitility) WaitForMemberOperatorConfig(hostAwait *HostAwaitility, criteria ...MemberOperatorConfigWaitCriterion) (*toolchainv1alpha1.MemberOperatorConfig, error) {
+func (a *MemberAwaitility) WaitForMemberOperatorConfig(t *testing.T, hostAwait *HostAwaitility, criteria ...MemberOperatorConfigWaitCriterion) *toolchainv1alpha1.MemberOperatorConfig {
 	// there should only be one MemberOperatorConfig with the name config
 	name := "config"
-	a.T.Logf("waiting for MemberOperatorConfig '%s'", name)
+	t.Logf("waiting for MemberOperatorConfig '%s'", name)
 	memberOperatorConfig := &toolchainv1alpha1.MemberOperatorConfig{}
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
 		memberOperatorConfig = &toolchainv1alpha1.MemberOperatorConfig{}
@@ -1663,42 +1667,40 @@ func (a *MemberAwaitility) WaitForMemberOperatorConfig(hostAwait *HostAwaitility
 		}
 		return true, nil
 	})
-	return memberOperatorConfig, err
+	require.NoError(t, err)
+	return memberOperatorConfig
 }
 
 // GetMemberOperatorPod returns the pod running the member operator controllers
-func (a *MemberAwaitility) GetMemberOperatorPod() (corev1.Pod, error) {
+func (a *MemberAwaitility) GetMemberOperatorPod(t *testing.T) *corev1.Pod {
 	pods := corev1.PodList{}
-	if err := a.Client.List(context.TODO(), &pods, client.InNamespace(a.Namespace), client.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
-		return corev1.Pod{}, err
-	}
-	if len(pods.Items) != 1 {
-		return corev1.Pod{}, fmt.Errorf("unexpected number of pods with label 'control-plane=controller-manager' in namespace '%s': %d ", a.Namespace, len(pods.Items))
-	}
-	return pods.Items[0], nil
+	err := a.Client.List(context.TODO(), &pods, client.InNamespace(a.Namespace), client.MatchingLabels{"control-plane": "controller-manager"})
+	require.NoError(t, err)
+	require.Len(t, pods.Items, 1, "unexpected number of pods with label 'control-plane=controller-manager' in namespace '%s': %d ", a.Namespace, len(pods.Items))
+	return &pods.Items[0]
 }
 
-func (a *MemberAwaitility) WaitForMemberWebhooks(image string) {
-	a.waitForUsersPodPriorityClass()
-	a.waitForService()
-	a.waitForWebhookDeployment(image)
-	ca := a.verifySecret()
-	a.verifyUserPodWebhookConfig(ca)
-	a.verifyUsersRolebindingsWebhookConfig(ca)
+func (a *MemberAwaitility) WaitForMemberWebhooks(t *testing.T, image string) {
+	a.waitForUsersPodPriorityClass(t)
+	a.waitForService(t)
+	a.waitForWebhookDeployment(t, image)
+	ca := a.verifySecret(t)
+	a.verifyUserPodWebhookConfig(t, ca)
+	a.verifyUsersRolebindingsWebhookConfig(t, ca)
 }
 
-func (a *MemberAwaitility) waitForUsersPodPriorityClass() {
-	a.T.Logf("checking PrioritiyClass resource '%s'", "sandbox-users-pods")
+func (a *MemberAwaitility) waitForUsersPodPriorityClass(t *testing.T) {
+	t.Logf("checking PrioritiyClass resource '%s'", "sandbox-users-pods")
 	actualPrioClass := &schedulingv1.PriorityClass{}
-	a.waitForResource("", "sandbox-users-pods", actualPrioClass)
+	a.waitForResource(t, "", "sandbox-users-pods", actualPrioClass)
 
-	assert.Equal(a.T, codereadyToolchainProviderLabel, actualPrioClass.Labels)
-	assert.Equal(a.T, int32(-3), actualPrioClass.Value)
-	assert.False(a.T, actualPrioClass.GlobalDefault)
-	assert.Equal(a.T, "Priority class for pods in users' namespaces", actualPrioClass.Description)
+	assert.Equal(t, codereadyToolchainProviderLabel, actualPrioClass.Labels)
+	assert.Equal(t, int32(-3), actualPrioClass.Value)
+	assert.False(t, actualPrioClass.GlobalDefault)
+	assert.Equal(t, "Priority class for pods in users' namespaces", actualPrioClass.Description)
 }
 
-func (a *MemberAwaitility) waitForResource(namespace, name string, object client.Object) {
+func (a *MemberAwaitility) waitForResource(t *testing.T, namespace, name string, object client.Object) {
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		if err := a.Client.Get(context.TODO(), test.NamespacedName(namespace, name), object); err != nil {
 			if errors.IsNotFound(err) {
@@ -1708,219 +1710,211 @@ func (a *MemberAwaitility) waitForResource(namespace, name string, object client
 		}
 		return true, nil
 	})
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 }
 
-func (a *MemberAwaitility) waitForService() {
-	a.T.Logf("waiting for Service '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
+func (a *MemberAwaitility) waitForService(t *testing.T) {
+	t.Logf("waiting for Service '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
 	actualService := &corev1.Service{}
-	a.waitForResource(a.Namespace, "member-operator-webhook", actualService)
-	assert.Equal(a.T, map[string]string{
+	a.waitForResource(t, a.Namespace, "member-operator-webhook", actualService)
+	assert.Equal(t, map[string]string{
 		"app":                                  "member-operator-webhook",
 		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 	}, actualService.Labels)
-	require.Len(a.T, actualService.Spec.Ports, 1)
-	assert.Equal(a.T, int32(443), actualService.Spec.Ports[0].Port)
-	assert.Equal(a.T, intstr.IntOrString{
+	require.Len(t, actualService.Spec.Ports, 1)
+	assert.Equal(t, int32(443), actualService.Spec.Ports[0].Port)
+	assert.Equal(t, intstr.IntOrString{
 		IntVal: 8443,
 	}, actualService.Spec.Ports[0].TargetPort)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualService.Spec.Selector)
+	assert.Equal(t, appMemberOperatorWebhookLabel, actualService.Spec.Selector)
 }
 
-func (a *MemberAwaitility) waitForWebhookDeployment(image string) {
-	a.T.Logf("checking Deployment '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
-	actualDeployment := a.WaitForDeploymentToGetReady("member-operator-webhook", 1,
+func (a *MemberAwaitility) waitForWebhookDeployment(t *testing.T, image string) {
+	t.Logf("checking Deployment '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
+	actualDeployment := a.WaitForDeploymentToGetReady(t, "member-operator-webhook", 1,
 		DeploymentHasContainerWithImage("mutator", image))
 
-	assert.Equal(a.T, bothWebhookLabels, actualDeployment.Labels)
-	assert.Equal(a.T, int32(1), *actualDeployment.Spec.Replicas)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
+	assert.Equal(t, bothWebhookLabels, actualDeployment.Labels)
+	assert.Equal(t, int32(1), *actualDeployment.Spec.Replicas)
+	assert.Equal(t, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
 
 	template := actualDeployment.Spec.Template
-	assert.Equal(a.T, "member-operator-webhook", template.ObjectMeta.Name)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
-	require.Len(a.T, template.Spec.Volumes, 1)
-	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Name)
-	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
-	require.Len(a.T, template.Spec.Containers, 1)
+	assert.Equal(t, "member-operator-webhook", template.ObjectMeta.Name)
+	assert.Equal(t, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
+	require.Len(t, template.Spec.Volumes, 1)
+	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Name)
+	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
+	require.Len(t, template.Spec.Containers, 1)
 
 	container := template.Spec.Containers[0]
-	assert.Equal(a.T, "mutator", container.Name)
-	assert.NotEmpty(a.T, container.Image)
-	assert.Equal(a.T, []string{"member-operator-webhook"}, container.Command)
-	assert.Equal(a.T, corev1.PullIfNotPresent, container.ImagePullPolicy)
-	assert.NotEmpty(a.T, container.Resources)
+	assert.Equal(t, "mutator", container.Name)
+	assert.NotEmpty(t, container.Image)
+	assert.Equal(t, []string{"member-operator-webhook"}, container.Command)
+	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.NotEmpty(t, container.Resources)
 
-	assert.Len(a.T, container.VolumeMounts, 1)
-	assert.Equal(a.T, "webhook-certs", container.VolumeMounts[0].Name)
-	assert.Equal(a.T, "/etc/webhook/certs", container.VolumeMounts[0].MountPath)
-	assert.True(a.T, container.VolumeMounts[0].ReadOnly)
+	assert.Len(t, container.VolumeMounts, 1)
+	assert.Equal(t, "webhook-certs", container.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/webhook/certs", container.VolumeMounts[0].MountPath)
+	assert.True(t, container.VolumeMounts[0].ReadOnly)
 
-	a.WaitForDeploymentToGetReady("member-operator-webhook", 1)
+	a.WaitForDeploymentToGetReady(t, "member-operator-webhook", 1)
 }
 
-func (a *MemberAwaitility) verifySecret() []byte {
-	a.T.Logf("checking Secret '%s' in namespace '%s'", "webhook-certs", a.Namespace)
+func (a *MemberAwaitility) verifySecret(t *testing.T) []byte {
+	t.Logf("checking Secret '%s' in namespace '%s'", "webhook-certs", a.Namespace)
 	secret := &corev1.Secret{}
-	a.waitForResource(a.Namespace, "webhook-certs", secret)
-	assert.NotEmpty(a.T, secret.Data["server-key.pem"])
-	assert.NotEmpty(a.T, secret.Data["server-cert.pem"])
+	a.waitForResource(t, a.Namespace, "webhook-certs", secret)
+	assert.NotEmpty(t, secret.Data["server-key.pem"])
+	assert.NotEmpty(t, secret.Data["server-cert.pem"])
 	ca := secret.Data["ca-cert.pem"]
-	assert.NotEmpty(a.T, ca)
+	assert.NotEmpty(t, ca)
 	return ca
 }
 
-func (a *MemberAwaitility) verifyUserPodWebhookConfig(ca []byte) {
-	a.T.Logf("checking MutatingWebhookConfiguration '%s'", "sandbox-users-pods")
+func (a *MemberAwaitility) verifyUserPodWebhookConfig(t *testing.T, ca []byte) {
+	t.Logf("checking MutatingWebhookConfiguration '%s'", "sandbox-users-pods")
 	actualMutWbhConf := &admv1.MutatingWebhookConfiguration{}
-	a.waitForResource("", "member-operator-webhook", actualMutWbhConf)
-	assert.Equal(a.T, bothWebhookLabels, actualMutWbhConf.Labels)
-	require.Len(a.T, actualMutWbhConf.Webhooks, 1)
+	a.waitForResource(t, "", "member-operator-webhook", actualMutWbhConf)
+	assert.Equal(t, bothWebhookLabels, actualMutWbhConf.Labels)
+	require.Len(t, actualMutWbhConf.Webhooks, 1)
 
 	webhook := actualMutWbhConf.Webhooks[0]
-	assert.Equal(a.T, "users.pods.webhook.sandbox", webhook.Name)
-	assert.Equal(a.T, []string{"v1"}, webhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *webhook.SideEffects)
-	assert.Equal(a.T, int32(5), *webhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
-	assert.Equal(a.T, admv1.Ignore, *webhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *webhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, webhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, webhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", webhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, webhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/mutate-users-pods", *webhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *webhook.ClientConfig.Service.Port)
-	require.Len(a.T, webhook.Rules, 1)
+	assert.Equal(t, "users.pods.webhook.sandbox", webhook.Name)
+	assert.Equal(t, []string{"v1"}, webhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *webhook.SideEffects)
+	assert.Equal(t, int32(5), *webhook.TimeoutSeconds)
+	assert.Equal(t, admv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
+	assert.Equal(t, admv1.Ignore, *webhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *webhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, webhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, webhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", webhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, webhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/mutate-users-pods", *webhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *webhook.ClientConfig.Service.Port)
+	require.Len(t, webhook.Rules, 1)
 
 	rule := webhook.Rules[0]
-	//assert.Equal(a.T, []admv1.OperationType{admv1.Create}, rule.Operations)
-	assert.Equal(a.T, []string{""}, rule.APIGroups)
-	assert.Equal(a.T, []string{"v1"}, rule.APIVersions)
-	assert.Equal(a.T, []string{"pods"}, rule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *rule.Scope)
+	//assert.Equal(t, []admv1.OperationType{admv1.Create}, rule.Operations)
+	assert.Equal(t, []string{""}, rule.APIGroups)
+	assert.Equal(t, []string{"v1"}, rule.APIVersions)
+	assert.Equal(t, []string{"pods"}, rule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *rule.Scope)
 }
 
-func (a *MemberAwaitility) verifyUsersRolebindingsWebhookConfig(ca []byte) {
-	a.T.Logf("checking ValidatingWebhookConfiguration '%s'", "member-operator-validating-webhook")
+func (a *MemberAwaitility) verifyUsersRolebindingsWebhookConfig(t *testing.T, ca []byte) {
+	t.Logf("checking ValidatingWebhookConfiguration '%s'", "member-operator-validating-webhook")
 	actualValWbhConf := &admv1.ValidatingWebhookConfiguration{}
-	a.waitForResource("", "member-operator-validating-webhook", actualValWbhConf)
-	assert.Equal(a.T, bothWebhookLabels, actualValWbhConf.Labels)
-	// require.Len(a.T, actualValWbhConf.Webhooks, 2)
+	a.waitForResource(t, "", "member-operator-validating-webhook", actualValWbhConf)
+	assert.Equal(t, bothWebhookLabels, actualValWbhConf.Labels)
+	// require.Len(t, actualValWbhConf.Webhooks, 2)
 
 	rolebindingWebhook := actualValWbhConf.Webhooks[0]
-	assert.Equal(a.T, "users.rolebindings.webhook.sandbox", rolebindingWebhook.Name)
-	assert.Equal(a.T, []string{"v1"}, rolebindingWebhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *rolebindingWebhook.SideEffects)
-	assert.Equal(a.T, int32(5), *rolebindingWebhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.Ignore, *rolebindingWebhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *rolebindingWebhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, rolebindingWebhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, rolebindingWebhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", rolebindingWebhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, rolebindingWebhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/validate-users-rolebindings", *rolebindingWebhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *rolebindingWebhook.ClientConfig.Service.Port)
-	require.Len(a.T, rolebindingWebhook.Rules, 1)
+	assert.Equal(t, "users.rolebindings.webhook.sandbox", rolebindingWebhook.Name)
+	assert.Equal(t, []string{"v1"}, rolebindingWebhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *rolebindingWebhook.SideEffects)
+	assert.Equal(t, int32(5), *rolebindingWebhook.TimeoutSeconds)
+	assert.Equal(t, admv1.Ignore, *rolebindingWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *rolebindingWebhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, rolebindingWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, rolebindingWebhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", rolebindingWebhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, rolebindingWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/validate-users-rolebindings", *rolebindingWebhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *rolebindingWebhook.ClientConfig.Service.Port)
+	require.Len(t, rolebindingWebhook.Rules, 1)
 
 	rolebindingRule := rolebindingWebhook.Rules[0]
-	assert.Equal(a.T, []admv1.OperationType{admv1.Create, admv1.Update}, rolebindingRule.Operations)
-	assert.Equal(a.T, []string{"rbac.authorization.k8s.io", "authorization.openshift.io"}, rolebindingRule.APIGroups)
-	assert.Equal(a.T, []string{"v1"}, rolebindingRule.APIVersions)
-	assert.Equal(a.T, []string{"rolebindings"}, rolebindingRule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *rolebindingRule.Scope)
+	assert.Equal(t, []admv1.OperationType{admv1.Create, admv1.Update}, rolebindingRule.Operations)
+	assert.Equal(t, []string{"rbac.authorization.k8s.io", "authorization.openshift.io"}, rolebindingRule.APIGroups)
+	assert.Equal(t, []string{"v1"}, rolebindingRule.APIVersions)
+	assert.Equal(t, []string{"rolebindings"}, rolebindingRule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *rolebindingRule.Scope)
 
 	checlusterWebhook := actualValWbhConf.Webhooks[1]
-	assert.Equal(a.T, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
-	assert.Equal(a.T, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
-	assert.Equal(a.T, int32(5), *checlusterWebhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.Ignore, *checlusterWebhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, checlusterWebhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
-	require.Len(a.T, checlusterWebhook.Rules, 1)
+	assert.Equal(t, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
+	assert.Equal(t, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
+	assert.Equal(t, int32(5), *checlusterWebhook.TimeoutSeconds)
+	assert.Equal(t, admv1.Ignore, *checlusterWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, checlusterWebhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
+	require.Len(t, checlusterWebhook.Rules, 1)
 
 	checlusterRule := checlusterWebhook.Rules[0]
-	assert.Equal(a.T, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
-	assert.Equal(a.T, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
-	assert.Equal(a.T, []string{"v2"}, checlusterRule.APIVersions)
-	assert.Equal(a.T, []string{"checlusters"}, checlusterRule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *checlusterRule.Scope)
+	assert.Equal(t, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
+	assert.Equal(t, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
+	assert.Equal(t, []string{"v2"}, checlusterRule.APIVersions)
+	assert.Equal(t, []string{"checlusters"}, checlusterRule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *checlusterRule.Scope)
 
 }
 
-func (a *MemberAwaitility) WaitForAutoscalingBufferApp() {
-	a.verifyAutoscalingBufferPriorityClass()
-	a.verifyAutoscalingBufferDeployment()
+func (a *MemberAwaitility) WaitForAutoscalingBufferApp(t *testing.T) {
+	a.verifyAutoscalingBufferPriorityClass(t)
+	a.verifyAutoscalingBufferDeployment(t)
 }
 
-func (a *MemberAwaitility) verifyAutoscalingBufferPriorityClass() {
-	a.T.Logf("checking PrioritiyClass '%s'", "member-operator-autoscaling-buffer")
+func (a *MemberAwaitility) verifyAutoscalingBufferPriorityClass(t *testing.T) {
+	t.Logf("checking PrioritiyClass '%s'", "member-operator-autoscaling-buffer")
 	actualPrioClass := &schedulingv1.PriorityClass{}
-	a.waitForResource("", "member-operator-autoscaling-buffer", actualPrioClass)
+	a.waitForResource(t, "", "member-operator-autoscaling-buffer", actualPrioClass)
 
-	assert.Equal(a.T, codereadyToolchainProviderLabel, actualPrioClass.Labels)
-	assert.Equal(a.T, int32(-5), actualPrioClass.Value)
-	assert.False(a.T, actualPrioClass.GlobalDefault)
-	assert.Equal(a.T, "This priority class is to be used by the autoscaling buffer pod only", actualPrioClass.Description)
+	assert.Equal(t, codereadyToolchainProviderLabel, actualPrioClass.Labels)
+	assert.Equal(t, int32(-5), actualPrioClass.Value)
+	assert.False(t, actualPrioClass.GlobalDefault)
+	assert.Equal(t, "This priority class is to be used by the autoscaling buffer pod only", actualPrioClass.Description)
 }
 
-func (a *MemberAwaitility) verifyAutoscalingBufferDeployment() {
-	a.T.Logf("checking Deployment '%s' in namespace '%s'", "autoscaling-buffer", a.Namespace)
+func (a *MemberAwaitility) verifyAutoscalingBufferDeployment(t *testing.T) {
+	t.Logf("checking Deployment '%s' in namespace '%s'", "autoscaling-buffer", a.Namespace)
 	actualDeployment := &appsv1.Deployment{}
-	a.waitForResource(a.Namespace, "autoscaling-buffer", actualDeployment)
+	a.waitForResource(t, a.Namespace, "autoscaling-buffer", actualDeployment)
 
-	assert.Equal(a.T, map[string]string{
+	assert.Equal(t, map[string]string{
 		"app":                                  "autoscaling-buffer",
 		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 	}, actualDeployment.Labels)
-	assert.Equal(a.T, int32(2), *actualDeployment.Spec.Replicas)
-	assert.Equal(a.T, map[string]string{"app": "autoscaling-buffer"}, actualDeployment.Spec.Selector.MatchLabels)
+	assert.Equal(t, int32(2), *actualDeployment.Spec.Replicas)
+	assert.Equal(t, map[string]string{"app": "autoscaling-buffer"}, actualDeployment.Spec.Selector.MatchLabels)
 
 	template := actualDeployment.Spec.Template
-	assert.Equal(a.T, map[string]string{"app": "autoscaling-buffer"}, template.ObjectMeta.Labels)
+	assert.Equal(t, map[string]string{"app": "autoscaling-buffer"}, template.ObjectMeta.Labels)
 
-	assert.Equal(a.T, "member-operator-autoscaling-buffer", template.Spec.PriorityClassName)
-	assert.Equal(a.T, int64(0), *template.Spec.TerminationGracePeriodSeconds)
+	assert.Equal(t, "member-operator-autoscaling-buffer", template.Spec.PriorityClassName)
+	assert.Equal(t, int64(0), *template.Spec.TerminationGracePeriodSeconds)
 
-	require.Len(a.T, template.Spec.Containers, 1)
+	require.Len(t, template.Spec.Containers, 1)
 	container := template.Spec.Containers[0]
-	assert.Equal(a.T, "autoscaling-buffer", container.Name)
-	assert.Equal(a.T, "gcr.io/google_containers/pause-amd64:3.2", container.Image)
-	assert.Equal(a.T, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.Equal(t, "autoscaling-buffer", container.Name)
+	assert.Equal(t, "gcr.io/google_containers/pause-amd64:3.2", container.Image)
+	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
 
 	expectedMemory, err := resource.ParseQuantity("50Mi")
-	require.NoError(a.T, err)
-	assert.True(a.T, container.Resources.Requests.Memory().Equal(expectedMemory))
-	assert.True(a.T, container.Resources.Limits.Memory().Equal(expectedMemory))
+	require.NoError(t, err)
+	assert.True(t, container.Resources.Requests.Memory().Equal(expectedMemory))
+	assert.True(t, container.Resources.Limits.Memory().Equal(expectedMemory))
 
-	a.WaitForDeploymentToGetReady("autoscaling-buffer", 2)
+	a.WaitForDeploymentToGetReady(t, "autoscaling-buffer", 2)
 }
 
 // WaitForExpectedNumberOfResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfResources(namespace, kind string, expected int, list func() (int, error)) error {
-	if actual, err := a.waitForExpectedNumberOfResources(expected, list); err != nil {
-		a.T.Logf("expected number of resources of kind '%s' in namespace '%s' to be %d but it was %d", kind, namespace, expected, actual)
-		return err
-	}
-	return nil
+func (a *MemberAwaitility) WaitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list func() (int, error)) {
+	a.waitForExpectedNumberOfResources(t, kind, expected, list)
 }
 
 // WaitForExpectedNumberOfClusterResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(kind string, expected int, list func() (int, error)) error {
-	if actual, err := a.waitForExpectedNumberOfResources(expected, list); err != nil {
-		a.T.Logf("expected number of resources of kind '%s' to be %d but it was %d", kind, expected, actual)
-		return err
-	}
-	return nil
+func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(t *testing.T, kind string, expected int, list func() (int, error)) {
+	a.waitForExpectedNumberOfResources(t, kind, expected, list)
 }
 
-func (a *MemberAwaitility) waitForExpectedNumberOfResources(expected int, list func() (int, error)) (int, error) {
+func (a *MemberAwaitility) waitForExpectedNumberOfResources(t *testing.T, kind string, expected int, list func() (int, error)) {
 	var actual int
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		a, err := list()
@@ -1930,10 +1924,10 @@ func (a *MemberAwaitility) waitForExpectedNumberOfResources(expected int, list f
 		actual = a
 		return actual == expected, nil
 	})
-	return actual, err
+	require.NoError(t, err, "expected number of resources of kind '%s' to be %d but it was %d", kind, expected, actual)
 }
 
-func (a *MemberAwaitility) UpdatePod(namespace, podName string, modifyPod func(pod *corev1.Pod)) (*corev1.Pod, error) {
+func (a *MemberAwaitility) UpdatePod(t *testing.T, namespace, podName string, modifyPod func(pod *corev1.Pod)) *corev1.Pod {
 	var m *corev1.Pod
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshPod := &corev1.Pod{}
@@ -1943,16 +1937,17 @@ func (a *MemberAwaitility) UpdatePod(namespace, podName string, modifyPod func(p
 
 		modifyPod(freshPod)
 		if err := a.Client.Update(context.TODO(), freshPod); err != nil {
-			a.T.Logf("error updating Pod '%s' Will retry again...", podName)
+			t.Logf("error updating Pod '%s' Will retry again...", podName)
 			return false, nil // nolint:nilerr
 		}
 		m = freshPod
 		return true, nil
 	})
-	return m, err
+	require.NoError(t, err)
+	return m
 }
 
-func (a *MemberAwaitility) UpdateConfigMap(namespace, cmName string, modifyCM func(*corev1.ConfigMap)) (*corev1.ConfigMap, error) {
+func (a *MemberAwaitility) UpdateConfigMap(t *testing.T, namespace, cmName string, modifyCM func(*corev1.ConfigMap)) *corev1.ConfigMap {
 	var cm *corev1.ConfigMap
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ConfigMap{}
@@ -1964,11 +1959,12 @@ func (a *MemberAwaitility) UpdateConfigMap(namespace, cmName string, modifyCM fu
 		}
 		modifyCM(obj)
 		if err := a.Client.Update(context.TODO(), obj); err != nil {
-			a.T.Logf("error updating ConfigMap '%s' Will retry again...", cmName)
+			t.Logf("error updating ConfigMap '%s' Will retry again...", cmName)
 			return false, nil // nolint:nilerr
 		}
 		cm = obj
 		return true, nil
 	})
-	return cm, err
+	require.NoError(t, err)
+	return cm
 }


### PR DESCRIPTION
Pass `t` explicitely in all calls and verify `err` within host and member awaitilities, hence
removing the need for subsequent calls to `require.NoError(t, err)` in the tests themselves.

Consequently, when running tests (with an intended failure), the output will be:

```
=== RUN   
TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready
    member.go:1592: waiting for MemberStatus 'toolchain-member-status' to match criteria
    member.go:1538: failed to find MemberStatus with matching criteria:
...

--- FAIL: TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready (241.23s)
```

instead of:

```
=== CONT  TestE2EFlow
    member.go:1588: waiting for MemberStatus 'toolchain-member-status' to match criteria
    member.go:1534: failed to find MemberStatus with matching criteria
...

--- FAIL: TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready
```

ie, `=== CONT` now becomes `=== RUN` in logs, which is more explicit (IMO)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
