### PR TITLE
fix: reflect the namespace the logs are pulled from

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -200,7 +200,7 @@ print-operator-logs:
 	@echo "==============================================================================================================="
 	@echo "======================= ${DEPLOYMENT_NAME} deployment logs - Namespace: ${NAMESPACE} =========================="
 	@echo "==============================================================================================================="
-	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${ARTIFACT_DIR}/${DEPLOYMENT_NAME}.log
+	-oc logs deployment.apps/${DEPLOYMENT_NAME} ${ADDITIONAL_PARAMS} --namespace ${NAMESPACE} > ${ARTIFACT_DIR}/${DEPLOYMENT_NAME}_${NAMESPACE}.log
 	@echo "==============================================================================================================="
 	@echo ""
 	@echo ""


### PR DESCRIPTION
The reason is that we have two member instances and the second instance overrides the log of the first one