### PR TITLE
refactor(test): introduce new HTTPRequest abstraction

### DIFF
--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -22,12 +22,13 @@ import (
 	authsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	k8swait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 var httpClient = HTTPClient
@@ -749,14 +750,10 @@ func signup(t *testing.T, hostAwait *wait.HostAwaitility) (*toolchainv1alpha1.Us
 
 func assertGetSignupStatusProvisioned(t *testing.T, await wait.Awaitilities, username, bearerToken string) {
 	hostAwait := await.Host()
-	route := await.Host().RegistrationServiceURL
 	memberAwait := await.Member1()
-	mp, mpStatus := parseResponse(t, invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusOK))
+	mp := waitForUserSignupReadyInRegistrationService(t, hostAwait.RegistrationServiceURL, username, bearerToken)
 	assert.Equal(t, username, mp["compliantUsername"])
 	assert.Equal(t, username, mp["username"])
-	require.IsType(t, false, mpStatus["ready"])
-	assert.True(t, mpStatus["ready"].(bool))
-	assert.Equal(t, "Provisioned", mpStatus["reason"])
 	assert.Equal(t, memberAwait.GetConsoleURL(), mp["consoleURL"])
 	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(t, err)
@@ -779,9 +776,44 @@ func assertGetSignupReturnsNotFound(t *testing.T, await wait.Awaitilities, beare
 	invokeEndpoint(t, "GET", route+"/api/v1/signup", bearerToken, "", http.StatusNotFound)
 }
 
+// waitForUserSignupReadyInRegistrationService waits and checks that the UserSignup is ready according to registration service /signup endpoint
+func waitForUserSignupReadyInRegistrationService(t *testing.T, registrationServiceURL, name, bearerToken string) map[string]interface{} {
+	t.Logf("waiting and verifying that UserSignup '%s' is ready according to registration service", name)
+	var mp, mpStatus map[string]interface{}
+	err := k8swait.Poll(time.Second*5, time.Second*60, func() (done bool, err error) {
+		mp, mpStatus = parseResponse(t, invokeEndpoint(t, "GET", registrationServiceURL+"/api/v1/signup", bearerToken, "", http.StatusOK))
+		// check if `ready` field is set
+		if _, ok := mpStatus["ready"]; !ok {
+			t.Logf("usersignup response for %s is missing `ready` field ", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+		// check if `ready` field is true,
+		// means that user signup is "ready"
+		if mpStatus["ready"].(bool) != true {
+			t.Logf("usersignup %s is not ready yet according to registration service", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+		// check signup status reason
+		if mpStatus["reason"] != toolchainv1alpha1.MasterUserRecordProvisionedReason {
+			t.Logf("usersignup %s is not Provisioned yet according to registration service", name)
+			t.Logf("registration service status response: %s", spew.Sdump(mpStatus))
+			return false, nil
+		}
+
+		return true, nil
+	})
+	require.NoError(t, err)
+	return mp
+}
+
+// invokeEndpoint invokes given http URL and returns the json body response
 func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, requiredStatus int) map[string]interface{} {
 	var reqBody io.Reader
+	t.Logf("invoking http request: %s %s", method, path)
 	if requestBody != "" {
+		t.Logf("request body: %s", requestBody)
 		reqBody = strings.NewReader(requestBody)
 	}
 	req, err := http.NewRequest(method, path, reqBody)
@@ -789,6 +821,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("content-type", "application/json")
 	resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer.Close(...)`
+	t.Logf("response status code: %d", resp.StatusCode)
 	require.NoError(t, err)
 	defer Close(t, resp)
 
@@ -805,6 +838,7 @@ func invokeEndpoint(t *testing.T, method, path, authToken, requestBody string, r
 	return mp
 }
 
+// parseResponse parses a given http response body
 func parseResponse(t *testing.T, responseBody map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
 	// Check that the response looks fine
 	status, ok := responseBody["status"].(map[string]interface{})

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	authsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
+	httpsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/http"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +33,7 @@ func TestLandingPageReachable(t *testing.T) {
 
 	// when & then
 	// just make sure that the landing page is reachable
-	wait.NewHTTPRequest().Method("GET").
+	httpsupport.NewRequest().Method("GET").
 		URL(route).
 		ContentType("text/plain").
 		RequireStatusCode(http.StatusOK).
@@ -48,7 +49,7 @@ func TestHealth(t *testing.T) {
 	t.Run("get healthcheck 200 OK", func(t *testing.T) {
 		// when
 		// Call health endpoint.
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("GET").
 			URL(route + "/api/v1/health").
 			RequireStatusCode(http.StatusOK).
@@ -84,7 +85,7 @@ func TestWoopra(t *testing.T) {
 	assertNotSecuredGetResponseEquals := func(endPointPath, expectedResponseValue string) {
 		// when & then
 		// Call woopra domain endpoint.
-		wait.NewHTTPRequest().
+		httpsupport.NewRequest().
 			Method("GET").
 			URL(fmt.Sprintf("%s/api/v1/%s", route, endPointPath)).
 			ContentType("text/plain").
@@ -113,7 +114,7 @@ func TestAuthConfig(t *testing.T) {
 	t.Run("get authconfig 200 OK", func(t *testing.T) {
 		// when & then
 		// Call authconfig endpoint.
-		wait.NewHTTPRequest().Method("GET").
+		httpsupport.NewRequest().Method("GET").
 			URL(route + "/api/v1/authconfig").
 			RequireStatusCode(http.StatusOK).
 			Execute(t)
@@ -129,7 +130,7 @@ func TestSignupFails(t *testing.T) {
 	t.Run("post signup error no token 401 Unauthorized", func(t *testing.T) {
 		// when
 		// Call signup endpoint without a token.
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			RequireStatusCode(http.StatusUnauthorized).
@@ -143,7 +144,7 @@ func TestSignupFails(t *testing.T) {
 	t.Run("post signup error invalid token 401 Unauthorized", func(t *testing.T) {
 		// when
 		// Call signup endpoint with an invalid token.
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token("1223123123").
@@ -163,7 +164,7 @@ func TestSignupFails(t *testing.T) {
 			authsupport.WithEmail(emailAddress),
 			authsupport.WithExp(time.Now().Add(-60*time.Second)))
 		require.NoError(t, err)
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token(token1).
@@ -178,7 +179,7 @@ func TestSignupFails(t *testing.T) {
 	t.Run("get signup error no token 401 Unauthorized", func(t *testing.T) {
 		// when
 		// Call signup endpoint without a token.
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("GET").
 			URL(route + "/api/v1/signup").
 			RequireStatusCode(http.StatusUnauthorized).
@@ -192,7 +193,7 @@ func TestSignupFails(t *testing.T) {
 	t.Run("get signup error invalid token 401 Unauthorized", func(t *testing.T) {
 		// when
 		// Call signup endpoint with an invalid token.
-		mp, _ := wait.NewHTTPRequest().Method("GET").
+		mp, _ := httpsupport.NewRequest().Method("GET").
 			URL(route + "/api/v1/signup").
 			Token("1223123123").
 			RequireStatusCode(http.StatusUnauthorized).
@@ -211,7 +212,7 @@ func TestSignupFails(t *testing.T) {
 			authsupport.WithEmail(emailAddress),
 			authsupport.WithExp(time.Now().Add(-60*time.Second)))
 		require.NoError(t, err)
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("GET").
 			URL(route + "/api/v1/signup").
 			Token(token1).
@@ -250,7 +251,7 @@ func TestSignupFails(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call signup endpoint with a valid token to initiate a signup process
-		response, _ := wait.NewHTTPRequest().
+		response, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token(token).
@@ -276,7 +277,7 @@ func TestSignupOK(t *testing.T) {
 	memberAwait := await.Member1()
 	signupUser := func(token, email, userSignupName string, identity *commonauth.Identity) *toolchainv1alpha1.UserSignup {
 		// Call signup endpoint with a valid token to initiate a signup process
-		wait.NewHTTPRequest().
+		httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token(token).
@@ -296,7 +297,7 @@ func TestSignupOK(t *testing.T) {
 		assertGetSignupStatusPendingApproval(t, await, identity.Username, token)
 
 		// Attempt to create same usersignup by calling post signup with same token should return an error
-		mp, _ := wait.NewHTTPRequest().
+		mp, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token(token).
@@ -368,7 +369,7 @@ func TestUserSignupFoundWhenNamedWithEncodedUsername(t *testing.T) {
 
 	// when
 	// Call the signup endpoint
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("POST").
 		URL(route + "/api/v1/signup").
 		Token(token0).
@@ -392,7 +393,7 @@ func TestUserSignupFoundWhenNamedWithEncodedUsername(t *testing.T) {
 		authsupport.WithPreferredUsername("arnold"))
 	require.NoError(t, err)
 
-	mp, mpStatus := wait.NewHTTPRequest().
+	mp, mpStatus := httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(token0).
@@ -419,7 +420,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call the signup endpoint
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("POST").
 		URL(route + "/api/v1/signup").
 		Token(token0).
@@ -436,11 +437,12 @@ func TestPhoneVerification(t *testing.T) {
 	assert.Equal(t, emailAddress, emailAnnotation)
 
 	// Call get signup endpoint with a valid token and make sure verificationRequired is true
-	mp, mpStatus := wait.NewHTTPRequest().
+	mp, mpStatus := httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(token0).
 		RequireStatusCode(http.StatusOK).
+		ParseResponse().
 		Execute(t)
 	assert.Equal(t, "", mp["compliantUsername"])
 	assert.Equal(t, identity0.Username, mp["username"])
@@ -462,7 +464,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 
 	// Initiate the verification process
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("PUT").
 		URL(route + "/api/v1/signup/verification").
 		Token(token0).
@@ -482,7 +484,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserVerificationExpiryAnnotationKey])
 
 	// Attempt to verify with an incorrect verification code
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup/verification/invalid").
 		Token(token0).
@@ -500,7 +502,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.Equal(t, verificationCode, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 
 	// Verify with the correct code
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("GET").
 		URL(route + fmt.Sprintf("/api/v1/signup/verification/%s",
 			userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])).
@@ -522,7 +524,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationInitTimestampAnnotationKey])
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
-	mp, mpStatus = wait.NewHTTPRequest().
+	mp, mpStatus = httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(token0).
@@ -547,7 +549,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve the UserSignup from the GET endpoint
-	_, mpStatus = wait.NewHTTPRequest().
+	_, mpStatus = httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(token0).
@@ -564,7 +566,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call the signup endpoint
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("POST").
 		URL(route + "/api/v1/signup").
 		Token(otherToken).
@@ -581,7 +583,7 @@ func TestPhoneVerification(t *testing.T) {
 	assert.Equal(t, otherEmailValue, otherEmailAnnotation)
 
 	// Initiate the verification process using the same phone number as previously
-	responseMap, _ := wait.NewHTTPRequest().
+	responseMap, _ := httpsupport.NewRequest().
 		Method("PUT").
 		URL(route + "/api/v1/signup/verification").
 		Token(otherToken).
@@ -619,7 +621,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now attempt the verification again
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("PUT").
 		URL(route + "/api/v1/signup/verification").
 		Token(otherToken).
@@ -652,7 +654,7 @@ func TestActivationCodeVerification(t *testing.T) {
 		userSignup, token := signup(t, hostAwait)
 
 		// when call verification endpoint with a valid activation code
-		wait.NewHTTPRequest().
+		httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup/verification/activation-code").
 			Token(token).
@@ -702,7 +704,7 @@ func TestActivationCodeVerification(t *testing.T) {
 			userSignup, token := signup(t, hostAwait)
 
 			// when call verification endpoint with a valid activation code
-			wait.NewHTTPRequest().
+			httpsupport.NewRequest().
 				Method("POST").
 				URL(route + "/api/v1/signup/verification/activation-code").
 				Token(token).
@@ -734,7 +736,7 @@ func TestActivationCodeVerification(t *testing.T) {
 			userSignup, token := signup(t, hostAwait)
 
 			// when call verification endpoint with a valid activation code
-			wait.NewHTTPRequest().
+			httpsupport.NewRequest().
 				Method("POST").
 				URL(route + "/api/v1/signup/verification/activation-code").
 				Token(token).
@@ -758,7 +760,7 @@ func TestActivationCodeVerification(t *testing.T) {
 			userSignup, token := signup(t, hostAwait)
 
 			// when call verification endpoint with a valid activation code
-			wait.NewHTTPRequest().
+			httpsupport.NewRequest().
 				Method("POST").
 				URL(route + "/api/v1/signup/verification/activation-code").
 				Token(token).
@@ -782,7 +784,7 @@ func TestActivationCodeVerification(t *testing.T) {
 			userSignup, token := signup(t, hostAwait)
 
 			// when call verification endpoint with a valid activation code
-			wait.NewHTTPRequest().
+			httpsupport.NewRequest().
 				Method("POST").
 				URL(route + "/api/v1/signup/verification/activation-code").
 				Token(token).
@@ -811,7 +813,7 @@ func signup(t *testing.T, hostAwait *wait.HostAwaitility) (*toolchainv1alpha1.Us
 	require.NoError(t, err)
 
 	// Call the signup endpoint
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("POST").
 		URL(route + "/api/v1/signup").
 		Token(token).
@@ -845,7 +847,7 @@ func assertGetSignupStatusProvisioned(t *testing.T, await wait.Awaitilities, use
 
 func assertGetSignupStatusPendingApproval(t *testing.T, await wait.Awaitilities, username, bearerToken string) {
 	route := await.Host().RegistrationServiceURL
-	mp, mpStatus := wait.NewHTTPRequest().
+	mp, mpStatus := httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(bearerToken).
@@ -860,7 +862,7 @@ func assertGetSignupStatusPendingApproval(t *testing.T, await wait.Awaitilities,
 
 func assertGetSignupReturnsNotFound(t *testing.T, await wait.Awaitilities, bearerToken string) {
 	route := await.Host().RegistrationServiceURL
-	wait.NewHTTPRequest().
+	httpsupport.NewRequest().
 		Method("GET").
 		URL(route + "/api/v1/signup").
 		Token(bearerToken).

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -34,6 +34,7 @@ func TestLandingPageReachable(t *testing.T) {
 	// just make sure that the landing page is reachable
 	wait.NewHTTPRequest().Method("GET").
 		URL(route).
+		ContentType("text/plain").
 		RequireStatusCode(http.StatusOK).
 		Execute(t)
 }
@@ -45,7 +46,6 @@ func TestHealth(t *testing.T) {
 	route := await.Host().RegistrationServiceURL
 
 	t.Run("get healthcheck 200 OK", func(t *testing.T) {
-
 		// when
 		// Call health endpoint.
 		mp, _ := wait.NewHTTPRequest().
@@ -87,6 +87,7 @@ func TestWoopra(t *testing.T) {
 		wait.NewHTTPRequest().
 			Method("GET").
 			URL(fmt.Sprintf("%s/api/v1/%s", route, endPointPath)).
+			ContentType("text/plain").
 			RequireStatusCode(http.StatusOK).
 			RequireResponseBody(expectedResponseValue).
 			Execute(t)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -14,6 +14,7 @@ import (
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	authsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/auth"
+	httpsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/http"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
@@ -580,7 +581,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		route := hostAwait.RegistrationServiceURL
 
 		// Call signup endpoint with a valid token to initiate a signup process
-		statusErr, _ := wait.NewHTTPRequest().
+		statusErr, _ := httpsupport.NewRequest().
 			Method("POST").
 			URL(route + "/api/v1/signup").
 			Token(token0).

--- a/testsupport/http/http_request.go
+++ b/testsupport/http/http_request.go
@@ -17,7 +17,7 @@ import (
 const ContentTypeApplicationJSON = "application/json"
 
 // NewRequest creates a new http client configuration
-func NewRequest() *HTTPRequest {
+func NewRequest() *Request {
 	cl := &http.Client{
 		Timeout: time.Second * 10,
 		Transport: &http.Transport{
@@ -27,12 +27,12 @@ func NewRequest() *HTTPRequest {
 		},
 	}
 
-	return &HTTPRequest{
+	return &Request{
 		client: cl,
 	}
 }
 
-// HTTPRequest provides an API for creating a new HTTP request.
+// Request provides an API for creating a new HTTP request.
 // Function chaining may be used to achieve an efficient "single-statement" HTTP requests creation, for example:
 //
 // body, status := NewRequest().
@@ -42,7 +42,7 @@ func NewRequest() *HTTPRequest {
 // RequireStatusCode(http.StatusOK).
 // ParseResponse().
 // Execute(t)
-type HTTPRequest struct {
+type Request struct {
 	client              *http.Client
 	method              string
 	url                 string
@@ -57,54 +57,54 @@ type HTTPRequest struct {
 
 // Method specifies the HTTP method to be used (GET/POST/PUT/DELETE ...)
 // This is a mandatory field and should be set before invoking Execute.
-func (c *HTTPRequest) Method(method string) *HTTPRequest {
+func (c *Request) Method(method string) *Request {
 	c.method = method
 	return c
 }
 
 // URL specifies the URL where the request will be invoked.
 // This is a mandatory field and should be set before invoking Execute.
-func (c *HTTPRequest) URL(URL string) *HTTPRequest {
+func (c *Request) URL(URL string) *Request {
 	c.url = URL
 	return c
 }
 
 // Token specifies the auth token to be used as bear token for the HTTP request.
 // This is an optional field and should be set if the endpoint is authenticated.
-func (c *HTTPRequest) Token(token string) *HTTPRequest {
+func (c *Request) Token(token string) *Request {
 	c.token = token
 	return c
 }
 
 // RequireStatusCode specifies which HTTP status code should be returned by the endpoint.
 // This is an optional field, if set the response status code will be compared against this value.
-func (c *HTTPRequest) RequireStatusCode(statusCode int) *HTTPRequest {
+func (c *Request) RequireStatusCode(statusCode int) *Request {
 	c.requireStatusCode = statusCode
 	return c
 }
 
 // RequireResponseBody pecifies which HTTP response body should be returned by the endpoint.
 // This is an optional field, if set the response body will be compared against this value.
-func (c *HTTPRequest) RequireResponseBody(responseBody string) *HTTPRequest {
+func (c *Request) RequireResponseBody(responseBody string) *Request {
 	c.requireResponseBody = responseBody
 	return c
 }
 
 // QueryParams specifies which the query parameters to be used during the HTTP call.
 // This is an optional field.
-func (c *HTTPRequest) QueryParams(queryParams map[string]string) *HTTPRequest {
+func (c *Request) QueryParams(queryParams map[string]string) *Request {
 	c.queryParams = queryParams
 	return c
 }
 
 // Body specifies which the HTTP body to be used during the HTTP call.
 // This is an optional field.
-func (c *HTTPRequest) Body(requestBody string) *HTTPRequest {
+func (c *Request) Body(requestBody string) *Request {
 	c.body = requestBody
 	return c
 }
 
-func (c *HTTPRequest) ContentType(contentType string) *HTTPRequest {
+func (c *Request) ContentType(contentType string) *Request {
 	c.contentType = contentType
 	return c
 }
@@ -115,14 +115,14 @@ func (c *HTTPRequest) ContentType(contentType string) *HTTPRequest {
 // - the `status` object as a map
 // see Execute method for more details on the parsing logic.
 // This is an optional field.
-func (c *HTTPRequest) ParseResponse() *HTTPRequest {
+func (c *Request) ParseResponse() *Request {
 	c.parseResponse = true
 	return c
 }
 
 // Execute triggers the HTTP request according to all configuration set in the above fields,
 // and does some parsing of the response if configured by the client.
-func (c *HTTPRequest) Execute(t *testing.T) (map[string]interface{}, map[string]interface{}) {
+func (c *Request) Execute(t *testing.T) (map[string]interface{}, map[string]interface{}) {
 	var reqBody io.Reader
 	t.Logf("invoking http request: %s %s", c.method, c.url)
 
@@ -191,7 +191,7 @@ func (c *HTTPRequest) Execute(t *testing.T) (map[string]interface{}, map[string]
 }
 
 // UnmarshalJSON runs json unmarshalling on the response body, if JSON content type was expected.
-func (c *HTTPRequest) UnmarshalJSON(t *testing.T, body []byte) (map[string]interface{}, map[string]interface{}) {
+func (c *Request) UnmarshalJSON(t *testing.T, body []byte) (map[string]interface{}, map[string]interface{}) {
 	mp := make(map[string]interface{})
 	if len(body) > 0 {
 		err := json.Unmarshal(body, &mp)

--- a/testsupport/http/http_request.go
+++ b/testsupport/http/http_request.go
@@ -1,4 +1,4 @@
-package wait
+package http
 
 import (
 	"crypto/tls"
@@ -16,8 +16,8 @@ import (
 // HTTP request, but can be configured using the `c.ContentType` method.
 const ContentTypeApplicationJSON = "application/json"
 
-// NewHTTPRequest creates a new http client configuration
-func NewHTTPRequest() *HTTPRequest {
+// NewRequest creates a new http client configuration
+func NewRequest() *HTTPRequest {
 	cl := &http.Client{
 		Timeout: time.Second * 10,
 		Transport: &http.Transport{
@@ -35,7 +35,7 @@ func NewHTTPRequest() *HTTPRequest {
 // HTTPRequest provides an API for creating a new HTTP request.
 // Function chaining may be used to achieve an efficient "single-statement" HTTP requests creation, for example:
 //
-// body, status := NewHTTPRequest().
+// body, status := NewRequest().
 // Method("GET").
 // URL(route + "/api/v1/signup").
 // Token(token0).

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -13,6 +13,7 @@ import (
 	commonauth "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	authsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
+	httpsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/http"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	"github.com/gofrs/uuid"
@@ -214,7 +215,7 @@ func (r *SignupRequest) Execute() *SignupRequest {
 	}
 
 	// Call the signup endpoint
-	wait.NewHTTPRequest().Method("POST").
+	httpsupport.NewRequest().Method("POST").
 		URL(hostAwait.RegistrationServiceURL + "/api/v1/signup").
 		Token(r.token).
 		RequireStatusCode(r.requiredHTTPStatus).

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -2,11 +2,8 @@ package testsupport
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net/http"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
@@ -67,13 +64,4 @@ func NewUserSignup(namespace, username string, email string) *toolchainv1alpha1.
 			Userid:   name,
 		},
 	}
-}
-
-var HTTPClient = &http.Client{
-	Timeout: time.Second * 10,
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true, // nolint:gosec
-		},
-	},
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -676,11 +676,12 @@ func (a *HostAwaitility) WaitForUserSignupByUserIDAndUsername(userID, username s
 func (a *HostAwaitility) WaitForUserSignupReadyInRegistrationService(t *testing.T, name, bearerToken string) map[string]interface{} {
 	t.Logf("waiting and verifying that UserSignup '%s' is ready according to registration service", name)
 	var mp, mpStatus map[string]interface{}
-	err := wait.Poll(time.Second*5, time.Second*60, func() (done bool, err error) {
+	err := wait.Poll(time.Second, time.Second*60, func() (done bool, err error) {
 		mp, mpStatus = NewHTTPRequest().Method("GET").
 			URL(a.RegistrationServiceURL + "/api/v1/signup").
 			Token(bearerToken).
 			RequireStatusCode(http.StatusOK).
+			ParseResponse().
 			Execute(t)
 		// check if `ready` field is set
 		if _, ok := mpStatus["ready"]; !ok {

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -17,7 +17,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
-
+	httpsupport "github.com/codeready-toolchain/toolchain-e2e/testsupport/http"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/require"
@@ -677,7 +677,7 @@ func (a *HostAwaitility) WaitForUserSignupReadyInRegistrationService(t *testing.
 	t.Logf("waiting and verifying that UserSignup '%s' is ready according to registration service", name)
 	var mp, mpStatus map[string]interface{}
 	err := wait.Poll(time.Second, time.Second*60, func() (done bool, err error) {
-		mp, mpStatus = NewHTTPRequest().Method("GET").
+		mp, mpStatus = httpsupport.NewRequest().Method("GET").
 			URL(a.RegistrationServiceURL + "/api/v1/signup").
 			Token(bearerToken).
 			RequireStatusCode(http.StatusOK).

--- a/testsupport/wait/http_request.go
+++ b/testsupport/wait/http_request.go
@@ -36,12 +36,12 @@ func NewHTTPRequest() *HTTPRequest {
 // Function chaining may be used to achieve an efficient "single-statement" HTTP requests creation, for example:
 //
 // body, status := NewHTTPRequest().
-// 					Method("GET").
-//					URL(route + "/api/v1/signup").
-//					Token(token0).
-//					RequireStatusCode(http.StatusOK).
-//					ParseResponse().
-//					Execute(t)
+// Method("GET").
+// URL(route + "/api/v1/signup").
+// Token(token0).
+// RequireStatusCode(http.StatusOK).
+// ParseResponse().
+// Execute(t)
 type HTTPRequest struct {
 	client              *http.Client
 	method              string
@@ -187,14 +187,14 @@ func (c *HTTPRequest) Execute(t *testing.T) (map[string]interface{}, map[string]
 	}
 
 	//  return JSON response
-	return c.UnmarshalJSON(t, body, err)
+	return c.UnmarshalJSON(t, body)
 }
 
 // UnmarshalJSON runs json unmarshalling on the response body, if JSON content type was expected.
-func (c *HTTPRequest) UnmarshalJSON(t *testing.T, body []byte, err error) (map[string]interface{}, map[string]interface{}) {
+func (c *HTTPRequest) UnmarshalJSON(t *testing.T, body []byte) (map[string]interface{}, map[string]interface{}) {
 	mp := make(map[string]interface{})
 	if len(body) > 0 {
-		err = json.Unmarshal(body, &mp)
+		err := json.Unmarshal(body, &mp)
 		require.NoError(t, err)
 	}
 

--- a/testsupport/wait/http_request.go
+++ b/testsupport/wait/http_request.go
@@ -1,0 +1,176 @@
+package wait
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// NewHTTPRequest creates a new http client configuration
+func NewHTTPRequest() *HTTPRequest {
+	cl := &http.Client{
+		Timeout: time.Second * 10,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // nolint:gosec
+			},
+		},
+	}
+
+	return &HTTPRequest{
+		client: cl,
+	}
+}
+
+// HTTPRequest provides an API for creating a new HTTP request.
+// Function chaining may be used to achieve an efficient "single-statement" HTTP requests creation, for example:
+//
+// body, status := NewHTTPRequest().
+// 					Method("GET").
+//					URL(route + "/api/v1/signup").
+//					Token(token0).
+//					RequireStatusCode(http.StatusOK).
+//					ParseResponse().
+//					Execute(t)
+type HTTPRequest struct {
+	client              *http.Client
+	method              string
+	url                 string
+	token               string
+	requireStatusCode   int
+	requireResponseBody string
+	body                string
+	queryParams         map[string]string
+	parseResponse       bool
+}
+
+// Method specifies the HTTP method to be used (GET/POST/PUT/DELETE ...)
+// This is a mandatory field and should be set before invoking Execute.
+func (c *HTTPRequest) Method(method string) *HTTPRequest {
+	c.method = method
+	return c
+}
+
+// URL specifies the URL where the request will be invoked.
+// This is a mandatory field and should be set before invoking Execute.
+func (c *HTTPRequest) URL(URL string) *HTTPRequest {
+	c.url = URL
+	return c
+}
+
+// Token specifies the auth token to be used as bear token for the HTTP request.
+// This is an optional field and should be set if the endpoint is authenticated.
+func (c *HTTPRequest) Token(token string) *HTTPRequest {
+	c.token = token
+	return c
+}
+
+// RequireStatusCode specifies which HTTP status code should be returned by the endpoint.
+// This is an optional field, if set the response status code will be compared against this value.
+func (c *HTTPRequest) RequireStatusCode(statusCode int) *HTTPRequest {
+	c.requireStatusCode = statusCode
+	return c
+}
+
+// RequireResponseBody pecifies which HTTP response body should be returned by the endpoint.
+// This is an optional field, if set the response body will be compared against this value.
+func (c *HTTPRequest) RequireResponseBody(responseBody string) *HTTPRequest {
+	c.requireResponseBody = responseBody
+	return c
+}
+
+// QueryParams specifies which the query parameters to be used during the HTTP call.
+// This is an optional field.
+func (c *HTTPRequest) QueryParams(queryParams map[string]string) *HTTPRequest {
+	c.queryParams = queryParams
+	return c
+}
+
+// Body specifies which the HTTP body to be used during the HTTP call.
+// This is an optional field.
+func (c *HTTPRequest) Body(requestBody string) *HTTPRequest {
+	c.body = requestBody
+	return c
+}
+
+// ParseResponse specifies if the response from the HTTP endpoint should be parsed according to custom logic.
+// See Execute method for more details on the parsing logic.
+// This is an optional field.
+func (c *HTTPRequest) ParseResponse() *HTTPRequest {
+	c.parseResponse = true
+	return c
+}
+
+// Execute triggers the HTTP request according to all configuration set in the above fields
+func (c *HTTPRequest) Execute(t *testing.T) (map[string]interface{}, map[string]interface{}) {
+	var reqBody io.Reader
+	t.Logf("invoking http request: %s %s", c.method, c.url)
+
+	// set request body if was specified
+	if c.body != "" {
+		t.Logf("request body: %s", c.body)
+		reqBody = strings.NewReader(c.body)
+	}
+	req, err := http.NewRequest(c.method, c.url, reqBody)
+	require.NoError(t, err)
+
+	// set auth token if was specified
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	req.Header.Set("content-type", "application/json")
+
+	// set query parameters if specified
+	if len(c.queryParams) > 0 {
+		q := req.URL.Query()
+		for key, val := range c.queryParams {
+			q.Add(key, val)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	// close connection after reading response
+	req.Close = true
+	resp, err := c.client.Do(req) // nolint:bodyclose // see `defer.Close(...)`
+	t.Logf("response status code: %d", resp.StatusCode)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+	// check for required status code if specified
+	if c.requireStatusCode != 0 {
+		require.Equal(t, c.requireStatusCode, resp.StatusCode, "unexpected response status with body: %s", body)
+	}
+
+	// check for required body if specified
+	if c.requireResponseBody != "" {
+		value := string(body)
+		require.NoError(t, err)
+
+		// Verify JSON response.
+		require.Equal(t, c.requireResponseBody, value)
+	}
+
+	mp := make(map[string]interface{})
+	if len(body) > 0 {
+		err = json.Unmarshal(body, &mp)
+		require.NoError(t, err)
+	}
+
+	if c.parseResponse {
+		// Check that the response looks fine
+		status, ok := mp["status"].(map[string]interface{})
+		require.True(t, ok)
+		return mp, status
+	}
+
+	// return plain response
+	return mp, nil
+}


### PR DESCRIPTION
This PR's introduces:

1. removal of the global variable `httpClient` 
2. move `WaitForUserSignupReadyInRegistrationService` to `host.go` 
3. create new `HTTPRequest` abstraction similar to `SignupRequest`  