### PR TITLE
Store host and member operator logs in artifacts directory on OpenShift CI

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -126,7 +126,7 @@ e2e-run:
 .PHONY: execute-tests
 execute-tests:
 	@echo "Starting test $(shell date)"
-	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -p 1 -parallel ${E2E_PARALLELISM} -v -timeout=90m -failfast && \
+	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -p 1 -parallel ${E2E_PARALLELISM} -v -timeout=90m -failfast || \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs

--- a/make/test.mk
+++ b/make/test.mk
@@ -126,7 +126,7 @@ e2e-run:
 .PHONY: execute-tests
 execute-tests:
 	@echo "Starting test $(shell date)"
-	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -p 1 -parallel ${E2E_PARALLELISM} -v -timeout=90m -failfast || \
+	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -p 1 -parallel ${E2E_PARALLELISM} -v -timeout=90m -failfast && \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs

--- a/make/test.mk
+++ b/make/test.mk
@@ -201,6 +201,7 @@ print-operator-logs:
 	@echo "======================= ${DEPLOYMENT_NAME} deployment logs - Namespace: ${NAMESPACE} =========================="
 	@echo "==============================================================================================================="
 	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE}
+	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${DEPLOYMENT_NAME}.log
 	@echo "==============================================================================================================="
 	@echo ""
 	@echo ""

--- a/make/test.mk
+++ b/make/test.mk
@@ -201,7 +201,7 @@ print-operator-logs:
 	@echo "======================= ${DEPLOYMENT_NAME} deployment logs - Namespace: ${NAMESPACE} =========================="
 	@echo "==============================================================================================================="
 	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE}
-	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${DEPLOYMENT_NAME}.log
+	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${ARTIFACT_DIR}/${DEPLOYMENT_NAME}.log
 	@echo "==============================================================================================================="
 	@echo ""
 	@echo ""

--- a/make/test.mk
+++ b/make/test.mk
@@ -200,7 +200,6 @@ print-operator-logs:
 	@echo "==============================================================================================================="
 	@echo "======================= ${DEPLOYMENT_NAME} deployment logs - Namespace: ${NAMESPACE} =========================="
 	@echo "==============================================================================================================="
-	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE}
 	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${ARTIFACT_DIR}/${DEPLOYMENT_NAME}.log
 	@echo "==============================================================================================================="
 	@echo ""


### PR DESCRIPTION
Dump operator logs to files during openshift ci.

The logs will be saved in the in the `artifacts` folder with the following naming convention `${DEPLOYMENT_NAME}.log`.

Example job with logs saved to files:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/635/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1602062639536541696/artifacts/e2e/test/artifacts/

Jira ticket: [CRT-1469](https://issues.redhat.com/browse/CRT-1469)