### PR TITLE
Flaky e2e test (TestSignupOK)

### DIFF
--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -22,12 +22,13 @@ import (
 	authsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 var httpClient = HTTPClient
@@ -749,14 +750,10 @@ func signup(t *testing.T, hostAwait *wait.HostAwaitility) (*toolchainv1alpha1.Us
 
 func assertGetSignupStatusProvisioned(t *testing.T, await wait.Awaitilities, username, bearerToken string) {
 	hostAwait := await.Host()
-	route := await.Host().RegistrationServiceURL
 	memberAwait := await.Member1()
-	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusOK))
+	mp := waitForUserSignupReadyInRegistrationService(t, hostAwait.RegistrationServiceURL, username, bearerToken)
 	assert.Equal(t, username, mp["compliantUsername"])
 	assert.Equal(t, username, mp["username"])
-	require.IsType(t, false, mpStatus["ready"])
-	assert.True(t, mpStatus["ready"].(bool))
-	assert.Equal(t, "Provisioned", mpStatus["reason"])
 	assert.Equal(t, memberAwait.GetConsoleURL(), mp["consoleURL"])
 	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(t, err)
@@ -779,9 +776,44 @@ func assertGetSignupReturnsNotFound(t *testing.T, await wait.Awaitilities, beare
 	invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusNotFound)
 }
 
+// waitForUserSignupReadyInRegistrationService waits and checks that the UserSignup is ready according to registration service /signup endpoint
+func waitForUserSignupReadyInRegistrationService(t *testing.T, registrationServiceURL, name, bearerToken string) map[string]interface{} {
+	t.Logf("waiting and verifying that UserSignup '%s' is ready according to registration service", name)
+	var mp, mpStatus map[string]interface{}
+	err := k8swait.Poll(time.Second*5, time.Second*60, func() (done bool, err error) {
+		mp, mpStatus = parseResponse(t, invokeEndpoint(t, "GET", registrationServiceURL+"/api/v1/signup", bearerToken, "", http.StatusOK))
+		// check if `ready` field is set
+		if _, ok := mpStatus["ready"]; !ok {
+			t.Logf("usersignup response for %s is missing `ready` field ", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+		// check if `ready` field is true,
+		// means that user signup is "ready"
+		if mpStatus["ready"].(bool) != true {
+			t.Logf("usersignup %s is not ready yet according to registration service", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+		// check signup status reason
+		if mpStatus["reason"] != toolchainv1alpha1.MasterUserRecordProvisionedReason {
+			t.Logf("usersignup %s is not Provisioned yet according to registration service", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+
+		return true, nil
+	})
+	require.NoError(t, err)
+	return mp
+}
+
+// invokeEndpoint invokes given http URL and returns the json body response
 func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, requiredStatus int) map[string]interface{} {
 	var reqBody io.Reader
+	t.Logf("invoking http request: %s %s", method, path)
 	if requestBody != "" {
+		t.Logf("request body: %s", requestBody)
 		reqBody = strings.NewReader(requestBody)
 	}
 	req, err := http.NewRequest(method, path, reqBody)
@@ -789,6 +821,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("content-type", "application/json")
 	resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer.Close(...)`
+	t.Logf("response status code: %d", resp.StatusCode)
 	require.NoError(t, err)
 	defer Close(t, resp)
 
@@ -805,6 +838,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 	return mp
 }
 
+// parseResponse parses a given http response body
 func parseResponse(t *testing.T, responseBody map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
 	// Check that the response looks fine
 	status, ok := responseBody["status"].(map[string]interface{})


### PR DESCRIPTION
Even thought the `TestSignupOK` test verifies [provisioned resources for signup](https://github.com/codeready-toolchain/toolchain-e2e/blob/7d324515b6befc36d5d6778b42a5f7cc3006d04a/testsupport/user_assertions.go#L29-L30) prior to call the registration service `GET /signup` entrypoint, there are cases in which the test failed with following errors:

```
member.go:969: waiting for Idler 'testuser-9cdcb523-498d-4b40-8cd9-ee1ca641d355-stage' to match criteria
    registration_service_test.go:758: 
        Error Trace: /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:758
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:335
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:364
        Error:      Should be true
        Test:       TestSignupOK
    registration_service_test.go:759: 
        Error Trace: /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:759
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:335
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:364
        Error:      Not equal: 
                    expected: "Provisioned"
                    actual  : "ProvisioningSpace"
                     
                    Diff:
                    --- Expected
                    +++ Actual
                    @@ -1 +1 @@
                    -Provisioned
                    +ProvisioningSpace
        Test:       TestSignupOK
    registration_service_test.go:760: 
        Error Trace: /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:760
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:335
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:364
        Error:      Not equal: 
                    expected: string("https://console-openshift-console.apps.ci-op-dwskhpgz-93ede.origin-ci-int-aws.dev.rhcloud.com/")
                    actual  : <nil>(<nil>)
        Test:       TestSignupOK
    registration_service_test.go:764: 
        Error Trace: /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:764
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:335
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:364
        Error:      Not equal: 
                    expected: string("https://api.ci-op-dwskhpgz-93ede.origin-ci-int-aws.dev.rhcloud.com:6443")
                    actual  : <nil>(<nil>)
        Test:       TestSignupOK
    registration_service_test.go:765: 
        Error Trace: /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:765
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:335
                    /tmp/toolchain-e2e/test/e2e/parallel/registration_service_test.go:364
        Error:      Not equal: 
                    expected: string("https://api-toolchain-host-05150951.apps.ci-op-dwskhpgz-93ede.origin-ci-int-aws.dev.rhcloud.com")
                    actual  : <nil>(<nil>)
        Test:       TestSignupOK
        — FAIL: TestSignupOK (48.76s) 
```

this PR implements retrying the HTTP call when this happens, to check if there is some sort temporary  _delay/mismatch_ with what the registration service _sees_. 

Also adds more logging that may help investigating further the issue. 
