### PR TITLE
invert test user signup manual approval scenarios

### DIFF
--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -280,40 +280,6 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute()
 
-	s.T().Run("set low capacity threshold and expect that user won't provisioned even when is approved manually", func(t *testing.T) {
-		// given
-		hostAwait.UpdateToolchainConfig(
-			testconfig.AutomaticApproval().Enabled(false),
-			testconfig.CapacityThresholds().ResourceCapacityThreshold(1),
-		)
-
-		// when
-		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("manualwithcapacity2").
-			Email("manualwithcapacity2@redhat.com").
-			ManuallyApprove().
-			RequireConditions(ConditionSet(Default(), ApprovedByAdmin(), ApprovedByAdminNoCluster())...).
-			Execute().Resources()
-
-		// then
-		s.userIsNotProvisioned(t, userSignup)
-
-		t.Run("reset the threshold and expect the user will be provisioned", func(t *testing.T) {
-			// when
-			hostAwait.UpdateToolchainConfig(
-				testconfig.AutomaticApproval().Enabled(false),
-				testconfig.CapacityThresholds().ResourceCapacityThreshold(80),
-			)
-
-			// then
-			userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
-				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
-				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
-			require.NoError(s.T(), err)
-			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
-		})
-	})
-
 	s.T().Run("set low max number of spaces and expect that user won't be provisioned even when is approved manually", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false),
@@ -325,16 +291,16 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		)
 		// create usersignup to reach max number of spaces on both members
 		NewSignupRequest(t, s.Awaitilities).
-			Username("manualwithcapacity3").
-			Email("manualwithcapacity3@redhat.com").
+			Username("manualwithcapacity2").
+			Email("manualwithcapacity2@redhat.com").
 			ManuallyApprove().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute().Resources()
 
 		// when
 		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
-			Username("manualwithcapacity4").
-			Email("manualwithcapacity4@redhat.com").
+			Username("manualwithcapacity3").
+			Email("manualwithcapacity3@redhat.com").
 			ManuallyApprove().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin(), ApprovedByAdminNoCluster())...).
 			Execute().Resources()
@@ -350,6 +316,40 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 						testconfig.PerMemberCluster(memberAwait1.ClusterName, 500),
 						testconfig.PerMemberCluster(memberAwait2.ClusterName, 500),
 					),
+			)
+
+			// then
+			userSignup, err := hostAwait.WaitForUserSignup(userSignup.Name,
+				wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin())...),
+				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
+			require.NoError(s.T(), err)
+			VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
+		})
+	})
+
+	s.T().Run("set low capacity threshold and expect that user won't provisioned even when is approved manually", func(t *testing.T) {
+		// given
+		hostAwait.UpdateToolchainConfig(
+			testconfig.AutomaticApproval().Enabled(false),
+			testconfig.CapacityThresholds().ResourceCapacityThreshold(1),
+		)
+
+		// when
+		userSignup, _ := NewSignupRequest(t, s.Awaitilities).
+			Username("manualwithcapacity4").
+			Email("manualwithcapacity4@redhat.com").
+			ManuallyApprove().
+			RequireConditions(ConditionSet(Default(), ApprovedByAdmin(), ApprovedByAdminNoCluster())...).
+			Execute().Resources()
+
+		// then
+		s.userIsNotProvisioned(t, userSignup)
+
+		t.Run("reset the threshold and expect the user will be provisioned", func(t *testing.T) {
+			// when
+			hostAwait.UpdateToolchainConfig(
+				testconfig.AutomaticApproval().Enabled(false),
+				testconfig.CapacityThresholds().ResourceCapacityThreshold(80),
 			)
 
 			// then


### PR DESCRIPTION
This PR fixes this e2e failure:
```
TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_max_number_of_spaces_and_expect_that_user_won't_be_provisioned_even_when_is_approved_manually
    signup_request.go:262: 
        	Error Trace:	/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/signup_request.go:262
        	            				/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/usersignup_test.go:332
        	Error:      	Received unexpected error:
        	            	timed out waiting for the condition
        	Test:       	TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_max_number_of_spaces_and_expect_that_user_won't_be_provisioned_even_when_is_approved_manually
.......
--- FAIL: TestRunUserSignupIntegrationTest (190.16s)
    --- PASS: TestRunUserSignupIntegrationTest/TestAutomaticApproval (44.19s)
  .......
    --- FAIL: TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval (141.90s)
        --- PASS: TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_capacity_threshold_and_expect_that_user_won't_provisioned_even_when_is_approved_manually (12.41s)
            --- PASS: TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_capacity_threshold_and_expect_that_user_won't_provisioned_even_when_is_approved_manually/reset_the_threshold_and_expect_the_user_will_be_provisioned (8.57s)
        --- FAIL: TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_max_number_of_spaces_and_expect_that_user_won't_be_provisioned_even_when_is_approved_manually
```

Since capacity manager was updated to deal with spaces, the order of the following subtests 

1.`TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_capacity_threshold_and_expect_that_user_won't_provisioned_even_when_is_approved_manually`

2.`TestRunUserSignupIntegrationTest/TestCapacityManagementWithManualApproval/set_low_max_number_of_spaces_and_expect_that_user_won't_be_provisioned_even_when_is_approved_manually`  

have to be inverted (this has been done also for `TestAutomaticApproval`).

 The test fails because `manualwithcapacity1` and `manualwithcapacity2` users can be provisioned on different member cluster , causing `manualwithcapacity3` to not be provisioned during scenario 2 from above list.

See build failure:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/636/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1602716863073095680/artifacts/e2e/test/build-log.txt
   