### PR TITLE
refactor(test): drop 'T' from awaitilities

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -489,9 +489,9 @@ func TestE2EFlow(t *testing.T) {
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(t, wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 			wait.UntilToolchainStatusUpdatedAfter(time.Now()), wait.UntilHasMurCount("external", originalMursPerDomainCount["external"]+8))
 		require.NoError(t, err)
-		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 8)
+		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 7)
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
-		VerifyIncreaseOfSpaceCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 8)
+		VerifyIncreaseOfSpaceCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 7)
 		VerifyIncreaseOfSpaceCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -266,7 +266,7 @@ func TestE2EFlow(t *testing.T) {
 		// check if the MUR and UA counts match
 		currentToolchainStatus, err := hostAwait.WaitForToolchainStatus(t, wait.UntilToolchainStatusHasConditions(
 			ToolchainStatusReadyAndUnreadyNotificationNotCreated()...), wait.UntilToolchainStatusUpdatedAfter(time.Now()),
-			wait.UntilHasMurCount("external", originalMursPerDomainCount["external"]+9))
+			wait.UntilHasMurCount("external", originalMursPerDomainCount["external"]+9)) // 5 multiple signups + johnSignup + johnExtraSignup + targetedJohnName + originalSubJohnSignup +
 		require.NoError(t, err)
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, johnsmithMur.Spec.UserAccounts[0].TargetCluster, 8)
 		VerifyIncreaseOfUserAccountCount(t, originalToolchainStatus, currentToolchainStatus, targetedJohnMur.Spec.UserAccounts[0].TargetCluster, 1)

--- a/test/e2e/nstemplatetier_test.go
+++ b/test/e2e/nstemplatetier_test.go
@@ -32,13 +32,13 @@ func TestNSTemplateTiers(t *testing.T) {
 
 	// Create and approve "testingtiers" signups
 	testingTiersName := "testingtiers"
-	testingtiers, _ := NewSignupRequest(t, awaitilities).
+	testingtiers, _ := NewSignupRequest(awaitilities).
 		Username(testingTiersName).
 		ManuallyApprove().
 		TargetCluster(awaitilities.Member1()).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().
+		Execute(t).
 		Resources()
 
 	// all tiers to check - keep the base as the last one, it will verify downgrade back to the default tier at the end of the test
@@ -60,7 +60,7 @@ func TestNSTemplateTiers(t *testing.T) {
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
 		// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
-		_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(tierToCheck,
+		_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierToCheck,
 			UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
 		require.NoError(t, err)
 
@@ -82,26 +82,26 @@ func TestSetDefaultTier(t *testing.T) {
 
 	t.Run("original default tier", func(t *testing.T) {
 		// Create and approve a new user that should be provisioned to the base tier
-		NewSignupRequest(t, awaitilities).
+		NewSignupRequest(awaitilities).
 			Username("defaulttier").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
 		// Create and approve a new user that should be provisioned to the advanced tier
-		NewSignupRequest(t, awaitilities).
+		NewSignupRequest(awaitilities).
 			Username("defaulttierchanged").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	})
 }
@@ -122,11 +122,11 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	hostAwait = hostAwait.WithRetryOptions(TimeoutOption(hostAwait.Timeout + time.Second*time.Duration(3*count*2)))       // 3 batches of `count` accounts, with 2s of interval between each update
 	memberAwait = memberAwait.WithRetryOptions(TimeoutOption(memberAwait.Timeout + time.Second*time.Duration(3*count*2))) // 3 batches of `count` accounts, with 2s of interval between each update
 
-	baseTier, err := hostAwait.WaitForNSTemplateTier("base")
+	baseTier, err := hostAwait.WaitForNSTemplateTier(t, "base")
 	require.NoError(t, err)
-	advancedTier, err := hostAwait.WaitForNSTemplateTier("advanced")
+	advancedTier, err := hostAwait.WaitForNSTemplateTier(t, "advanced")
 	require.NoError(t, err)
-	baseextendedidlingTier, err := hostAwait.WaitForNSTemplateTier("baseextendedidling")
+	baseextendedidlingTier, err := hostAwait.WaitForNSTemplateTier(t, "baseextendedidling")
 	require.NoError(t, err)
 
 	// create new NSTemplateTiers (derived from `base`)
@@ -148,11 +148,11 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	t.Log("updating tiers")
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources
-	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(advancedTier), tiers.WithSpaceRoles(advancedTier))
+	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
-	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(baseextendedidlingTier), tiers.WithClusterResources(baseextendedidlingTier))
+	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
 	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
-	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(advancedTier))
+	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
 
 	// then
 	t.Log("verifying users and spaces after tier updates")
@@ -178,27 +178,28 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	t.Run("test reset deactivating state when promoting user", func(t *testing.T) {
-		userSignup, _ := NewSignupRequest(t, awaitilities).
+		userSignup, _ := NewSignupRequest(awaitilities).
 			Username("promoteuser").
 			Email("promoteuser@redhat.com").
 			ManuallyApprove().
 			TargetCluster(awaitilities.Member1()).
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 
 		// Set the deactivating state on the UserSignup
-		updatedUserSignup, err := hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivating(us, true)
-		})
+		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+			func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivating(us, true)
+			})
 		require.NoError(t, err)
 
 		// Move the MUR to the user tier with longer deactivation time
 		tiers.MoveMURToTier(t, hostAwait, updatedUserSignup.Spec.Username, "deactivate90")
 
 		// Ensure the deactivating state is reset after promotion
-		promotedUserSignup, err := hostAwait.WaitForUserSignup(updatedUserSignup.Name)
+		promotedUserSignup, err := hostAwait.WaitForUserSignup(t, updatedUserSignup.Name)
 		require.NoError(t, err)
 		require.False(t, states.Deactivating(promotedUserSignup), "usersignup should not be deactivating")
 		VerifyResourcesProvisionedForSignup(t, awaitilities, promotedUserSignup, "deactivate90", "base")
@@ -235,13 +236,13 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 	// and wait until they are all provisioned by calling EnsureMUR()
 	userSignups := make([]*toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
-		userSignups[i], _ = NewSignupRequest(t, awaitilities).
+		userSignups[i], _ = NewSignupRequest(awaitilities).
 			Username(fmt.Sprintf(nameFmt, i)).
 			ManuallyApprove().
 			WaitForMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			TargetCluster(targetCluster).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 
@@ -255,21 +256,21 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 }
 
 func verifyStatus(t *testing.T, hostAwait *HostAwaitility, tierName string, expectedCount int) {
-	_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(tierName, UntilNSTemplateTierStatusUpdates(expectedCount))
+	_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierName, UntilNSTemplateTierStatusUpdates(expectedCount))
 	require.NoError(t, err)
 }
 
 func verifyResourceUpdatesForUserSignups(t *testing.T, hostAwait *HostAwaitility, memberAwaitility *MemberAwaitility, userSignups []*toolchainv1alpha1.UserSignup, tier *tiers.CustomNSTemplateTier) {
 	// if there's an annotation that describes on which other tier this one is based (for e2e tests only)
 	for _, usersignup := range userSignups {
-		userAccount, err := memberAwaitility.WaitForUserAccount(usersignup.Status.CompliantUsername,
+		userAccount, err := memberAwaitility.WaitForUserAccount(t, usersignup.Status.CompliantUsername,
 			UntilUserAccountHasConditions(Provisioned()),
 			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Spec.Userid, usersignup.Spec.OriginalSub)),
 			UntilUserAccountMatchesMur(hostAwait))
 		require.NoError(t, err)
 		require.NotNil(t, userAccount)
 
-		nsTemplateSet, err := memberAwaitility.WaitForNSTmplSet(usersignup.Status.CompliantUsername, UntilNSTemplateSetHasTier(tier.Name))
+		nsTemplateSet, err := memberAwaitility.WaitForNSTmplSet(t, usersignup.Status.CompliantUsername, UntilNSTemplateSetHasTier(tier.Name))
 		if err != nil {
 			t.Logf("getting NSTemplateSet '%s' failed with: %s", usersignup.Status.CompliantUsername, err)
 		}

--- a/test/e2e/parallel/serviceaccount_test.go
+++ b/test/e2e/parallel/serviceaccount_test.go
@@ -23,13 +23,13 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 	member := awaitilities.Member1()
 
 	// let's provision user
-	_, mur := NewSignupRequest(t, awaitilities).
+	_, mur := NewSignupRequest(awaitilities).
 		Username("do-not-override-sa").
 		ManuallyApprove().
 		TargetCluster(member).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().
+		Execute(t).
 		Resources()
 
 	// and move the user to appstudio tier
@@ -37,7 +37,7 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 	VerifyResourcesProvisionedForSpace(t, awaitilities, mur.Name)
 
 	// get the SA that is provisioned for the user in the ns
-	sa, err := member.WaitForServiceAccount(mur.Name, fmt.Sprintf("appstudio-%s", mur.Name))
+	sa, err := member.WaitForServiceAccount(t, mur.Name, fmt.Sprintf("appstudio-%s", mur.Name))
 	require.NoError(t, err)
 	expectedSecrets := getSASecrets(t, member, mur.Name, sa.Name)
 
@@ -49,14 +49,14 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 
 	// drop the SpaceRoles annotation from the namespace to trigger the reconciliation
 	require.NoError(t, err)
-	_, err = member.UpdateNSTemplateSet(mur.Name, func(nsTmplSet *v1alpha1.NSTemplateSet) {
+	_, err = member.UpdateNSTemplateSet(t, mur.Name, func(nsTmplSet *v1alpha1.NSTemplateSet) {
 		delete(nsTmplSet.Annotations, v1alpha1.LastAppliedSpaceRolesAnnotationKey)
 	})
 	require.NoError(t, err)
 
 	// then
 	VerifyResourcesProvisionedForSpace(t, awaitilities, mur.Name)
-	sa, err = member.WaitForServiceAccount(mur.Name, fmt.Sprintf("appstudio-%s", mur.Name))
+	sa, err = member.WaitForServiceAccount(t, mur.Name, fmt.Sprintf("appstudio-%s", mur.Name))
 	require.NoError(t, err)
 	assert.Equal(t, "stay", sa.Annotations["should"])
 

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -37,11 +37,11 @@ func TestCreateSocialEvent(t *testing.T) {
 		)
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		err := hostAwait.CreateWithCleanup(t, event)
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 		}))
@@ -60,11 +60,11 @@ func TestCreateSocialEvent(t *testing.T) {
 			testsocialevent.WithSpaceTier("base1ns"))
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		err := hostAwait.CreateWithCleanup(t, event)
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidUserTierReason,
@@ -81,7 +81,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			_, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))
@@ -96,11 +96,11 @@ func TestCreateSocialEvent(t *testing.T) {
 			testsocialevent.WithSpaceTier("invalid"))
 
 		// when
-		err := hostAwait.CreateWithCleanup(context.TODO(), event)
+		err := hostAwait.CreateWithCleanup(t, event)
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidSpaceTierReason,
@@ -117,7 +117,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			_, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -60,8 +60,8 @@ func TestProxyFlow(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	memberConfigurationWithSkipUserCreation := testconfig.ModifyMemberOperatorConfigObj(memberAwait.GetMemberOperatorConfig(), testconfig.SkipUserCreation(true))
-	hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"), testconfig.Members().Default(memberConfigurationWithSkipUserCreation.Spec))
+	memberConfigurationWithSkipUserCreation := testconfig.ModifyMemberOperatorConfigObj(memberAwait.GetMemberOperatorConfig(t), testconfig.SkipUserCreation(true))
+	hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"), testconfig.Members().Default(memberConfigurationWithSkipUserCreation.Spec))
 
 	users := []proxyUser{
 		{
@@ -87,14 +87,14 @@ func TestProxyFlow(t *testing.T) {
 	for index, user := range users {
 		t.Run(user.username, func(t *testing.T) {
 			// Create and approve signup
-			req := NewSignupRequest(t, awaitilities).
+			req := NewSignupRequest(awaitilities).
 				Username(user.username).
 				IdentityID(user.identityID).
 				ManuallyApprove().
 				TargetCluster(user.expectedMemberCluster).
 				EnsureMUR().
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-				Execute()
+				Execute(t)
 
 			user.signup, _ = req.Resources()
 			user.token = req.GetToken()
@@ -109,7 +109,7 @@ func TestProxyFlow(t *testing.T) {
 				w := newWsWatcher(t, user, hostAwait.APIProxyURL)
 				closeConnection := w.Start()
 				defer closeConnection()
-				proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+				proxyCl := hostAwait.CreateAPIProxyClient(t, user.token)
 
 				// Create and retrieve the application resources multiple times for the same user to make sure the proxy cache kicks in.
 				for i := 0; i < 2; i++ {
@@ -154,7 +154,7 @@ func TestProxyFlow(t *testing.T) {
 				}
 
 				// when
-				proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+				proxyCl := hostAwait.CreateAPIProxyClient(t, user.token)
 
 				// then
 				err := proxyCl.Create(context.TODO(), expectedApp)
@@ -181,7 +181,7 @@ func TestProxyFlow(t *testing.T) {
 					}
 
 					// when
-					proxyCl := hostAwait.CreateAPIProxyClient(user.token)
+					proxyCl := hostAwait.CreateAPIProxyClient(t, user.token)
 					err = proxyCl.Create(context.TODO(), appToCreate)
 
 					// then
@@ -193,11 +193,11 @@ func TestProxyFlow(t *testing.T) {
 
 	// preexisting user & identity are still there
 	// Verify provisioned User
-	_, err := memberAwait.WaitForUser(preexistingUser.Name)
+	_, err := memberAwait.WaitForUser(t, preexistingUser.Name)
 	assert.NoError(t, err)
 
 	// Verify provisioned Identity
-	_, err = memberAwait.WaitForIdentity(preexistingIdentity.Name)
+	_, err = memberAwait.WaitForIdentity(t, preexistingIdentity.Name)
 	assert.NoError(t, err)
 }
 
@@ -210,7 +210,7 @@ func createPreexistingUserAndIdentity(t *testing.T, user proxyUser) (*userv1.Use
 			identitypkg.NewIdentityNamingStandard(user.identityID.String(), "rhd").IdentityName(),
 		},
 	}
-	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(context.TODO(), preexistingUser))
+	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(t, preexistingUser))
 
 	preexistingIdentity := &userv1.Identity{
 		ObjectMeta: metav1.ObjectMeta{
@@ -223,7 +223,7 @@ func createPreexistingUserAndIdentity(t *testing.T, user proxyUser) (*userv1.Use
 			UID:  preexistingUser.UID,
 		},
 	}
-	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(context.TODO(), preexistingIdentity))
+	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(t, preexistingIdentity))
 	return preexistingUser, preexistingIdentity
 }
 

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -38,6 +38,58 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 		Execute(t)
 	hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultSpaceTier("appstudio"))
 
+	t.Run("set low max number of spaces and expect that space won't be provisioned but added on waiting list", func(t *testing.T) {
+		// given
+		hostAwait.UpdateToolchainConfig(t,
+			testconfig.CapacityThresholds().
+				MaxNumberOfSpaces(
+					testconfig.PerMemberCluster(memberAwait1.ClusterName, -1),
+					testconfig.PerMemberCluster(memberAwait2.ClusterName, -1),
+				),
+		)
+
+		// when
+		space1, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithName("space-waitinglist1"))
+
+		// we need to sleep one second to create UserSignup with different creation time
+		time.Sleep(time.Second)
+		space2, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithName("space-waitinglist2"))
+
+		// then
+		waitUntilSpaceIsPendingCluster(t, hostAwait, space1.Name)
+		waitUntilSpaceIsPendingCluster(t, hostAwait, space2.Name)
+
+		t.Run("increment the max number of spaces and expect that first space will be provisioned.", func(t *testing.T) {
+			// when
+			hostAwait.UpdateToolchainConfig(t,
+				testconfig.CapacityThresholds().
+					MaxNumberOfSpaces(
+						// increment max spaces only on member1
+						testconfig.PerMemberCluster(memberAwait1.ClusterName, 2),
+						testconfig.PerMemberCluster(memberAwait2.ClusterName, -1),
+					),
+			)
+
+			// then
+			VerifyResourcesProvisionedForSpace(t, awaitilities, space1.Name)
+			// the second space won't be provisioned immediately
+			waitUntilSpaceIsPendingCluster(t, hostAwait, space2.Name)
+			t.Run("reset the max number and expect the second space will be provisioned as well", func(t *testing.T) {
+				// when
+				hostAwait.UpdateToolchainConfig(t,
+					testconfig.CapacityThresholds().
+						MaxNumberOfSpaces(
+							testconfig.PerMemberCluster(memberAwait1.ClusterName, 500),
+							testconfig.PerMemberCluster(memberAwait2.ClusterName, 500),
+						),
+				)
+
+				// then
+				VerifyResourcesProvisionedForSpace(t, awaitilities, space2.Name)
+			})
+		})
+	})
+
 	t.Run("set low capacity threshold and expect that space will have default tier, but won't have target cluster so it won't be provisioned", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(t,
@@ -59,69 +111,6 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 
 			// then
 			VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
-		})
-	})
-
-	t.Run("set low max number of spaces and expect that space won't be provisioned but added on waiting list", func(t *testing.T) {
-		// given
-		hostAwait.UpdateToolchainConfig(t,
-			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(
-					testconfig.PerMemberCluster(memberAwait1.ClusterName, 1),
-					testconfig.PerMemberCluster(memberAwait2.ClusterName, 1),
-				),
-		)
-
-		// when
-		space1, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithName("space-waitinglist1"))
-
-		// we need to sleep one second to create UserSignup with different creation time
-		time.Sleep(time.Second)
-		space2, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithName("space-waitinglist2"))
-
-		// then
-		waitUntilSpaceIsPendingCluster(t, hostAwait, space1.Name)
-		waitUntilSpaceIsPendingCluster(t, hostAwait, space2.Name)
-
-		t.Run("increment the max number of spaces and expect that first space will be provisioned.", func(t *testing.T) {
-			// when
-			toolchainStatus, err := hostAwait.WaitForToolchainStatus(t,
-				wait.UntilToolchainStatusUpdatedAfter(time.Now()))
-			require.NoError(t, err)
-			spaceLimitsM1, spaceLimitsM2 := 0, 0
-			for _, m := range toolchainStatus.Status.Members {
-				if memberAwait1.ClusterName == m.ClusterName {
-					spaceLimitsM1 = m.SpaceCount
-				} else if memberAwait2.ClusterName == m.ClusterName {
-					spaceLimitsM2 = m.SpaceCount
-				}
-			}
-			hostAwait.UpdateToolchainConfig(t,
-				testconfig.CapacityThresholds().
-					MaxNumberOfSpaces(
-						// increment max spaces only on member1
-						testconfig.PerMemberCluster(memberAwait1.ClusterName, spaceLimitsM1+1),
-						testconfig.PerMemberCluster(memberAwait2.ClusterName, spaceLimitsM2),
-					),
-			)
-
-			// then
-			VerifyResourcesProvisionedForSpace(t, awaitilities, space1.Name)
-			// the second space won't be provisioned immediately
-			waitUntilSpaceIsPendingCluster(t, hostAwait, space2.Name)
-			t.Run("reset the max number and expect the second space will be provisioned as well", func(t *testing.T) {
-				// when
-				hostAwait.UpdateToolchainConfig(t,
-					testconfig.CapacityThresholds().
-						MaxNumberOfSpaces(
-							testconfig.PerMemberCluster(memberAwait1.ClusterName, 500),
-							testconfig.PerMemberCluster(memberAwait2.ClusterName, 500),
-						),
-				)
-
-				// then
-				VerifyResourcesProvisionedForSpace(t, awaitilities, space2.Name)
-			})
 		})
 	})
 

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -28,7 +28,7 @@ func TestToolchainClusterE2E(t *testing.T) {
 // in the target cluster type operator
 func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wait.Awaitility) {
 	// given
-	current, ok, err := await.GetToolchainCluster(otherAwait.Type, otherAwait.Namespace, nil)
+	current, ok, err := await.GetToolchainCluster(t, otherAwait.Type, otherAwait.Namespace, nil)
 	require.NoError(t, err)
 	require.True(t, ok, "ToolchainCluster should exist")
 
@@ -55,12 +55,12 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 		// then the ToolchainCluster should be ready
 		require.NoError(t, err)
-		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, wait.ReadyToolchainCluster)
+		_, err = await.WaitForNamedToolchainClusterWithCondition(t, toolchainCluster.Name, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 		// other ToolchainCluster should be ready, too
-		_, err = await.WaitForToolchainClusterWithCondition(otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = await.WaitForToolchainClusterWithCondition(t, otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
-		_, err = otherAwait.WaitForToolchainClusterWithCondition(await.Type, await.Namespace, wait.ReadyToolchainCluster)
+		_, err = otherAwait.WaitForToolchainClusterWithCondition(t, await.Type, await.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 	})
 
@@ -86,15 +86,15 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		err := await.Client.Create(context.TODO(), toolchainCluster)
 		// then the ToolchainCluster should be offline
 		require.NoError(t, err)
-		_, err = await.WaitForNamedToolchainClusterWithCondition(toolchainCluster.Name, &toolchainv1alpha1.ToolchainClusterCondition{
+		_, err = await.WaitForNamedToolchainClusterWithCondition(t, toolchainCluster.Name, &toolchainv1alpha1.ToolchainClusterCondition{
 			Type:   toolchainv1alpha1.ToolchainClusterOffline,
 			Status: corev1.ConditionTrue,
 		})
 		require.NoError(t, err)
 		// other ToolchainCluster should be ready, too
-		_, err = await.WaitForToolchainClusterWithCondition(otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = await.WaitForToolchainClusterWithCondition(t, otherAwait.Type, otherAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
-		_, err = otherAwait.WaitForToolchainClusterWithCondition(await.Type, await.Namespace, wait.ReadyToolchainCluster)
+		_, err = otherAwait.WaitForToolchainClusterWithCondition(t, await.Type, await.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 	})
 }

--- a/test/e2e/toolchainstatus_test.go
+++ b/test/e2e/toolchainstatus_test.go
@@ -20,7 +20,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	hostAwait.UpdateToolchainConfig(
+	hostAwait.UpdateToolchainConfig(t,
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))
 
@@ -30,7 +30,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 	// so we can start with accurate counters/metrics and not get flaky because of previous tests,
 	// in particular w.r.t the `userSignupsPerActivationAndDomain` counter which is not decremented when a user
 	// is deleted
-	err := hostAwait.DeleteToolchainStatus("toolchain-status")
+	err := hostAwait.DeleteToolchainStatus(t, "toolchain-status")
 	require.NoError(t, err)
 	// restarting the pod after the `toolchain-status` resource was deleted will trigger a recount based on resources
 	err = hostAwait.DeletePods(client.InNamespace(hostAwait.Namespace), client.MatchingLabels{"name": "controller-manager"})
@@ -59,7 +59,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 
 		t.Run("verify metrics did not change after restarting pod without forcing recount", func(t *testing.T) {
 			// given
-			hostAwait.UpdateToolchainConfig(testconfig.Metrics().ForceSynchronization(false))
+			hostAwait.UpdateToolchainConfig(t, testconfig.Metrics().ForceSynchronization(false))
 
 			// when restarting the pod
 			err := hostAwait.DeletePods(client.InNamespace(hostAwait.Namespace), client.MatchingLabels{"name": "controller-manager"})
@@ -67,13 +67,13 @@ func TestForceMetricsSynchronization(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			// metrics have not changed yet
-			metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external")                       // value was increased by 1
-			metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // value was increased by 1
+			metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external")                       // value was increased by 1
+			metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // value was increased by 1
 		})
 
 		t.Run("verify metrics are still correct after restarting pod and forcing recount", func(t *testing.T) {
 			// given
-			hostAwait.UpdateToolchainConfig(testconfig.Metrics().ForceSynchronization(true))
+			hostAwait.UpdateToolchainConfig(t, testconfig.Metrics().ForceSynchronization(true))
 
 			// when restarting the pod
 			// TODO: unneeded once the ToolchainConfig controller will be in place ?
@@ -82,8 +82,8 @@ func TestForceMetricsSynchronization(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			// metrics have been updated
-			metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external")                        // unchanged
-			metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "10", "domain", "external") // updated
+			metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external")                        // unchanged
+			metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "10", "domain", "external") // updated
 
 		})
 	})

--- a/test/e2e/user_rolebindings_test.go
+++ b/test/e2e/user_rolebindings_test.go
@@ -32,13 +32,13 @@ func TestUserCreatingRoleBindings(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create and approve a sandbox user
-	testsupport.NewSignupRequest(t, awaitilities).
+	testsupport.NewSignupRequest(awaitilities).
 		Username("harleyquinn").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(testsupport.ConditionSet(testsupport.Default(), testsupport.ApprovedByAdmin())...).
-		Execute()
+		Execute(t)
 
 	//create a non-sandbox user
 	nonsandboxUser := userv1.User{

--- a/test/e2e/user_workloads_test.go
+++ b/test/e2e/user_workloads_test.go
@@ -38,21 +38,21 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	hostAwait := s.Host()
 	memberAwait := s.Member1()
 	// Provision a user to idle with a short idling timeout
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
-	NewSignupRequest(s.T(), s.Awaitilities).
+	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
+	NewSignupRequest(s.Awaitilities).
 		Username("test-idler").
 		Email("test-idler@redhat.com").
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute()
+		Execute(s.T())
 
-	idler, err := memberAwait.WaitForIdler("test-idler-dev", wait.IdlerConditions(Running()))
+	idler, err := memberAwait.WaitForIdler(s.T(), "test-idler-dev", wait.IdlerConditions(Running()))
 	require.NoError(s.T(), err)
 
 	// Noise
-	idlerNoise, err := memberAwait.WaitForIdler("test-idler-stage", wait.IdlerConditions(Running()))
+	idlerNoise, err := memberAwait.WaitForIdler(s.T(), "test-idler-stage", wait.IdlerConditions(Running()))
 	require.NoError(s.T(), err)
 
 	// Create payloads for both users
@@ -60,50 +60,50 @@ func (s *userWorkloadsTestSuite) TestIdlerAndPriorityClass() {
 	podsNoise := s.prepareWorkloads(idlerNoise.Name, wait.WithSandboxPriorityClass())
 
 	// Create another noise pods in non-user namespace
-	memberAwait.CreateNamespace("workloads-noise")
+	memberAwait.CreateNamespace(s.T(), "workloads-noise")
 	externalNsPodsNoise := s.prepareWorkloads("workloads-noise", wait.WithOriginalPriorityClass())
 
 	// Set a short timeout for one of the idler to trigger pod idling
 	idler.Spec.TimeoutSeconds = 5
-	idler, err = memberAwait.UpdateIdlerSpec(idler) // The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
+	idler, err = memberAwait.UpdateIdlerSpec(s.T(), idler) // The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
 	require.NoError(s.T(), err)
 
 	// Wait for the pods to be deleted
 	for _, p := range podsToIdle {
-		err := memberAwait.WaitUntilPodsDeleted(p.Namespace, wait.WithPodName(p.Name))
+		err := memberAwait.WaitUntilPodsDeleted(s.T(), p.Namespace, wait.WithPodName(p.Name))
 		require.NoError(s.T(), err)
 	}
 	// check notification was created
-	_, err = hostAwait.WaitForNotificationWithName("test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
+	_, err = hostAwait.WaitForNotificationWithName(s.T(), "test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
 	require.NoError(s.T(), err)
 
 	// make sure that "noise" pods are still there, and notification is not created for stage namespace
-	_, err = memberAwait.WaitForPods(idlerNoise.Name, len(podsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithSandboxPriorityClass())
+	_, err = memberAwait.WaitForPods(s.T(), idlerNoise.Name, len(podsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithSandboxPriorityClass())
 	require.NoError(s.T(), err)
-	_, err = memberAwait.WaitForPods("workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
+	_, err = memberAwait.WaitForPods(s.T(), "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(s.T(), err)
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName("test-idler-stage-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
+	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName(s.T(), "test-idler-stage-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
 	require.True(s.T(), errors.IsNotFound(err))
 
 	// Check if notification has been deleted before creating another pod
-	err = hostAwait.WaitUntilNotificationWithNameDeleted("test-idler-dev-idled")
+	err = hostAwait.WaitUntilNotificationWithNameDeleted(s.T(), "test-idler-dev-idled")
 	require.NoError(s.T(), err)
 
 	// Create another pod and make sure it's deleted.
 	// In the tests above the Idler reconcile was triggered after we changed the Idler resource (to set a short timeout).
 	// Now we want to verify that the idler reconcile is triggered without modifying the Idler resource.
 	// Notification shouldn't be created again.
-	pod := s.createStandalonePod(idler.Name, "idler-test-pod-2")    // create just one standalone pod. No need to create all possible pod controllers which may own pods.
-	_, err = memberAwait.WaitForPod(idler.Name, "idler-test-pod-2") // pod was created
+	pod := s.createStandalonePod(idler.Name, "idler-test-pod-2")           // create just one standalone pod. No need to create all possible pod controllers which may own pods.
+	_, err = memberAwait.WaitForPod(s.T(), idler.Name, "idler-test-pod-2") // pod was created
 	require.NoError(s.T(), err)
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
-	err = memberAwait.WaitUntilPodDeleted(pod.Namespace, pod.Name)
+	err = memberAwait.WaitUntilPodDeleted(s.T(), pod.Namespace, pod.Name)
 	require.NoError(s.T(), err)
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName("test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
+	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName(s.T(), "test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(Sent()))
 	require.True(s.T(), errors.IsNotFound(err))
 
 	// There should not be any pods left in the namespace
-	err = memberAwait.WaitUntilPodsDeleted(idler.Name, wait.WithPodLabel("idler", "idler"))
+	err = memberAwait.WaitUntilPodsDeleted(s.T(), idler.Name, wait.WithPodLabel("idler", "idler"))
 	require.NoError(s.T(), err)
 }
 
@@ -131,7 +131,7 @@ func (s *userWorkloadsTestSuite) prepareWorkloads(namespace string, additionalPo
 	rc := s.createReplicationController(namespace)
 	n = n + int(*rc.Spec.Replicas)
 
-	pods, err := memberAwait.WaitForPods(namespace, n, append(additionalPodCriteria, wait.PodRunning(),
+	pods, err := memberAwait.WaitForPods(s.T(), namespace, n, append(additionalPodCriteria, wait.PodRunning(),
 		wait.WithPodLabel("idler", "idler"))...)
 	require.NoError(s.T(), err)
 	return pods
@@ -149,7 +149,7 @@ func (s *userWorkloadsTestSuite) createDeployment(namespace string) *appsv1.Depl
 			Template: podTemplateSpec("idler-deployment"),
 		},
 	}
-	err := memberAwait.Create(deployment)
+	err := memberAwait.Create(s.T(), deployment)
 	require.NoError(s.T(), err)
 
 	return deployment
@@ -167,7 +167,7 @@ func (s *userWorkloadsTestSuite) createReplicaSet(namespace string) *appsv1.Repl
 			Template: podTemplateSpec("idler-rs"),
 		},
 	}
-	err := memberAwait.Create(rs)
+	err := memberAwait.Create(s.T(), rs)
 	require.NoError(s.T(), err)
 
 	return rs
@@ -183,7 +183,7 @@ func (s *userWorkloadsTestSuite) createDaemonSet(namespace string) *appsv1.Daemo
 			Template: podTemplateSpec("idler-ds"),
 		},
 	}
-	err := memberAwait.Create(ds)
+	err := memberAwait.Create(s.T(), ds)
 	require.NoError(s.T(), err)
 
 	return ds
@@ -199,7 +199,7 @@ func (s *userWorkloadsTestSuite) createJob(namespace string) *batchv1.Job {
 		},
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
-	err := memberAwait.Create(job)
+	err := memberAwait.Create(s.T(), job)
 	require.NoError(s.T(), err)
 
 	return job
@@ -218,7 +218,7 @@ func (s *userWorkloadsTestSuite) createDeploymentConfig(namespace string) *opens
 			Template: &spec,
 		},
 	}
-	err := memberAwait.Create(dc)
+	err := memberAwait.Create(s.T(), dc)
 	require.NoError(s.T(), err)
 
 	return dc
@@ -237,7 +237,7 @@ func (s *userWorkloadsTestSuite) createReplicationController(namespace string) *
 			Template: &spec,
 		},
 	}
-	err := memberAwait.Create(rc)
+	err := memberAwait.Create(s.T(), rc)
 	require.NoError(s.T(), err)
 
 	return rc
@@ -255,7 +255,7 @@ func (s *userWorkloadsTestSuite) createStandalonePod(namespace, name string) *co
 		Spec: podSpec(),
 	}
 	pod.Spec.PriorityClassName = "system-cluster-critical"
-	err := memberAwait.Create(pod)
+	err := memberAwait.Create(s.T(), pod)
 	require.NoError(s.T(), err)
 	return pod
 }

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -27,7 +27,7 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -37,51 +37,52 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 		username := fmt.Sprintf("user-%04d", i)
 
 		// Create UserSignup
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait2).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                                                            // all signups
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all activated
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)                                                    // all activated
-	metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 0)                                                 // none deactivated
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // none activated on member-1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 2, "cluster_name", memberAwait2.ClusterName)                 // all activated on member-2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 2, "cluster_name", memberAwait2.ClusterName) // 2 spaces created on member-2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 2)                                                            // all signups
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all activated
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 2)                                                    // all activated
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsDeactivatedMetric, 0)                                                 // none deactivated
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // none activated on member-1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 2, "cluster_name", memberAwait2.ClusterName)                 // all activated on member-2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 2, "cluster_name", memberAwait2.ClusterName) // 2 spaces created on member-2
 
 	// when deactivating the users
 	for username, usersignup := range usersignups {
-		_, err := hostAwait.UpdateUserSignup(usersignup.Name, func(usersignup *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivated(usersignup, true)
-		})
+		_, err := hostAwait.UpdateUserSignup(t, usersignup.Name,
+			func(usersignup *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(usersignup, true)
+			})
 		require.NoError(t, err)
 
-		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(username)
+		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
 		require.NoError(t, err)
 
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(username)
+		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, username)
 		require.NoError(t, err)
 	}
 
 	// then verify the value of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 2)                                                            // all signups (even if deactivated)
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all deactivated (but this metric is never decremented)
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 2)                                                    // all deactivated (but counters are never decremented)
-	metricsAssertion.WaitForMetricDelta(UserSignupsDeactivatedMetric, 2)                                                 // all deactivated
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // all deactivated on member-1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)                 // all deactivated on member-2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName) // 2 spaces deleted from member-2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 2)                                                            // all signups (even if deactivated)
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "internal") // all deactivated (but this metric is never decremented)
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // never incremented
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 2)                                                    // all deactivated (but counters are never decremented)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsDeactivatedMetric, 2)                                                 // all deactivated
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)                  // all deactivated on member-1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)                 // all deactivated on member-2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName) // 2 spaces deleted from member-2
 
 }
 
@@ -94,7 +95,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -105,48 +106,49 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		username := fmt.Sprintf("user-%04d", i)
 
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
-			_, err := hostAwait.UpdateUserSignup(usersignups[username].Name, func(usersignup *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(usersignup, true)
-			})
+			_, err := hostAwait.UpdateUserSignup(t, usersignups[username].Name,
+				func(usersignup *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(usersignup, true)
+				})
 			require.NoError(t, err)
 
-			err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(username)
+			err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
 			require.NoError(t, err)
 
-			err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(username)
+			err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, username)
 			require.NoError(t, err)
 
 			// reactivate the user
-			usersignups[username], _ = NewSignupRequest(t, awaitilities).
+			usersignups[username], _ = NewSignupRequest(awaitilities).
 				IdentityID(uuid.Must(uuid.FromString(usersignups[username].Spec.Userid))).
 				Username(username).
 				ManuallyApprove().
 				TargetCluster(memberAwait).
 				EnsureMUR().
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-				Execute().
+				Execute(t).
 				Resources()
 		}
 	}
 
 	// then verify the value of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "1", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "2", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 1, "activations", "3", "domain", "external") // 1 activation
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "1", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "2", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 1, "activations", "3", "domain", "external") // 1 activation
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
 
 	t.Run("restart host-operator pod and verify that metrics are still available", func(t *testing.T) {
 		// given
@@ -158,15 +160,15 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 		// then check how much time it takes to restart and process all existing resources
 		require.NoError(t, err)
 		// host metrics should become available again at this point
-		_, err = hostAwait.WaitForRouteToBeAvailable(hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
+		_, err = hostAwait.WaitForRouteToBeAvailable(t, hostAwait.Namespace, "host-operator-metrics-service", "/metrics")
 		require.NoError(t, err, "failed while setting up or waiting for the route to the 'host-operator-metrics-service' service to be available")
 		// also verify that the metric values "survived" the restart
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // user-0001 was 1 time (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "external") // user-0002 was 2 times (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "external") // user-0003 was 3 times (unchanged after pod restarted)
-		metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "external") // user-0001 was 1 time (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "1", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "external") // user-0002 was 2 times (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "2", "domain", "internal") // no activation
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "external") // user-0003 was 3 times (unchanged after pod restarted)
+		metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 0, "activations", "3", "domain", "internal") // no activation
 	})
 }
 
@@ -176,7 +178,7 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
@@ -185,12 +187,12 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
-		usersignups[username], _ = NewSignupRequest(t, awaitilities).
+		usersignups[username], _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 
@@ -200,13 +202,13 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for space to be deleted
-	err = hostAwait.WaitUntilUserSignupDeleted(usersignups["user-0001"].GetName())
+	err = hostAwait.WaitUntilUserSignupDeleted(t, usersignups["user-0001"].GetName())
 	require.NoError(t, err)
-	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(usersignups["user-0001"].GetName())
+	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, usersignups["user-0001"].GetName())
 	require.NoError(t, err)
 
 	// and verify that the values of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // user-0001 and user-0002 have been provisioned
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // user-0001 and user-0002 have been provisioned
 
 	// when deleting user "user-0002"
 	err = hostAwait.Client.Delete(context.TODO(), usersignups["user-0002"])
@@ -215,13 +217,13 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// wait for space to be deleted
-	err = hostAwait.WaitUntilUserSignupDeleted(usersignups["user-0002"].GetName())
+	err = hostAwait.WaitUntilUserSignupDeleted(t, usersignups["user-0002"].GetName())
 	require.NoError(t, err)
-	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(usersignups["user-0002"].GetName())
+	err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, usersignups["user-0002"].GetName())
 	require.NoError(t, err)
 
 	// and verify that the values of the `sandbox_users_per_activations` metric
-	metricsAssertion.WaitForMetricDelta(UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // same offset as above: users has been deleted but metric remains unchanged
+	metricsAssertion.WaitForMetricDelta(t, UsersPerActivationsAndDomainMetric, 2, "activations", "1", "domain", "external") // same offset as above: users has been deleted but metric remains unchanged
 }
 
 // TestMetricsWhenUsersBanned verifies that the relevant gauges are decreased when a user is banned, and increased again when unbanned
@@ -238,35 +240,35 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	// given
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
-	userSignup, _ := NewSignupRequest(t, awaitilities).
+	userSignup, _ := NewSignupRequest(awaitilities).
 		Username("metricsbanprovisioned").
 		Email("metricsbanprovisioned@test.com").
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().Resources()
+		Execute(t).Resources()
 
 	// when creating the BannedUser resource
 	bannedUser := banUser(t, hostAwait, userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 
 	// then
 	// confirm the user is banned
-	_, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(userSignup.Name,
+	_, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(t, userSignup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...))
 	require.NoError(t, err)
 	// verify the metrics
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 1)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)  // no user on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName)  // no user on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
 
 	t.Run("unban the banned user", func(t *testing.T) {
 		// given
@@ -278,23 +280,23 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 		// then
 		// confirm the BannedUser resource is deleted
-		err = hostAwait.WaitUntilBannedUserDeleted(bannedUser.GetName())
+		err = hostAwait.WaitUntilBannedUserDeleted(t, bannedUser.GetName())
 		require.NoError(t, err)
 		// wait for space to be deleted
-		err = hostAwait.WaitUntilUserSignupDeleted(bannedUser.GetName())
+		err = hostAwait.WaitUntilUserSignupDeleted(t, bannedUser.GetName())
 		require.NoError(t, err)
-		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(bannedUser.GetName())
+		err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, bannedUser.GetName())
 		require.NoError(t, err)
 		// verify the metrics
-		metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 0)         // unchanged: user signup already existed
-		metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // user approved
-		metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)   // unchanged: banneduser already existed
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user provisioned on member1
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space provisioned on member1
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no spaces on member2
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 0)         // unchanged: user signup already existed
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // user approved
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)   // unchanged: banneduser already existed
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user provisioned on member1
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space provisioned on member1
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no spaces on member2
 	})
 }
 
@@ -305,71 +307,73 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	hostAwait.UpdateToolchainConfig(testconfig.AutomaticApproval().Enabled(false))
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// host metrics should be available at this point
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 	// Create UserSignup
-	_, mur := NewSignupRequest(t, awaitilities).
+	_, mur := NewSignupRequest(awaitilities).
 		Username("janedoe").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute().
+		Execute(t).
 		Resources()
 
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // approved
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space present on member1
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // approved
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space present on member1
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
 
 	// when disabling MUR
-	_, err := hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
-		mur.Spec.Disabled = true
-	})
+	_, err := hostAwait.UpdateMasterUserRecordSpec(t, mur.Name,
+		func(mur *toolchainv1alpha1.MasterUserRecord) {
+			mur.Spec.Disabled = true
+		})
 	require.NoError(t, err)
 
 	// then
 	// verify the metrics
-	metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 1)
-	metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 1) // still approved even though (temporarily) disabled
-	metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-	metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 1, "domain", "external")
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
-	metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space is on member1
-	metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 1)
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 1) // still approved even though (temporarily) disabled
+	metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+	metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 1, "domain", "external")
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 1, "cluster_name", memberAwait.ClusterName)  // user is on member1
+	metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName) // no user on member2
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 1, "cluster_name", memberAwait.ClusterName)        // space is on member1
+	metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)       // no space on member2
 
 	t.Run("re-enabled mur", func(t *testing.T) {
 		// given
 		metricsAssertion := InitMetricsAssertion(t, awaitilities)
 
 		// When re-enabling MUR
-		mur, err = hostAwait.UpdateMasterUserRecordSpec(mur.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
-			mur.Spec.Disabled = false
-		})
+		mur, err = hostAwait.UpdateMasterUserRecordSpec(t, mur.Name,
+			func(mur *toolchainv1alpha1.MasterUserRecord) {
+				mur.Spec.Disabled = false
+			})
 		require.NoError(t, err)
 
 		// then
 		// verify the metrics
-		metricsAssertion.WaitForMetricDelta(UserSignupsMetric, 0)         // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserSignupsApprovedMetric, 0) // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserSignupsBannedMetric, 0)
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "external") // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName) // unchanged, user was already provisioned
-		metricsAssertion.WaitForMetricDelta(UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
-		metricsAssertion.WaitForMetricDelta(SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsMetric, 0)         // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsApprovedMetric, 0) // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserSignupsBannedMetric, 0)
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "external") // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, MasterUserRecordsPerDomainMetric, 0, "domain", "internal")
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait.ClusterName) // unchanged, user was already provisioned
+		metricsAssertion.WaitForMetricDelta(t, UserAccountsMetric, 0, "cluster_name", memberAwait2.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait.ClusterName)
+		metricsAssertion.WaitForMetricDelta(t, SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName)
 
 	})
 }
@@ -387,7 +391,7 @@ func banUser(t *testing.T, hostAwait *wait.HostAwaitility, email string) *toolch
 			Email: email,
 		},
 	}
-	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
+	err := hostAwait.CreateWithCleanup(t, bannedUser)
 	require.NoError(t, err)
 	return bannedUser
 }

--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -12,11 +12,10 @@ func TestSetupMigration(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 
 	runner := migration.SetupMigrationRunner{
-		T:            t,
 		Awaitilities: awaitilities,
 		WithCleanup:  false,
 	}
 
-	runner.Run()
+	runner.Run(t)
 
 }

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -27,15 +27,14 @@ const (
 )
 
 type SetupMigrationRunner struct {
-	T            *testing.T
 	Awaitilities wait.Awaitilities
 	WithCleanup  bool
 }
 
-func (r *SetupMigrationRunner) Run() {
+func (r *SetupMigrationRunner) Run(t *testing.T) {
 	var wg sync.WaitGroup
 
-	toRun := []func(){
+	toRun := []func(t *testing.T){
 		r.prepareAppStudioProvisionedSpace,
 		r.prepareSecondMemberProvisionedSpace,
 		r.prepareProvisionedUser,
@@ -46,97 +45,98 @@ func (r *SetupMigrationRunner) Run() {
 
 	for _, funcToRun := range toRun {
 		wg.Add(1)
-		go func(run func()) {
+		go func(run func(t *testing.T)) {
 			defer wg.Done()
-			run()
+			run(t)
 		}(funcToRun)
 	}
 
 	wg.Wait()
 }
 
-func (r *SetupMigrationRunner) prepareAppStudioProvisionedSpace() {
-	r.createAndWaitForSpace(ProvisionedAppStudioSpace, "appstudio", r.Awaitilities.Member1())
+func (r *SetupMigrationRunner) prepareAppStudioProvisionedSpace(t *testing.T) {
+	r.createAndWaitForSpace(t, ProvisionedAppStudioSpace, "appstudio", r.Awaitilities.Member1())
 }
 
-func (r *SetupMigrationRunner) prepareSecondMemberProvisionedSpace() {
-	r.createAndWaitForSpace(SecondMemberProvisionedSpace, "base", r.Awaitilities.Member2())
+func (r *SetupMigrationRunner) prepareSecondMemberProvisionedSpace(t *testing.T) {
+	r.createAndWaitForSpace(t, SecondMemberProvisionedSpace, "base", r.Awaitilities.Member2())
 }
 
-func (r *SetupMigrationRunner) createAndWaitForSpace(name, tierName string, targetCluster *wait.MemberAwaitility) {
+func (r *SetupMigrationRunner) createAndWaitForSpace(t *testing.T, name, tierName string, targetCluster *wait.MemberAwaitility) {
 	hostAwait := r.Awaitilities.Host()
-	space := test.NewSpace(r.Awaitilities, test.WithName(name), test.WithTierName(tierName), test.WithTargetCluster(targetCluster.ClusterName))
+	space := test.NewSpace(t, r.Awaitilities, test.WithName(name), test.WithTierName(tierName), test.WithTargetCluster(targetCluster.ClusterName))
 	err := hostAwait.Client.Create(context.TODO(), space)
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 
-	test.CreateMurWithAdminSpaceBindingForSpace(r.T, r.Awaitilities, space, false)
+	test.CreateMurWithAdminSpaceBindingForSpace(t, r.Awaitilities, space, false)
 
-	_, err = hostAwait.WaitForSpace(space.Name,
+	_, err = hostAwait.WaitForSpace(t, space.Name,
 		wait.UntilSpaceHasConditions(test.Provisioned()))
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 	if r.WithCleanup {
-		cleanup.AddCleanTasks(r.Awaitilities.Host(), space)
+		cleanup.AddCleanTasks(t, r.Awaitilities.Host().Client, space)
 	}
 }
 
-func (r *SetupMigrationRunner) prepareProvisionedUser() {
-	r.prepareUser(ProvisionedUser, r.Awaitilities.Member1())
+func (r *SetupMigrationRunner) prepareProvisionedUser(t *testing.T) {
+	r.prepareUser(t, ProvisionedUser, r.Awaitilities.Member1())
 }
 
-func (r *SetupMigrationRunner) prepareSecondMemberProvisionedUser() {
-	r.prepareUser(SecondMemberProvisionedUser, r.Awaitilities.Member2())
+func (r *SetupMigrationRunner) prepareSecondMemberProvisionedUser(t *testing.T) {
+	r.prepareUser(t, SecondMemberProvisionedUser, r.Awaitilities.Member2())
 }
 
-func (r *SetupMigrationRunner) prepareDeactivatedUser() {
-	userSignup := r.prepareUser(DeactivatedUser, r.Awaitilities.Member1())
+func (r *SetupMigrationRunner) prepareDeactivatedUser(t *testing.T) {
+	userSignup := r.prepareUser(t, DeactivatedUser, r.Awaitilities.Member1())
 	hostAwait := r.Awaitilities.Host()
 
 	// deactivate the UserSignup
-	userSignup, err := hostAwait.UpdateUserSignup(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-		states.SetDeactivated(us, true)
-	})
-	require.NoError(r.T, err)
-	r.T.Logf("user signup '%s' set to deactivated", userSignup.Name)
+	userSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+		func(us *toolchainv1alpha1.UserSignup) {
+			states.SetDeactivated(us, true)
+		})
+	require.NoError(t, err)
+	t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
 	// verify that MUR is deleted
-	err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(userSignup.Status.CompliantUsername) // TODO wait for space deletion too after Space migration is done
-	require.NoError(r.T, err)
+	err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, userSignup.Status.CompliantUsername) // TODO wait for space deletion too after Space migration is done
+	require.NoError(t, err)
 }
 
-func (r *SetupMigrationRunner) prepareBannedUser() {
-	userSignup := r.prepareUser(BannedUser, r.Awaitilities.Member1())
+func (r *SetupMigrationRunner) prepareBannedUser(t *testing.T) {
+	userSignup := r.prepareUser(t, BannedUser, r.Awaitilities.Member1())
 	hostAwait := r.Awaitilities.Host()
 
 	// Create the BannedUser
 	bannedUser := test.NewBannedUser(hostAwait, userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 	err := hostAwait.Client.Create(context.TODO(), bannedUser)
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 
-	r.T.Logf("BannedUser '%s' created", bannedUser.Spec.Email)
+	t.Logf("BannedUser '%s' created", bannedUser.Spec.Email)
 
 	// Confirm the user is banned
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(userSignup.Name,
+	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*15)).WaitForUserSignup(t, userSignup.Name,
 		wait.ContainsCondition(test.Banned()[0]))
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 }
 
-func (r *SetupMigrationRunner) prepareAppStudioProvisionedUser() {
-	r.prepareUser(AppStudioProvisionedUser, r.Awaitilities.Member1())
+func (r *SetupMigrationRunner) prepareAppStudioProvisionedUser(t *testing.T) {
+	r.prepareUser(t, AppStudioProvisionedUser, r.Awaitilities.Member1())
 	hostAwait := r.Awaitilities.Host()
 
 	// promote to appstudio
-	tiers.MoveSpaceToTier(r.T, hostAwait, AppStudioProvisionedUser, "appstudio")
+	tiers.MoveSpaceToTier(t, hostAwait, AppStudioProvisionedUser, "appstudio")
 
-	r.T.Logf("user %s was promoted to appstudio tier", AppStudioProvisionedUser)
+	t.Logf("user %s was promoted to appstudio tier", AppStudioProvisionedUser)
 
 	// verify that it's promoted
-	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(AppStudioProvisionedUser,
+	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(t, AppStudioProvisionedUser,
 		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 }
 
-func (r *SetupMigrationRunner) prepareUser(name string, targetCluster *wait.MemberAwaitility) *toolchainv1alpha1.UserSignup {
-	requestBuilder := test.NewSignupRequest(r.T, r.Awaitilities).
+func (r *SetupMigrationRunner) prepareUser(t *testing.T, name string, targetCluster *wait.MemberAwaitility) *toolchainv1alpha1.UserSignup {
+	requestBuilder := test.NewSignupRequest(r.Awaitilities).
 		Username(name).
 		ManuallyApprove().
 		TargetCluster(targetCluster)
@@ -146,10 +146,10 @@ func (r *SetupMigrationRunner) prepareUser(name string, targetCluster *wait.Memb
 
 	signup, _ := requestBuilder.
 		RequireConditions(test.ConditionSet(test.Default(), test.ApprovedByAdmin())...).
-		Execute().
+		Execute(t).
 		Resources()
-	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(signup.Status.CompliantUsername,
+	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(t, signup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasConditions(test.Provisioned(), test.ProvisionedNotificationCRCreated()))
-	require.NoError(r.T, err)
+	require.NoError(t, err)
 	return signup
 }

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -64,7 +64,7 @@ func TestAfterMigration(t *testing.T) {
 
 	wg.Wait()
 
-	cleanup.ExecuteAllCleanTasks(awaitilities.Host())
+	cleanup.ExecuteAllCleanTasks(t)
 
 	t.Run("run migration setup with new operator versions for compatibility", func(t *testing.T) {
 		// We need to run the migration setup part to ensure the compatibility with both versions of the sandbox (the old one as well as the new one)
@@ -86,60 +86,59 @@ func TestAfterMigration(t *testing.T) {
 		// content of the resources, nor labels, etc... because it was already verified when the PR that was merged. If we agree on such a generic setup logic,
 		// then we can easily make sure that it's fully compatible with both versions of Dev Sandbox.
 		runner := migration.SetupMigrationRunner{
-			T:            t,
 			Awaitilities: awaitilities,
 			WithCleanup:  true,
 		}
 
-		runner.Run()
+		runner.Run(t)
 	})
 }
 
 func verifyAppStudioProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	space, _ := VerifyResourcesProvisionedForSpace(t, awaitilities, migration.ProvisionedAppStudioSpace)
 	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), fmt.Sprintf("for-space-%s", migration.ProvisionedAppStudioSpace))
-	cleanup.AddCleanTasks(awaitilities.Host(), space)
-	cleanup.AddCleanTasks(awaitilities.Host(), userSignupForSpace)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
 }
 
 func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	space, _ := VerifyResourcesProvisionedForSpace(t, awaitilities, migration.SecondMemberProvisionedSpace)
 	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), fmt.Sprintf("for-space-%s", migration.SecondMemberProvisionedSpace))
-	cleanup.AddCleanTasks(awaitilities.Host(), space)
-	cleanup.AddCleanTasks(awaitilities.Host(), userSignupForSpace)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
 }
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
-	cleanup.AddCleanTasks(awaitilities.Host(), signup)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 	DeactivateAndCheckUser(t, awaitilities, signup)
 	ReactivateAndCheckUser(t, awaitilities, signup)
 }
 
 func verifySecondMemberProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
-	cleanup.AddCleanTasks(awaitilities.Host(), signup)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "base")
 	CreateBannedUser(t, awaitilities.Host(), signup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey])
 }
 
 func verifyAppStudioProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
-	cleanup.AddCleanTasks(awaitilities.Host(), signup)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
 }
 
 func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
-	cleanup.AddCleanTasks(awaitilities.Host(), signup)
+	cleanup.AddCleanTasks(t, awaitilities.Host().Client, signup)
 
-	_, err := awaitilities.Host().WaitForUserSignup(signup.Name,
+	_, err := awaitilities.Host().WaitForUserSignup(t, signup.Name,
 		wait.UntilUserSignupContainsConditions(ConditionSet(Default(), DeactivatedWithoutPreDeactivation())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueDeactivated))
 	require.NoError(t, err)
 	require.True(t, states.Deactivated(signup), "usersignup should be deactivated")
 
-	err = awaitilities.Host().WaitUntilMasterUserRecordAndSpaceBindingsDeleted(migration.DeactivatedUser)
+	err = awaitilities.Host().WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, migration.DeactivatedUser)
 	require.NoError(t, err)
 
-	err = awaitilities.Host().WaitUntilSpaceAndSpaceBindingsDeleted(migration.DeactivatedUser)
+	err = awaitilities.Host().WaitUntilSpaceAndSpaceBindingsDeleted(t, migration.DeactivatedUser)
 	require.NoError(t, err)
 
 	ReactivateAndCheckUser(t, awaitilities, signup)
@@ -147,18 +146,18 @@ func verifyDeactivatedSignup(t *testing.T, awaitilities wait.Awaitilities, signu
 
 func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {
 	hostAwait := awaitilities.Host()
-	cleanup.AddCleanTasks(hostAwait, signup)
+	cleanup.AddCleanTasks(t, hostAwait.Client, signup)
 
 	// verify that it's still banned
-	_, err := hostAwait.WaitForUserSignup(signup.Name,
+	_, err := hostAwait.WaitForUserSignup(t, signup.Name,
 		wait.UntilUserSignupHasConditions(ConditionSet(Default(), ApprovedByAdmin(), Banned())...),
 		wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
 	require.NoError(t, err)
 
-	err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(migration.BannedUser)
+	err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, migration.BannedUser)
 	require.NoError(t, err)
 
-	err = awaitilities.Host().WaitUntilSpaceAndSpaceBindingsDeleted(migration.BannedUser)
+	err = awaitilities.Host().WaitUntilSpaceAndSpaceBindingsDeleted(t, migration.BannedUser)
 	require.NoError(t, err)
 
 	// get the BannedUser resource
@@ -179,13 +178,13 @@ func verifyBannedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *to
 }
 
 func checkMURMigratedAndGetSignup(t *testing.T, hostAwait *wait.HostAwaitility, murName string) *toolchainv1alpha1.UserSignup {
-	provisionedMur, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*120)).WaitForMasterUserRecord(murName,
+	provisionedMur, err := hostAwait.WithRetryOptions(wait.TimeoutOption(time.Second*120)).WaitForMasterUserRecord(t, murName,
 		wait.UntilMasterUserRecordHasCondition(Provisioned()),
 		wait.UntilMasterUserRecordHasNoTierHashLabel(), // after migration there should be no tier hash label so we should wait for that to confirm migration is completed before proceeding
 	)
 	require.NoError(t, err)
 
-	signup, err := hostAwait.WaitForUserSignup(provisionedMur.Labels[toolchainv1alpha1.OwnerLabelKey])
+	signup, err := hostAwait.WaitForUserSignup(t, provisionedMur.Labels[toolchainv1alpha1.OwnerLabelKey])
 	require.NoError(t, err)
 
 	checkMURMigrated(t, provisionedMur)

--- a/testsupport/banneduser.go
+++ b/testsupport/banneduser.go
@@ -1,7 +1,6 @@
 package testsupport
 
 import (
-	"context"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -16,7 +15,7 @@ import (
 // CreateBannedUser creates the BannedUser resource
 func CreateBannedUser(t *testing.T, hostAwait *wait.HostAwaitility, email string) *toolchainv1alpha1.BannedUser {
 	bannedUser := NewBannedUser(hostAwait, email)
-	err := hostAwait.CreateWithCleanup(context.TODO(), bannedUser)
+	err := hostAwait.CreateWithCleanup(t, bannedUser)
 	require.NoError(t, err)
 
 	t.Logf("BannedUser '%s' created", bannedUser.Spec.Email)

--- a/testsupport/cleanup/clean.go
+++ b/testsupport/cleanup/clean.go
@@ -40,12 +40,11 @@ var cleaning = &cleanManager{
 
 type AwaitilityInt interface {
 	GetClient() client.Client
-	GetT() *testing.T
 }
 
 // AddCleanTasks adds cleaning tasks for the given objects that will be automatically performed at the end of the test execution
-func AddCleanTasks(a AwaitilityInt, objects ...client.Object) {
-	cleaning.addCleanTasks(a.GetT(), a.GetClient(), objects...)
+func AddCleanTasks(t *testing.T, cl client.Client, objects ...client.Object) {
+	cleaning.addCleanTasks(t, cl, objects...)
 }
 
 func (c *cleanManager) addCleanTasks(t *testing.T, cl client.Client, objects ...client.Object) {
@@ -60,8 +59,8 @@ func (c *cleanManager) addCleanTasks(t *testing.T, cl client.Client, objects ...
 }
 
 // ExecuteAllCleanTasks triggers cleanup of all resources that were marked to be cleaned before that
-func ExecuteAllCleanTasks(a AwaitilityInt) {
-	cleaning.clean(a.GetT())()
+func ExecuteAllCleanTasks(t *testing.T) {
+	cleaning.clean(t)()
 }
 
 func (c *cleanManager) clean(t *testing.T) func() {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -61,7 +61,7 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		})
 		require.NoError(t, err)
 
-		initHostAwait = wait.NewHostAwaitility(t, kubeconfig, cl, hostNs, registrationServiceNs)
+		initHostAwait = wait.NewHostAwaitility(kubeconfig, cl, hostNs, registrationServiceNs)
 
 		// wait for host operator to be ready
 		initHostAwait.WaitForDeploymentToGetReady(t, "host-operator-controller-manager", 1)
@@ -163,7 +163,7 @@ func getMemberAwaitility(t *testing.T, cl client.Client, hostAwait *wait.HostAwa
 	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition(t, "member", namespace, wait.ReadyToolchainCluster)
 	require.NoError(t, err)
 	clusterName := memberCluster.Name
-	memberAwait := wait.NewMemberAwaitility(t, memberConfig.RestConfig, memberClient, namespace, clusterName)
+	memberAwait := wait.NewMemberAwaitility(memberConfig.RestConfig, memberClient, namespace, clusterName)
 
 	deployment := memberAwait.WaitForDeploymentToGetReady(t, "member-operator-controller-manager", 1)
 

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -64,13 +64,13 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		initHostAwait = wait.NewHostAwaitility(t, kubeconfig, cl, hostNs, registrationServiceNs)
 
 		// wait for host operator to be ready
-		initHostAwait.WaitForDeploymentToGetReady("host-operator-controller-manager", 1)
+		initHostAwait.WaitForDeploymentToGetReady(t, "host-operator-controller-manager", 1)
 
 		// wait for registration service to be ready
-		initHostAwait.WaitForDeploymentToGetReady("registration-service", 2)
+		initHostAwait.WaitForDeploymentToGetReady(t, "registration-service", 2)
 
 		// set registration service values
-		registrationServiceRoute, err := initHostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "registration-service", "/")
+		registrationServiceRoute, err := initHostAwait.WaitForRouteToBeAvailable(t, registrationServiceNs, "registration-service", "/")
 		require.NoError(t, err, "failed while waiting for registration service route")
 
 		registrationServiceURL := "http://" + registrationServiceRoute.Spec.Host
@@ -80,7 +80,7 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		initHostAwait.RegistrationServiceURL = registrationServiceURL
 
 		// set api proxy values
-		apiRoute, err := initHostAwait.WaitForRouteToBeAvailable(registrationServiceNs, "api", "/proxyhealth")
+		apiRoute, err := initHostAwait.WaitForRouteToBeAvailable(t, registrationServiceNs, "api", "/proxyhealth")
 		require.NoError(t, err)
 		initHostAwait.APIProxyURL = strings.TrimSuffix(fmt.Sprintf("https://%s/%s", apiRoute.Spec.Host, apiRoute.Spec.Path), "/")
 
@@ -90,26 +90,26 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 
 		initMember2Await, _ = getMemberAwaitility(t, cl, initHostAwait, memberNs2)
 
-		hostToolchainCluster, err := initMemberAwait.WaitForToolchainClusterWithCondition("e2e", hostNs, wait.ReadyToolchainCluster)
+		hostToolchainCluster, err := initMemberAwait.WaitForToolchainClusterWithCondition(t, "e2e", hostNs, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 		hostConfig, err := cluster.NewClusterConfig(cl, &hostToolchainCluster, 6*time.Second)
 		require.NoError(t, err)
 		initHostAwait.RestConfig = hostConfig.RestConfig
 
 		// setup host metrics route for metrics verification in tests
-		hostMetricsRoute, err := initHostAwait.SetupRouteForService("host-operator-metrics-service", "/metrics")
+		hostMetricsRoute, err := initHostAwait.SetupRouteForService(t, "host-operator-metrics-service", "/metrics")
 		require.NoError(t, err)
 		initHostAwait.MetricsURL = hostMetricsRoute.Status.Ingress[0].Host
 
 		// setup member metrics route for metrics verification in tests
-		memberMetricsRoute, err := initMemberAwait.SetupRouteForService("member-operator-metrics-service", "/metrics")
+		memberMetricsRoute, err := initMemberAwait.SetupRouteForService(t, "member-operator-metrics-service", "/metrics")
 		require.NoError(t, err, "failed while setting up or waiting for the route to the 'member-operator-metrics' service to be available")
 		initMemberAwait.MetricsURL = memberMetricsRoute.Status.Ingress[0].Host
 
-		_, err = initMemberAwait.WaitForToolchainClusterWithCondition(initHostAwait.Type, initHostAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = initMemberAwait.WaitForToolchainClusterWithCondition(t, initHostAwait.Type, initHostAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 
-		_, err = initMember2Await.WaitForToolchainClusterWithCondition(initHostAwait.Type, initHostAwait.Namespace, wait.ReadyToolchainCluster)
+		_, err = initMember2Await.WaitForToolchainClusterWithCondition(t, initHostAwait.Type, initHostAwait.Namespace, wait.ReadyToolchainCluster)
 		require.NoError(t, err)
 
 		// Wait for the webhooks in Member 1 only because we do not deploy webhooks for Member 2
@@ -129,28 +129,28 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 			}
 		}
 		require.NotEmpty(t, webhookImage, "The value of the env var MEMBER_OPERATOR_WEBHOOK_IMAGE wasn't found in the deployment of the member operator.")
-		initMemberAwait.WaitForMemberWebhooks(webhookImage)
-		initMemberAwait.WaitForAutoscalingBufferApp()
-		initMember2Await.WaitForAutoscalingBufferApp()
+		initMemberAwait.WaitForMemberWebhooks(t, webhookImage)
+		initMemberAwait.WaitForAutoscalingBufferApp(t)
+		initMember2Await.WaitForAutoscalingBufferApp(t)
 
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
 		// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
-		err = initHostAwait.WaitUntilBaseNSTemplateTierIsUpdated()
+		err = initHostAwait.WaitUntilBaseNSTemplateTierIsUpdated(t)
 		require.NoError(t, err)
 
 		// check that the default user tier exists and is updated to the current version, an outdated version is applied from deploy/e2e-tests/usertier-base.yaml as
 		// part of the e2e test setup make target for the purpose of verifying the user tier update mechanism on startup of the host operator
-		err = initHostAwait.WaitUntilBaseUserTierIsUpdated()
+		err = initHostAwait.WaitUntilBaseUserTierIsUpdated(t)
 		require.NoError(t, err)
 
 		t.Log("all operators are ready and in running state")
 	})
 
-	return wait.NewAwaitilities(initHostAwait.ForTest(t), initMemberAwait.ForTest(t), initMember2Await.ForTest(t))
+	return wait.NewAwaitilities(initHostAwait, initMemberAwait, initMember2Await)
 }
 
 func getMemberAwaitility(t *testing.T, cl client.Client, hostAwait *wait.HostAwaitility, namespace string) (*wait.MemberAwaitility, *appsv1.Deployment) {
-	memberClusterE2e, err := hostAwait.WaitForToolchainClusterWithCondition("e2e", namespace, wait.ReadyToolchainCluster)
+	memberClusterE2e, err := hostAwait.WaitForToolchainClusterWithCondition(t, "e2e", namespace, wait.ReadyToolchainCluster)
 	require.NoError(t, err)
 	memberConfig, err := cluster.NewClusterConfig(cl, &memberClusterE2e, 6*time.Second)
 	require.NoError(t, err)
@@ -160,12 +160,12 @@ func getMemberAwaitility(t *testing.T, cl client.Client, hostAwait *wait.HostAwa
 	})
 	require.NoError(t, err)
 
-	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition("member", namespace, wait.ReadyToolchainCluster)
+	memberCluster, err := hostAwait.WaitForToolchainClusterWithCondition(t, "member", namespace, wait.ReadyToolchainCluster)
 	require.NoError(t, err)
 	clusterName := memberCluster.Name
 	memberAwait := wait.NewMemberAwaitility(t, memberConfig.RestConfig, memberClient, namespace, clusterName)
 
-	deployment := memberAwait.WaitForDeploymentToGetReady("member-operator-controller-manager", 1)
+	deployment := memberAwait.WaitForDeploymentToGetReady(t, "member-operator-controller-manager", 1)
 
 	return memberAwait, deployment
 }

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -15,14 +15,13 @@ import (
 type MetricsAssertionHelper struct {
 	await          metricsProvider
 	baselineValues map[string]float64
-	t              *testing.T
 }
 
 type metricsProvider interface {
-	GetMetricValue(family string, labels ...string) float64
-	GetMetricValueOrZero(family string, labels ...string) float64
-	WaitForTestResourcesCleanup(initialDelay time.Duration) error
-	WaitUntiltMetricHasValue(family string, expectedValue float64, labels ...string)
+	GetMetricValue(t *testing.T, family string, labels ...string) float64
+	GetMetricValueOrZero(t *testing.T, family string, labels ...string) float64
+	WaitForTestResourcesCleanup(t *testing.T, initialDelay time.Duration) error
+	WaitUntiltMetricHasValue(t *testing.T, family string, expectedValue float64, labels ...string)
 }
 
 // metric constants
@@ -45,10 +44,10 @@ const (
 // InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
 func InitMetricsAssertion(t *testing.T, awaitilities wait.Awaitilities) *MetricsAssertionHelper {
 	// Wait for pending usersignup deletions before capturing baseline values so that test assertions are stable
-	err := awaitilities.Host().WaitForTestResourcesCleanup(10 * time.Second)
+	err := awaitilities.Host().WaitForTestResourcesCleanup(t, 10*time.Second)
 	require.NoError(t, err)
 	// wait for toolchainstatus metrics to be updated
-	_, err = awaitilities.Host().WaitForToolchainStatus(
+	_, err = awaitilities.Host().WaitForToolchainStatus(t,
 		wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 		wait.UntilToolchainStatusUpdatedAfter(time.Now()))
 	require.NoError(t, err)
@@ -57,54 +56,53 @@ func InitMetricsAssertion(t *testing.T, awaitilities wait.Awaitilities) *Metrics
 	m := &MetricsAssertionHelper{
 		await:          awaitilities.Host(),
 		baselineValues: make(map[string]float64),
-		t:              t,
 	}
-	m.captureBaselineValues(awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
+	m.captureBaselineValues(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
 	t.Logf("captured baselines:\n%s", spew.Sdump(m.baselineValues))
 	return m
 }
 
-func (m *MetricsAssertionHelper) captureBaselineValues(memberClusterNames ...string) {
-	m.baselineValues[UserSignupsMetric] = m.await.GetMetricValue(UserSignupsMetric)
-	m.baselineValues[UserSignupsApprovedMetric] = m.await.GetMetricValue(UserSignupsApprovedMetric)
-	m.baselineValues[UserSignupsDeactivatedMetric] = m.await.GetMetricValue(UserSignupsDeactivatedMetric)
-	m.baselineValues[UserSignupsAutoDeactivatedMetric] = m.await.GetMetricValue(UserSignupsAutoDeactivatedMetric)
-	m.baselineValues[UserSignupsBannedMetric] = m.await.GetMetricValue(UserSignupsBannedMetric)
+func (m *MetricsAssertionHelper) captureBaselineValues(t *testing.T, memberClusterNames ...string) {
+	m.baselineValues[UserSignupsMetric] = m.await.GetMetricValue(t, UserSignupsMetric)
+	m.baselineValues[UserSignupsApprovedMetric] = m.await.GetMetricValue(t, UserSignupsApprovedMetric)
+	m.baselineValues[UserSignupsDeactivatedMetric] = m.await.GetMetricValue(t, UserSignupsDeactivatedMetric)
+	m.baselineValues[UserSignupsAutoDeactivatedMetric] = m.await.GetMetricValue(t, UserSignupsAutoDeactivatedMetric)
+	m.baselineValues[UserSignupsBannedMetric] = m.await.GetMetricValue(t, UserSignupsBannedMetric)
 	for _, name := range memberClusterNames { // sum of gauge value of all member clusters
-		userAccountKey := m.baselineKey(UserAccountsMetric, "cluster_name", name)
-		m.baselineValues[userAccountKey] += m.await.GetMetricValue(UserAccountsMetric, "cluster_name", name)
+		userAccountKey := m.baselineKey(t, UserAccountsMetric, "cluster_name", name)
+		m.baselineValues[userAccountKey] += m.await.GetMetricValue(t, UserAccountsMetric, "cluster_name", name)
 
-		spacesKey := m.baselineKey(SpacesMetric, "cluster_name", name)
-		m.baselineValues[spacesKey] += m.await.GetMetricValue(SpacesMetric, "cluster_name", name)
+		spacesKey := m.baselineKey(t, SpacesMetric, "cluster_name", name)
+		m.baselineValues[spacesKey] += m.await.GetMetricValue(t, SpacesMetric, "cluster_name", name)
 	}
 	// capture `sandbox_users_per_activations_and_domain` with "activations" from `1` to `10` and `internal`/`external` domains
 	for i := 1; i <= 10; i++ {
 		for _, domain := range []string{"internal", "external"} {
-			key := m.baselineKey(UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
-			m.baselineValues[key] = m.await.GetMetricValueOrZero(UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
+			key := m.baselineKey(t, UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
+			m.baselineValues[key] = m.await.GetMetricValueOrZero(t, UsersPerActivationsAndDomainMetric, "activations", strconv.Itoa(i), "domain", domain)
 		}
 	}
 	for _, domain := range []string{"internal", "external"} {
-		key := m.baselineKey(MasterUserRecordsPerDomainMetric, "domain", domain)
-		m.baselineValues[key] = m.await.GetMetricValueOrZero(MasterUserRecordsPerDomainMetric, "domain", domain)
+		key := m.baselineKey(t, MasterUserRecordsPerDomainMetric, "domain", domain)
+		m.baselineValues[key] = m.await.GetMetricValueOrZero(t, MasterUserRecordsPerDomainMetric, "domain", domain)
 	}
 }
 
 // WaitForMetricDelta waits for the metric value to reach the adjusted value. The adjusted value is the delta value combined with the baseline value.
-func (m *MetricsAssertionHelper) WaitForMetricDelta(family string, delta float64, labels ...string) {
+func (m *MetricsAssertionHelper) WaitForMetricDelta(t *testing.T, family string, delta float64, labels ...string) {
 	// The delta is relative to the starting value, eg. If there are 3 usersignups when a test is started and we are waiting
 	// for 2 more usersignups to be created (delta is +2) then the actual metric value (adjustedValue) we're waiting for is 5
-	key := m.baselineKey(string(family), labels...)
+	key := m.baselineKey(t, string(family), labels...)
 	adjustedValue := m.baselineValues[key] + delta
-	m.await.WaitUntiltMetricHasValue(string(family), adjustedValue, labels...)
+	m.await.WaitUntiltMetricHasValue(t, string(family), adjustedValue, labels...)
 }
 
 // generates a key to retain the baseline metric value, by joining the metric name and its labels.
 // Note: there are probably more sophisticated ways to combine the name and the labels, but for now
 // this simple concatenation should be enough to make the keys unique
-func (m *MetricsAssertionHelper) baselineKey(name string, labelAndValues ...string) string {
+func (m *MetricsAssertionHelper) baselineKey(t *testing.T, name string, labelAndValues ...string) string {
 	if len(labelAndValues)%2 != 0 {
-		m.t.Fatal("`labelAndValues` must be pairs of labels and values")
+		t.Fatal("`labelAndValues` must be pairs of labels and values")
 	}
 	return strings.Join(append([]string{name}, labelAndValues...), ",")
 }

--- a/testsupport/metrics_server_assertions.go
+++ b/testsupport/metrics_server_assertions.go
@@ -10,13 +10,13 @@ import (
 // VerifyHostMetricsService verifies that there is a service called `host-operator-metrics-service`
 // in the host namespace.
 func VerifyHostMetricsService(t *testing.T, hostAwait *wait.HostAwaitility) {
-	_, err := hostAwait.WaitForMetricsService("host-operator-metrics-service")
+	_, err := hostAwait.WaitForMetricsService(t, "host-operator-metrics-service")
 	require.NoError(t, err, "failed while waiting for 'host-operator-metrics-service' service")
 }
 
 // VerifyMemberMetricsService verifies that there is a service called `member-operator-metrics-service`
 // in the member namespace.
 func VerifyMemberMetricsService(t *testing.T, memberAwait *wait.MemberAwaitility) {
-	_, err := memberAwait.WaitForMetricsService("member-operator-metrics-service")
+	_, err := memberAwait.WaitForMetricsService(t, "member-operator-metrics-service")
 	require.NoError(t, err, "failed while waiting for 'member-operator-metrics-service' service")
 }

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -1,7 +1,6 @@
 package testsupport
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -20,14 +19,14 @@ import (
 var notAllowedChars = regexp.MustCompile("[^-a-z0-9]")
 
 // NewSpace initializes a new Space object with the given options. By default, it doesn't set anything in the spec.
-func NewSpace(awaitilities wait.Awaitilities, opts ...SpaceOption) *toolchainv1alpha1.Space {
-	namePrefix := strings.ToLower(awaitilities.Host().T.Name())
+func NewSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOption) *toolchainv1alpha1.Space {
+	namePrefix := strings.ToLower(t.Name())
 	// Remove all invalid characters
 	namePrefix = notAllowedChars.ReplaceAllString(namePrefix, "")
 
-	// Trim if the length exceeds 50 chars (63 is the max)
-	if len(namePrefix) > 50 {
-		namePrefix = namePrefix[0:50]
+	// Trim if the length exceeds 40 chars (63 is the max)
+	if len(namePrefix) > 40 {
+		namePrefix = namePrefix[0:40]
 	}
 
 	space := &toolchainv1alpha1.Space{
@@ -76,20 +75,20 @@ func WithTierNameAndHashLabel(tierName, hash string) SpaceOption {
 // CreateSpace initializes a new Space object using the NewSpace function, and then creates it in the cluster
 // It also automatically provisions MasterUserRecord and creates SpaceBinding for it
 func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOption) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
-	space := NewSpace(awaitilities, opts...)
-	err := awaitilities.Host().CreateWithCleanup(context.TODO(), space)
+	space := NewSpace(t, awaitilities, opts...)
+	err := awaitilities.Host().CreateWithCleanup(t, space)
 	require.NoError(t, err)
-	space, err = awaitilities.Host().WaitForSpace(space.Name, wait.UntilSpaceHasAnyTargetClusterSet(), wait.UntilSpaceHasAnyTierNameSet())
+	space, err = awaitilities.Host().WaitForSpace(t, space.Name, wait.UntilSpaceHasAnyTargetClusterSet(), wait.UntilSpaceHasAnyTierNameSet())
 	require.NoError(t, err)
 	// we also need to create a MUR & SpaceBinding, otherwise, the Space could be automatically deleted by the SpaceCleanup controller
 	signup, mur, spaceBinding := CreateMurWithAdminSpaceBindingForSpace(t, awaitilities, space, true)
 	// make sure that the NSTemplateSet associated with the Space was updated after the space binding was created (new entry in the `spec.SpaceRoles`)
 	// before we can check the resources (roles and rolebindings)
-	tier, err := awaitilities.Host().WaitForNSTemplateTier(space.Spec.TierName)
+	tier, err := awaitilities.Host().WaitForNSTemplateTier(t, space.Spec.TierName)
 	require.NoError(t, err)
 	if memberAwait, err := awaitilities.Member(space.Status.TargetCluster); err == nil {
 		// if member is `unknown` or invalid (depending on the test case), then don't try to check the associated NSTemplateSet
-		_, err = memberAwait.WaitForNSTmplSet(space.Name,
+		_, err = memberAwait.WaitForNSTmplSet(t, space.Name,
 			wait.UntilNSTemplateSetHasSpaceRoles(
 				wait.SpaceRole(tier.Spec.SpaceRoles["admin"].TemplateRef, mur.Name)))
 		require.NoError(t, err)
@@ -101,9 +100,9 @@ func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...SpaceOpti
 // CreateSpaceWithBinding initializes a new Space object using the NewSpace function, and then creates it in the cluster
 // It also automatically creates SpaceBinding for it and for the given MasterUserRecord
 func CreateSpaceWithBinding(t *testing.T, awaitilities wait.Awaitilities, mur *toolchainv1alpha1.MasterUserRecord, opts ...SpaceOption) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBinding) {
-	space := NewSpace(awaitilities, opts...)
+	space := NewSpace(t, awaitilities, opts...)
 
-	err := awaitilities.Host().CreateWithCleanup(context.TODO(), space)
+	err := awaitilities.Host().CreateWithCleanup(t, space)
 	require.NoError(t, err)
 
 	// we need to  create the SpaceBinding, otherwise, the Space could be automatically deleted by the SpaceCleanup controller
@@ -126,13 +125,13 @@ func getSpaceTargetMember(t *testing.T, awaitilities wait.Awaitilities, space *t
 // VerifyResourcesProvisionedForSpace waits until the space has some target cluster and a tier name set together with the additional criteria (if provided)
 // then it gets the target member cluster specified for the space and verifies all resources provisioned for the Space
 func VerifyResourcesProvisionedForSpace(t *testing.T, awaitilities wait.Awaitilities, spaceName string, additionalCriteria ...wait.SpaceWaitCriterion) (*toolchainv1alpha1.Space, *toolchainv1alpha1.NSTemplateSet) {
-	space, err := awaitilities.Host().WaitForSpace(spaceName,
+	space, err := awaitilities.Host().WaitForSpace(t, spaceName,
 		append(additionalCriteria,
 			wait.UntilSpaceHasAnyTargetClusterSet(),
 			wait.UntilSpaceHasAnyTierNameSet())...)
 	require.NoError(t, err)
 	targetCluster := getSpaceTargetMember(t, awaitilities, space)
-	tier, err := awaitilities.Host().WaitForNSTemplateTier(space.Spec.TierName)
+	tier, err := awaitilities.Host().WaitForNSTemplateTier(t, space.Spec.TierName)
 	require.NoError(t, err)
 	checks, err := tiers.NewChecksForTier(tier)
 	require.NoError(t, err)
@@ -151,7 +150,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	require.NoError(t, err)
 
 	// wait for space to be fully provisioned
-	space, err := hostAwait.WaitForSpace(spaceName,
+	space, err := hostAwait.WaitForSpace(t, spaceName,
 		wait.UntilSpaceHasTier(tier.Name),
 		wait.UntilSpaceHasLabelWithValue(fmt.Sprintf("toolchain.dev.openshift.com/%s-tier-hash", tier.Name), hash),
 		wait.UntilSpaceHasConditions(Provisioned()),
@@ -172,7 +171,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	}
 
 	// get NSTemplateSet
-	nsTmplSet, err := targetCluster.WaitForNSTmplSet(spaceName, wait.UntilNSTemplateSetHasTier(tier.Name), wait.UntilNSTemplateSetHasConditions(Provisioned()))
+	nsTmplSet, err := targetCluster.WaitForNSTmplSet(t, spaceName, wait.UntilNSTemplateSetHasTier(tier.Name), wait.UntilNSTemplateSetHasConditions(Provisioned()))
 	require.NoError(t, err)
 
 	// verify NSTemplateSet with namespace & cluster scoped resources
@@ -180,7 +179,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 
 	if tier.Name == "appstudio" {
 		// checks that namespace exists and has the expected label(s)
-		ns, err := targetCluster.WaitForNamespace(space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName, wait.UntilNamespaceIsActive())
+		ns, err := targetCluster.WaitForNamespace(t, space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName, wait.UntilNamespaceIsActive())
 		require.NoError(t, err)
 		require.Contains(t, ns.Labels, toolchainv1alpha1.WorkspaceLabelKey)
 		assert.Equal(t, space.Name, ns.Labels[toolchainv1alpha1.WorkspaceLabelKey])
@@ -191,7 +190,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 
 func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awaitilities, space *toolchainv1alpha1.Space, cleanup bool) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.MasterUserRecord, *toolchainv1alpha1.SpaceBinding) {
 	username := "for-space-" + space.Name
-	builder := NewSignupRequest(t, awaitilities).
+	builder := NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
@@ -201,7 +200,7 @@ func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awai
 	if !cleanup {
 		builder.DisableCleanup()
 	}
-	signup, mur := builder.Execute().Resources()
+	signup, mur := builder.Execute(t).Resources()
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 	var binding *toolchainv1alpha1.SpaceBinding
 	if cleanup {

--- a/testsupport/spacebinding.go
+++ b/testsupport/spacebinding.go
@@ -13,7 +13,7 @@ import (
 
 // VerifySpaceBinding waits until a spacebinding with the given mur and space name exists and then verifies the contents are correct
 func VerifySpaceBinding(t *testing.T, hostAwait *wait.HostAwaitility, murName, spaceName, spaceRole string) *toolchainv1alpha1.SpaceBinding {
-	spaceBinding, err := hostAwait.WaitForSpaceBinding(murName, spaceName,
+	spaceBinding, err := hostAwait.WaitForSpaceBinding(t, murName, spaceName,
 		wait.UntilSpaceBindingHasMurName(murName),
 		wait.UntilSpaceBindingHasSpaceName(spaceName),
 		wait.UntilSpaceBindingHasSpaceRole(spaceRole),
@@ -25,7 +25,7 @@ func VerifySpaceBinding(t *testing.T, hostAwait *wait.HostAwaitility, murName, s
 // CreateSpaceBinding creates SpaceBinding resource for the given MUR & Space with the given space role
 func CreateSpaceBinding(t *testing.T, hostAwait *wait.HostAwaitility, mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, spaceRole string) *toolchainv1alpha1.SpaceBinding {
 	spaceBinding := NewSpaceBinding(mur, space, spaceRole)
-	err := hostAwait.CreateWithCleanup(context.TODO(), spaceBinding)
+	err := hostAwait.CreateWithCleanup(t, spaceBinding)
 	require.NoError(t, err)
 	return spaceBinding
 }

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -45,7 +45,7 @@ var (
 
 type TierChecks interface {
 	GetClusterObjectChecks() []clusterObjectsCheck
-	GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs
+	GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs
 	GetNamespaceObjectChecks(nsType string) []namespaceObjectsCheck
 	GetSpaceRoleChecks(spaceRoles map[string][]string) ([]spaceRoleObjectsCheck, error)
 }
@@ -118,7 +118,7 @@ func (c *customTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return checks.GetClusterObjectChecks()
 }
 
-func (c *customTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
+func (c *customTierChecks) GetExpectedTemplateRefs(_ *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
 	var clusterResourcesTmplRef *string
 	if c.tier.NSTemplateTier.Spec.ClusterResources != nil {
 		clusterResourcesTmplRef = &c.tier.NSTemplateTier.Spec.ClusterResources.TemplateRef
@@ -187,9 +187,9 @@ func (a *baseTierChecks) GetSpaceRoleChecks(spaceRoles map[string][]string) ([]s
 	return checks, nil
 }
 
-func (a *baseTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "stage")
+func (a *baseTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
+	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
+	verifyNsTypes(t, a.tierName, templateRefs, "dev", "stage")
 	return templateRefs
 }
 
@@ -256,9 +256,9 @@ func (a *base1nsTierChecks) GetSpaceRoleChecks(spaceRoles map[string][]string) (
 	return checks, nil
 }
 
-func (a *base1nsTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev")
+func (a *base1nsTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
+	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
+	verifyNsTypes(t, a.tierName, templateRefs, "dev")
 	return templateRefs
 }
 
@@ -379,9 +379,9 @@ func (a *advancedTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 		idlers(0, "dev", "stage"))
 }
 
-func (a *advancedTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev", "stage")
+func (a *advancedTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
+	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
+	verifyNsTypes(t, a.tierName, templateRefs, "dev", "stage")
 	return templateRefs
 }
 
@@ -399,9 +399,9 @@ func (a *testTierChecks) GetSpaceRoleChecks(_ map[string][]string) ([]spaceRoleO
 	return []spaceRoleObjectsCheck{}, nil
 }
 
-func (a *testTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "dev")
+func (a *testTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
+	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
+	verifyNsTypes(t, a.tierName, templateRefs, "dev")
 	return templateRefs
 }
 
@@ -470,9 +470,9 @@ func (a *appstudioTierChecks) GetSpaceRoleChecks(spaceRoles map[string][]string)
 	return checks, nil
 }
 
-func (a *appstudioTierChecks) GetExpectedTemplateRefs(hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(hostAwait, a.tierName)
-	verifyNsTypes(hostAwait.T, a.tierName, templateRefs, "appstudio")
+func (a *appstudioTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
+	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
+	verifyNsTypes(t, a.tierName, templateRefs, "appstudio")
 	return templateRefs
 }
 
@@ -512,7 +512,7 @@ type clusterObjectsCheck func(t *testing.T, memberAwait *wait.MemberAwaitility, 
 
 func userEditRoleBinding(userName string) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, userName+"-edit")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, userName+"-edit")
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "User", rb.Subjects[0].Kind)
@@ -527,7 +527,7 @@ func userEditRoleBinding(userName string) spaceRoleObjectsCheck {
 
 func rbacEditRoleBinding(userName string) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, userName+"-rbac-edit")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, userName+"-rbac-edit")
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "User", rb.Subjects[0].Kind)
@@ -542,7 +542,7 @@ func rbacEditRoleBinding(userName string) spaceRoleObjectsCheck {
 
 func crtadminViewRoleBinding() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, "crtadmin-view")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, "crtadmin-view")
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "Group", rb.Subjects[0].Kind)
@@ -557,7 +557,7 @@ func crtadminViewRoleBinding() namespaceObjectsCheck {
 
 func crtadminPodsRoleBinding() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, "crtadmin-pods")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, "crtadmin-pods")
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "Group", rb.Subjects[0].Kind)
@@ -572,7 +572,7 @@ func crtadminPodsRoleBinding() namespaceObjectsCheck {
 
 func execPodsRole() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
-		role, err := memberAwait.WaitForRole(ns, "exec-pods")
+		role, err := memberAwait.WaitForRole(t, ns, "exec-pods")
 		require.NoError(t, err)
 		assert.Len(t, role.Rules, 1)
 		expected := &rbacv1.Role{
@@ -593,7 +593,7 @@ func execPodsRole() namespaceObjectsCheck {
 
 func rbacEditRole() spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		role, err := memberAwait.WaitForRole(ns, "rbac-edit")
+		role, err := memberAwait.WaitForRole(t, ns, "rbac-edit")
 		require.NoError(t, err)
 		assert.Len(t, role.Rules, 1)
 		expected := &rbacv1.Role{
@@ -629,7 +629,7 @@ func resourceQuotaComputeDeploy(cpuLimit, memoryLimit, cpuRequest, memoryRequest
 		require.NoError(t, err)
 
 		criteria := resourceQuotaMatches(ns.Name, "compute-deploy", spec)
-		_, err = memberAwait.WaitForResourceQuota(ns.Name, "compute-deploy", criteria)
+		_, err = memberAwait.WaitForResourceQuota(t, ns.Name, "compute-deploy", criteria)
 		require.NoError(t, err)
 	}
 }
@@ -651,7 +651,7 @@ func resourceQuotaComputeBuild(cpuLimit, memoryLimit, cpuRequest, memoryRequest 
 		require.NoError(t, err)
 
 		criteria := resourceQuotaMatches(ns.Name, "compute-build", spec)
-		_, err = memberAwait.WaitForResourceQuota(ns.Name, "compute-build", criteria)
+		_, err = memberAwait.WaitForResourceQuota(t, ns.Name, "compute-build", criteria)
 		require.NoError(t, err)
 	}
 }
@@ -672,14 +672,14 @@ func resourceQuotaStorage(ephemeralLimit, storageRequest, ephemeralRequest, pvcs
 		require.NoError(t, err)
 
 		criteria := resourceQuotaMatches(ns.Name, "storage", spec)
-		_, err = memberAwait.WaitForResourceQuota(ns.Name, "storage", criteria)
+		_, err = memberAwait.WaitForResourceQuota(t, ns.Name, "storage", criteria)
 		require.NoError(t, err)
 	}
 }
 
 func limitRange(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) namespaceObjectsCheck { // nolint:unparam
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
-		lr, err := memberAwait.WaitForLimitRange(ns, "resource-limits")
+		lr, err := memberAwait.WaitForLimitRange(t, ns, "resource-limits")
 		require.NoError(t, err)
 		def := make(map[corev1.ResourceName]resource.Quantity)
 		def[corev1.ResourceCPU], err = resource.ParseQuantity(cpuLimit)
@@ -710,7 +710,7 @@ func limitRange(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) namespa
 
 func networkPolicySameNamespace() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
-		np, err := memberAwait.WaitForNetworkPolicy(ns, "allow-same-namespace")
+		np, err := memberAwait.WaitForNetworkPolicy(t, ns, "allow-same-namespace")
 		require.NoError(t, err)
 		assert.Equal(t, "codeready-toolchain", np.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 		expected := &netv1.NetworkPolicy{
@@ -745,7 +745,7 @@ func networkPolicyAllowFromOtherNamespace(otherNamespaceKinds ...string) namespa
 			})
 		}
 
-		np, err := memberAwait.WaitForNetworkPolicy(ns, "allow-from-other-user-namespaces")
+		np, err := memberAwait.WaitForNetworkPolicy(t, ns, "allow-from-other-user-namespaces")
 		require.NoError(t, err)
 		expected := &netv1.NetworkPolicy{
 			Spec: netv1.NetworkPolicySpec{
@@ -789,7 +789,7 @@ func networkPolicyIngressFromPolicyGroup(name, group string) namespaceObjectsChe
 
 func networkPolicyIngress(name, labelName, labelValue string) namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
-		np, err := memberAwait.WaitForNetworkPolicy(ns, name)
+		np, err := memberAwait.WaitForNetworkPolicy(t, ns, name)
 		require.NoError(t, err)
 		assert.Equal(t, "codeready-toolchain", np.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 		expected := &netv1.NetworkPolicy{
@@ -831,7 +831,7 @@ func idlers(timeoutSeconds int, namespaceTypes ...string) clusterObjectsCheckCre
 				} else {
 					idlerName = fmt.Sprintf("%s-%s", userName, nt)
 				}
-				idler, err := memberAwait.WaitForIdler(idlerName, wait.IdlerHasTier(tierLabel), wait.IdlerHasTimeoutSeconds(timeoutSeconds))
+				idler, err := memberAwait.WaitForIdler(t, idlerName, wait.IdlerHasTier(tierLabel), wait.IdlerHasTimeoutSeconds(timeoutSeconds))
 				require.NoError(t, err)
 				assert.Equal(t, userName, idler.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
 			}
@@ -873,7 +873,7 @@ func clusterResourceQuotaCompute(cpuLimit, cpuRequest, memoryLimit, storageLimit
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-compute", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-compute", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -893,7 +893,7 @@ func clusterResourceQuotaDeployments() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-deployments", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-deployments", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -911,7 +911,7 @@ func clusterResourceQuotaReplicas() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-replicas", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-replicas", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -929,7 +929,7 @@ func clusterResourceQuotaRoutes() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-routes", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-routes", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -951,7 +951,7 @@ func clusterResourceQuotaJobs() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-jobs", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-jobs", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -967,7 +967,7 @@ func clusterResourceQuotaServices() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-services", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-services", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -983,7 +983,7 @@ func clusterResourceQuotaBuildConfig() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-bc", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-bc", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -999,7 +999,7 @@ func clusterResourceQuotaSecrets() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-secrets", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-secrets", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -1015,7 +1015,7 @@ func clusterResourceQuotaConfigMap() clusterObjectsCheckCreator {
 
 			criteria := clusterResourceQuotaMatches(userName, tierLabel, hard)
 
-			_, err = memberAwait.WaitForClusterResourceQuota(fmt.Sprintf("for-%s-cm", userName), criteria)
+			_, err = memberAwait.WaitForClusterResourceQuota(t, fmt.Sprintf("for-%s-cm", userName), criteria)
 			require.NoError(t, err)
 		}
 	}
@@ -1062,7 +1062,7 @@ func count(resource corev1.ResourceName) corev1.ResourceName {
 func numberOfToolchainRoles(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		roles := &rbacv1.RoleList{}
-		err := memberAwait.WaitForExpectedNumberOfResources(ns.Name, "Roles", number, func() (int, error) {
+		err := memberAwait.WaitForExpectedNumberOfResources(t, ns.Name, "Roles", number, func() (int, error) {
 			err := memberAwait.Client.List(context.TODO(), roles, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
 			return len(roles.Items), err
@@ -1073,7 +1073,7 @@ func numberOfToolchainRoles(number int) spaceRoleObjectsCheck {
 				rs[i] = r.Name
 			}
 			t.Logf("found %d roles: %s", len(roles.Items), spew.Sdump(rs))
-			if nsTmplSet, err := memberAwait.WaitForNSTmplSet(owner); err == nil {
+			if nsTmplSet, err := memberAwait.WaitForNSTmplSet(t, owner); err == nil {
 				t.Logf("associated NSTemplateSet: %s", spew.Sdump(nsTmplSet))
 			}
 		}
@@ -1084,7 +1084,7 @@ func numberOfToolchainRoles(number int) spaceRoleObjectsCheck {
 func numberOfToolchainRoleBindings(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		roleBindings := &rbacv1.RoleBindingList{}
-		err := memberAwait.WaitForExpectedNumberOfResources(ns.Name, "RoleBindings", number, func() (int, error) {
+		err := memberAwait.WaitForExpectedNumberOfResources(t, ns.Name, "RoleBindings", number, func() (int, error) {
 			err := memberAwait.Client.List(context.TODO(), roleBindings, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
 			return len(roleBindings.Items), err
@@ -1095,7 +1095,7 @@ func numberOfToolchainRoleBindings(number int) spaceRoleObjectsCheck {
 				rbs[i] = rb.Name
 			}
 			t.Logf("found %d role bindings: %s", len(roleBindings.Items), spew.Sdump(rbs))
-			if nsTmplSet, err := memberAwait.WaitForNSTmplSet(owner); err == nil {
+			if nsTmplSet, err := memberAwait.WaitForNSTmplSet(t, owner); err == nil {
 				t.Logf("associated NSTemplateSet: %s", spew.Sdump(nsTmplSet))
 			}
 		}
@@ -1105,7 +1105,7 @@ func numberOfToolchainRoleBindings(number int) spaceRoleObjectsCheck {
 
 func numberOfToolchainServiceAccounts(number int) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		err := memberAwait.WaitForExpectedNumberOfResources(ns.Name, "ServiceAccounts", number, func() (int, error) {
+		err := memberAwait.WaitForExpectedNumberOfResources(t, ns.Name, "ServiceAccounts", number, func() (int, error) {
 			serviceAccounts := &corev1.ServiceAccountList{}
 			err := memberAwait.Client.List(context.TODO(), serviceAccounts, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
@@ -1117,7 +1117,7 @@ func numberOfToolchainServiceAccounts(number int) spaceRoleObjectsCheck {
 
 func numberOfLimitRanges(number int) namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		err := memberAwait.WaitForExpectedNumberOfResources(ns.Name, "LimitRanges", number, func() (int, error) {
+		err := memberAwait.WaitForExpectedNumberOfResources(t, ns.Name, "LimitRanges", number, func() (int, error) {
 			limitRanges := &corev1.LimitRangeList{}
 			err := memberAwait.Client.List(context.TODO(), limitRanges, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
@@ -1129,7 +1129,7 @@ func numberOfLimitRanges(number int) namespaceObjectsCheck {
 
 func numberOfNetworkPolicies(number int) namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		err := memberAwait.WaitForExpectedNumberOfResources(ns.Name, "NetworkPolicies", number, func() (int, error) {
+		err := memberAwait.WaitForExpectedNumberOfResources(t, ns.Name, "NetworkPolicies", number, func() (int, error) {
 			nps := &netv1.NetworkPolicyList{}
 			err := memberAwait.Client.List(context.TODO(), nps, providerMatchingLabels, client.InNamespace(ns.Name))
 			require.NoError(t, err)
@@ -1142,7 +1142,7 @@ func numberOfNetworkPolicies(number int) namespaceObjectsCheck {
 func numberOfClusterResourceQuotas(number int) clusterObjectsCheckCreator {
 	return func() clusterObjectsCheck {
 		return func(t *testing.T, memberAwait *wait.MemberAwaitility, userName, tierLabel string) {
-			err := memberAwait.WaitForExpectedNumberOfClusterResources("ClusterResourceQuotas", number, func() (int, error) {
+			err := memberAwait.WaitForExpectedNumberOfClusterResources(t, "ClusterResourceQuotas", number, func() (int, error) {
 				quotas := &quotav1.ClusterResourceQuotaList{}
 				matchingLabels := client.MatchingLabels(map[string]string{ // make sure we only list the ClusterResourceQuota resources associated with the given "userName"
 					"toolchain.dev.openshift.com/provider": "codeready-toolchain",
@@ -1166,14 +1166,14 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 		if !strings.HasPrefix(ns.Name, "migration-") {
 			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("argocd.argoproj.io/managed-by", "gitops-service-argocd"))
 		}
-		_, err := memberAwait.WaitForNamespaceWithName(ns.Name, labelWaitCriterion...)
+		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)
 	}
 }
 
 func appstudioServiceAccount(userName string) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		sa, err := memberAwait.WaitForServiceAccount(ns.Name, fmt.Sprintf("appstudio-%s", userName))
+		sa, err := memberAwait.WaitForServiceAccount(t, ns.Name, fmt.Sprintf("appstudio-%s", userName))
 		require.NoError(t, err)
 		assert.Equal(t, "codeready-toolchain", sa.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 		assert.Equal(t, owner, sa.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
@@ -1182,7 +1182,7 @@ func appstudioServiceAccount(userName string) spaceRoleObjectsCheck {
 
 func appstudioUserActionsRole() spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		role, err := memberAwait.WaitForRole(ns, "appstudio-user-actions")
+		role, err := memberAwait.WaitForRole(t, ns, "appstudio-user-actions")
 		require.NoError(t, err)
 		assert.Len(t, role.Rules, 12)
 		expected := &rbacv1.Role{
@@ -1258,7 +1258,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 
 func appstudioUserActionsRoleBinding(userName string) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, fmt.Sprintf("appstudio-%s-user-actions", userName))
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, fmt.Sprintf("appstudio-%s-user-actions", userName))
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
@@ -1270,7 +1270,7 @@ func appstudioUserActionsRoleBinding(userName string) spaceRoleObjectsCheck {
 		assert.Equal(t, "codeready-toolchain", rb.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 		assert.Equal(t, owner, rb.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
 
-		rb, err = memberAwait.WaitForRoleBinding(ns, fmt.Sprintf("appstudio-%s-actions-user", userName))
+		rb, err = memberAwait.WaitForRoleBinding(t, ns, fmt.Sprintf("appstudio-%s-actions-user", userName))
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "User", rb.Subjects[0].Kind)
@@ -1285,7 +1285,7 @@ func appstudioUserActionsRoleBinding(userName string) spaceRoleObjectsCheck {
 
 func appstudioViewRoleBinding(userName string) spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, fmt.Sprintf("appstudio-%s-view", userName))
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, fmt.Sprintf("appstudio-%s-view", userName))
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
@@ -1297,7 +1297,7 @@ func appstudioViewRoleBinding(userName string) spaceRoleObjectsCheck {
 		assert.Equal(t, "codeready-toolchain", rb.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 		assert.Equal(t, owner, rb.ObjectMeta.Labels["toolchain.dev.openshift.com/owner"])
 
-		rb, err = memberAwait.WaitForRoleBinding(ns, fmt.Sprintf("appstudio-%s-view-user", userName))
+		rb, err = memberAwait.WaitForRoleBinding(t, ns, fmt.Sprintf("appstudio-%s-view-user", userName))
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "User", rb.Subjects[0].Kind)
@@ -1312,7 +1312,7 @@ func appstudioViewRoleBinding(userName string) spaceRoleObjectsCheck {
 
 func memberOperatorSaReadRoleBinding() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		rb, err := memberAwait.WaitForRoleBinding(ns, "member-operator-sa-read")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, "member-operator-sa-read")
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "Group", rb.Subjects[0].Kind)
@@ -1327,7 +1327,7 @@ func memberOperatorSaReadRoleBinding() namespaceObjectsCheck {
 
 func toolchainSaReadRole() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		role, err := memberAwait.WaitForRole(ns, "toolchain-sa-read")
+		role, err := memberAwait.WaitForRole(t, ns, "toolchain-sa-read")
 		require.NoError(t, err)
 		expected := &rbacv1.Role{
 			Rules: []rbacv1.PolicyRule{

--- a/testsupport/tiers/nstemplateset.go
+++ b/testsupport/tiers/nstemplateset.go
@@ -16,15 +16,15 @@ import (
 
 func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet, checks TierChecks) {
 	t.Logf("verifying NSTemplateSet '%s' and its resources", nsTmplSet.Name)
-	expectedTemplateRefs := checks.GetExpectedTemplateRefs(hostAwait)
+	expectedTemplateRefs := checks.GetExpectedTemplateRefs(t, hostAwait)
 
-	_, err := memberAwait.WaitForNSTmplSet(nsTmplSet.Name, UntilNSTemplateSetHasTemplateRefs(expectedTemplateRefs))
+	_, err := memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name, UntilNSTemplateSetHasTemplateRefs(expectedTemplateRefs))
 	require.NoError(t, err)
 
 	// Verify all namespaces and objects within
 	namespaceObjectChecks := sync.WaitGroup{}
 	for _, templateRef := range expectedTemplateRefs.Namespaces {
-		ns, err := memberAwait.WaitForNamespace(nsTmplSet.Name, templateRef, nsTmplSet.Spec.TierName, wait.UntilNamespaceIsActive())
+		ns, err := memberAwait.WaitForNamespace(t, nsTmplSet.Name, templateRef, nsTmplSet.Spec.TierName, wait.UntilNamespaceIsActive())
 		require.NoError(t, err)
 		_, nsType, _, err := wait.Split(templateRef)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwa
 		}
 		spaceRoles := map[string][]string{}
 		for _, r := range nsTmplSet.Spec.SpaceRoles {
-			tmpl, err := hostAwait.WaitForTierTemplate(r.TemplateRef)
+			tmpl, err := hostAwait.WaitForTierTemplate(t, r.TemplateRef)
 			require.NoError(t, err)
 			t.Logf("space role template: %s", tmpl.GetName())
 			spaceRoles[tmpl.Spec.Type] = r.Usernames

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -1,6 +1,8 @@
 package tiers
 
 import (
+	"testing"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
@@ -14,9 +16,9 @@ type TemplateRefs struct {
 }
 
 // GetTemplateRefs returns the expected templateRefs for all the namespace templates and the optional cluster resources template for the given tier
-func GetTemplateRefs(hostAwait *wait.HostAwaitility, tierName string) TemplateRefs { // nolint:unparam // false positive on unused return param `0`??
-	templateTier, err := hostAwait.WaitForNSTemplateTier(tierName, wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
-	require.NoError(hostAwait.T, err)
+func GetTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility, tierName string) TemplateRefs { // nolint:unparam // false positive on unused return param `0`??
+	templateTier, err := hostAwait.WaitForNSTemplateTier(t, tierName, wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
+	require.NoError(t, err)
 	nsRefs := make([]string, 0, len(templateTier.Spec.Namespaces))
 	for _, ns := range templateTier.Spec.Namespaces {
 		nsRefs = append(nsRefs, ns.TemplateRef)

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -13,7 +13,7 @@ import (
 )
 
 func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility, expectedURL string) {
-	err := memberAwait.WaitForMemberStatus(
+	err := memberAwait.WaitForMemberStatus(t,
 		wait.UntilMemberStatusHasConditions(ToolchainStatusReady()),
 		wait.UntilMemberStatusHasUsageSet(),
 		wait.UntilMemberStatusHasConsoleURLSet(expectedURL, RoutesAvailable()))
@@ -21,10 +21,10 @@ func VerifyMemberStatus(t *testing.T, memberAwait *wait.MemberAwaitility, expect
 }
 
 func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility) {
-	memberCluster, found, err := hostAwait.GetToolchainCluster(cluster.Member, memberAwait.Namespace, nil)
+	memberCluster, found, err := hostAwait.GetToolchainCluster(t, cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(t, err)
 	require.True(t, found)
-	_, err = hostAwait.WaitForToolchainStatus(wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
+	_, err = hostAwait.WaitForToolchainStatus(t, wait.UntilToolchainStatusHasConditions(ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 		wait.UntilAllMembersHaveUsageSet(),
 		wait.UntilAllMembersHaveAPIEndpoint(memberCluster.Spec.APIEndpoint),
 		wait.UntilProxyURLIsPresent(hostAwait.APIProxyURL))

--- a/testsupport/toolchainconfig_assertions.go
+++ b/testsupport/toolchainconfig_assertions.go
@@ -9,11 +9,11 @@ import (
 )
 
 func VerifyToolchainConfig(t *testing.T, hostAwait *wait.HostAwaitility, criteria ...wait.ToolchainConfigWaitCriterion) {
-	_, err := hostAwait.WaitForToolchainConfig(criteria...)
+	_, err := hostAwait.WaitForToolchainConfig(t, criteria...)
 	require.NoError(t, err, "failed while waiting for ToolchainConfig to meet the required criteria")
 }
 
 func VerifyMemberOperatorConfig(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, criteria ...wait.MemberOperatorConfigWaitCriterion) {
-	_, err := memberAwait.WaitForMemberOperatorConfig(hostAwait, criteria...)
+	_, err := memberAwait.WaitForMemberOperatorConfig(t, hostAwait, criteria...)
 	require.NoError(t, err, "failed while waiting for MemberOperatorConfig to meet the required criteria")
 }

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -31,12 +31,12 @@ func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			continue
 		}
 		// Create an approved UserSignup resource
-		signups[i], _ = NewSignupRequest(t, awaitilities).
+		signups[i], _ = NewSignupRequest(awaitilities).
 			Username(name).
 			Email(fmt.Sprintf("multiple-signup-testuser-%d@test.com", i)).
 			ManuallyApprove().
 			TargetCluster(targetCluster).
-			Execute().
+			Execute(t).
 			Resources()
 	}
 	return signups

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1327,6 +1327,54 @@ func UntilHasMurCount(domain string, expectedCount int) ToolchainStatusWaitCrite
 	}
 }
 
+// UntilHasUserAccountCount returns a `ToolchainStatusWaitCriterion` which checks that the given
+// ToolchainStatus has the given count of MasterUserRecords
+func UntilHasUserAccountCount(clusterName string, expectedCount int) ToolchainStatusWaitCriterion {
+	return ToolchainStatusWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.ToolchainStatus) bool {
+			for _, m := range actual.Status.Members {
+				if m.ClusterName == clusterName {
+					return m.UserAccountCount == expectedCount
+				}
+			}
+			return false
+		},
+		Diff: func(actual *toolchainv1alpha1.ToolchainStatus) string {
+			actualCount := 0
+			for _, m := range actual.Status.Members {
+				if m.ClusterName == clusterName {
+					actualCount = m.UserAccountCount
+				}
+			}
+			return fmt.Sprintf("expected UserAccount count for cluster %s to be %d. Actual: %d", clusterName, expectedCount, actualCount)
+		},
+	}
+}
+
+// UntilHasSpaceCount returns a `ToolchainStatusWaitCriterion` which checks that the given
+// ToolchainStatus has the given count of MasterUserRecords
+func UntilHasSpaceCount(clusterName string, expectedCount int) ToolchainStatusWaitCriterion {
+	return ToolchainStatusWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.ToolchainStatus) bool {
+			for _, m := range actual.Status.Members {
+				if m.ClusterName == clusterName {
+					return m.SpaceCount == expectedCount
+				}
+			}
+			return false
+		},
+		Diff: func(actual *toolchainv1alpha1.ToolchainStatus) string {
+			actualCount := 0
+			for _, m := range actual.Status.Members {
+				if m.ClusterName == clusterName {
+					actualCount = m.SpaceCount
+				}
+			}
+			return fmt.Sprintf("expected Space count for cluster %s to be %d. Actual: %d", clusterName, expectedCount, actualCount)
+		},
+	}
+}
+
 // WaitForToolchainStatus waits until the ToolchainStatus is available with the provided criteria, if any
 func (a *HostAwaitility) WaitForToolchainStatus(t *testing.T, criteria ...ToolchainStatusWaitCriterion) (*toolchainv1alpha1.ToolchainStatus, error) {
 	// there should only be one toolchain status with the name toolchain-status

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -44,7 +44,6 @@ type HostAwaitility struct {
 func NewHostAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns string, registrationServiceNs string) *HostAwaitility {
 	return &HostAwaitility{
 		Awaitility: &Awaitility{
-			T:             t,
 			Client:        cl,
 			RestConfig:    cfg,
 			Namespace:     ns,
@@ -60,15 +59,6 @@ func NewHostAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns stri
 func (a *HostAwaitility) WithRetryOptions(options ...RetryOption) *HostAwaitility {
 	return &HostAwaitility{
 		Awaitility:             a.Awaitility.WithRetryOptions(options...),
-		RegistrationServiceNs:  a.RegistrationServiceNs,
-		RegistrationServiceURL: a.RegistrationServiceURL,
-		APIProxyURL:            a.APIProxyURL,
-	}
-}
-
-func (a *HostAwaitility) ForTest(t *testing.T) *HostAwaitility {
-	return &HostAwaitility{
-		Awaitility:             a.Awaitility.ForTest(t),
 		RegistrationServiceNs:  a.RegistrationServiceNs,
 		RegistrationServiceURL: a.RegistrationServiceURL,
 		APIProxyURL:            a.APIProxyURL,
@@ -163,8 +153,8 @@ func (a *HostAwaitility) allResources() ([]runtime.Object, error) {
 }
 
 // WaitForMasterUserRecord waits until there is a MasterUserRecord available with the given name and the optional conditions
-func (a *HostAwaitility) WaitForMasterUserRecord(name string, criteria ...MasterUserRecordWaitCriterion) (*toolchainv1alpha1.MasterUserRecord, error) {
-	a.T.Logf("waiting for MasterUserRecord '%s' in namespace '%s' to match criteria", name, a.Namespace)
+func (a *HostAwaitility) WaitForMasterUserRecord(t *testing.T, name string, criteria ...MasterUserRecordWaitCriterion) (*toolchainv1alpha1.MasterUserRecord, error) {
+	t.Logf("waiting for MasterUserRecord '%s' in namespace '%s' to match criteria", name, a.Namespace)
 	var mur *toolchainv1alpha1.MasterUserRecord
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.MasterUserRecord{}
@@ -179,7 +169,7 @@ func (a *HostAwaitility) WaitForMasterUserRecord(name string, criteria ...Master
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printMasterUserRecordWaitCriterionDiffs(mur, criteria...)
+		a.printMasterUserRecordWaitCriterionDiffs(t, mur, criteria...)
 	}
 	return mur, err
 }
@@ -195,21 +185,21 @@ func (a *HostAwaitility) GetMasterUserRecord(name string) (*toolchainv1alpha1.Ma
 // UpdateMasterUserRecordSpec tries to update the Spec of the given MasterUserRecord
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
 // Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecordSpec(murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
-	return a.UpdateMasterUserRecord(false, murName, modifyMur)
+func (a *HostAwaitility) UpdateMasterUserRecordSpec(t *testing.T, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
+	return a.UpdateMasterUserRecord(t, false, murName, modifyMur)
 }
 
 // UpdateMasterUserRecordStatus tries to update the Status of the given MasterUserRecord
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
 // Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecordStatus(murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
-	return a.UpdateMasterUserRecord(true, murName, modifyMur)
+func (a *HostAwaitility) UpdateMasterUserRecordStatus(t *testing.T, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
+	return a.UpdateMasterUserRecord(t, true, murName, modifyMur)
 }
 
 // UpdateMasterUserRecord tries to update the Spec or the Status of the given MasterUserRecord
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
 // Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecord(status bool, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
+func (a *HostAwaitility) UpdateMasterUserRecord(t *testing.T, status bool, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
 	var m *toolchainv1alpha1.MasterUserRecord
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshMur := &toolchainv1alpha1.MasterUserRecord{}
@@ -221,11 +211,11 @@ func (a *HostAwaitility) UpdateMasterUserRecord(status bool, murName string, mod
 		if status {
 			// Update status
 			if err := a.Client.Status().Update(context.TODO(), freshMur); err != nil {
-				a.T.Logf("error updating MasterUserRecord.Status '%s': %s. Will retry again...", murName, err.Error())
+				t.Logf("error updating MasterUserRecord.Status '%s': %s. Will retry again...", murName, err.Error())
 				return false, nil
 			}
 		} else if err := a.Client.Update(context.TODO(), freshMur); err != nil {
-			a.T.Logf("error updating MasterUserRecord.Spec '%s': %s. Will retry again...", murName, err.Error())
+			t.Logf("error updating MasterUserRecord.Spec '%s': %s. Will retry again...", murName, err.Error())
 			return false, nil
 		}
 		m = freshMur
@@ -237,7 +227,7 @@ func (a *HostAwaitility) UpdateMasterUserRecord(status bool, murName string, mod
 // UpdateUserSignup tries to update the Spec of the given UserSignup
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated UserSignup
-func (a *HostAwaitility) UpdateUserSignup(userSignupName string, modifyUserSignup func(us *toolchainv1alpha1.UserSignup)) (*toolchainv1alpha1.UserSignup, error) {
+func (a *HostAwaitility) UpdateUserSignup(t *testing.T, userSignupName string, modifyUserSignup func(us *toolchainv1alpha1.UserSignup)) (*toolchainv1alpha1.UserSignup, error) {
 	var userSignup *toolchainv1alpha1.UserSignup
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshUserSignup := &toolchainv1alpha1.UserSignup{}
@@ -247,7 +237,7 @@ func (a *HostAwaitility) UpdateUserSignup(userSignupName string, modifyUserSignu
 
 		modifyUserSignup(freshUserSignup)
 		if err := a.Client.Update(context.TODO(), freshUserSignup); err != nil {
-			a.T.Logf("error updating UserSignup '%s': %s. Will retry again...", userSignupName, err.Error())
+			t.Logf("error updating UserSignup '%s': %s. Will retry again...", userSignupName, err.Error())
 			return false, nil
 		}
 		userSignup = freshUserSignup
@@ -259,7 +249,7 @@ func (a *HostAwaitility) UpdateUserSignup(userSignupName string, modifyUserSignu
 // UpdateSpace tries to update the Spec of the given Space
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated Space
-func (a *HostAwaitility) UpdateSpace(spaceName string, modifySpace func(s *toolchainv1alpha1.Space)) (*toolchainv1alpha1.Space, error) {
+func (a *HostAwaitility) UpdateSpace(t *testing.T, spaceName string, modifySpace func(s *toolchainv1alpha1.Space)) (*toolchainv1alpha1.Space, error) {
 	var s *toolchainv1alpha1.Space
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshSpace := &toolchainv1alpha1.Space{}
@@ -268,7 +258,7 @@ func (a *HostAwaitility) UpdateSpace(spaceName string, modifySpace func(s *toolc
 		}
 		modifySpace(freshSpace)
 		if err := a.Client.Update(context.TODO(), freshSpace); err != nil {
-			a.T.Logf("error updating Space '%s': %s. Will retry again...", spaceName, err.Error())
+			t.Logf("error updating Space '%s': %s. Will retry again...", spaceName, err.Error())
 			return false, nil
 		}
 		s = freshSpace
@@ -292,7 +282,7 @@ func matchMasterUserRecordWaitCriterion(actual *toolchainv1alpha1.MasterUserReco
 	return true
 }
 
-func (a *HostAwaitility) printMasterUserRecordWaitCriterionDiffs(actual *toolchainv1alpha1.MasterUserRecord, criteria ...MasterUserRecordWaitCriterion) {
+func (a *HostAwaitility) printMasterUserRecordWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.MasterUserRecord, criteria ...MasterUserRecordWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find MasterUserRecord\n")
@@ -312,11 +302,11 @@ func (a *HostAwaitility) printMasterUserRecordWaitCriterionDiffs(actual *toolcha
 		}
 	}
 	// also include other resources relevant in the host namespace, to help troubleshooting
-	a.listAndPrint("UserSignups", a.Namespace, &toolchainv1alpha1.UserSignupList{})
-	a.listAndPrint("MasterUserRecords", a.Namespace, &toolchainv1alpha1.MasterUserRecordList{})
-	a.listAndPrint("Spaces", a.Namespace, &toolchainv1alpha1.SpaceList{})
+	a.listAndPrint(t, "UserSignups", a.Namespace, &toolchainv1alpha1.UserSignupList{})
+	a.listAndPrint(t, "MasterUserRecords", a.Namespace, &toolchainv1alpha1.MasterUserRecordList{})
+	a.listAndPrint(t, "Spaces", a.Namespace, &toolchainv1alpha1.SpaceList{})
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilMasterUserRecordIsBeingDeleted checks if MasterUserRecord has Deletion Timestamp
@@ -424,7 +414,7 @@ func matchUserSignupWaitCriterion(actual *toolchainv1alpha1.UserSignup, criteria
 	return true
 }
 
-func (a *HostAwaitility) printUserSignupWaitCriterionDiffs(actual *toolchainv1alpha1.UserSignup, criteria ...UserSignupWaitCriterion) {
+func (a *HostAwaitility) printUserSignupWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.UserSignup, criteria ...UserSignupWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find UserSignup\n")
@@ -445,7 +435,7 @@ func (a *HostAwaitility) printUserSignupWaitCriterionDiffs(actual *toolchainv1al
 	// also include other resources relevant in the host namespace, to help troubleshooting
 	buf.WriteString(a.sprintAllResources())
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilUserSignupIsBeingDeleted returns a `UserSignupWaitCriterion` which checks that the given
@@ -553,8 +543,8 @@ func UntilUserSignupHasCompliantUsername() UserSignupWaitCriterion {
 }
 
 // WaitForTestResourcesCleanup waits for all UserSignup, MasterUserRecord, Space, SpaceBinding, NSTemplateSet and Namespace deletions to complete
-func (a *HostAwaitility) WaitForTestResourcesCleanup(initialDelay time.Duration) error {
-	a.T.Logf("waiting for resource cleanup")
+func (a *HostAwaitility) WaitForTestResourcesCleanup(t *testing.T, initialDelay time.Duration) error {
+	t.Logf("waiting for resource cleanup")
 	time.Sleep(initialDelay)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		usList := &toolchainv1alpha1.UserSignupList{}
@@ -621,8 +611,8 @@ func (a *HostAwaitility) WaitForTestResourcesCleanup(initialDelay time.Duration)
 }
 
 // WaitForUserSignup waits until there is a UserSignup available with the given name and set of status conditions
-func (a *HostAwaitility) WaitForUserSignup(name string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
-	a.T.Logf("waiting for UserSignup '%s' in namespace '%s' to match criteria", name, a.Namespace)
+func (a *HostAwaitility) WaitForUserSignup(t *testing.T, name string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
+	t.Logf("waiting for UserSignup '%s' in namespace '%s' to match criteria", name, a.Namespace)
 	var userSignup *toolchainv1alpha1.UserSignup
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.UserSignup{}
@@ -637,14 +627,14 @@ func (a *HostAwaitility) WaitForUserSignup(name string, criteria ...UserSignupWa
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printUserSignupWaitCriterionDiffs(userSignup, criteria...)
+		a.printUserSignupWaitCriterionDiffs(t, userSignup, criteria...)
 	}
 	return userSignup, err
 }
 
 // WaitForUserSignup waits until there is a UserSignup available with the given name and set of status conditions
-func (a *HostAwaitility) WaitForUserSignupByUserIDAndUsername(userID, username string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
-	a.T.Logf("waiting for UserSignup '%s' or '%s' in namespace '%s' to match criteria", userID, username, a.Namespace)
+func (a *HostAwaitility) WaitForUserSignupByUserIDAndUsername(t *testing.T, userID, username string, criteria ...UserSignupWaitCriterion) (*toolchainv1alpha1.UserSignup, error) {
+	t.Logf("waiting for UserSignup '%s' or '%s' in namespace '%s' to match criteria", userID, username, a.Namespace)
 	encodedUsername := EncodeUserIdentifier(username)
 	var userSignup *toolchainv1alpha1.UserSignup
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
@@ -666,14 +656,14 @@ func (a *HostAwaitility) WaitForUserSignupByUserIDAndUsername(userID, username s
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printUserSignupWaitCriterionDiffs(userSignup, criteria...)
+		a.printUserSignupWaitCriterionDiffs(t, userSignup, criteria...)
 	}
 	return userSignup, err
 }
 
 // WaitAndVerifyThatUserSignupIsNotCreated waits and checks that the UserSignup is not created
-func (a *HostAwaitility) WaitAndVerifyThatUserSignupIsNotCreated(name string) {
-	a.T.Logf("waiting and verifying that UserSignup '%s' in namespace '%s' is not created", name, a.Namespace)
+func (a *HostAwaitility) WaitAndVerifyThatUserSignupIsNotCreated(t *testing.T, name string) {
+	t.Logf("waiting and verifying that UserSignup '%s' in namespace '%s' is not created", name, a.Namespace)
 	var userSignup *toolchainv1alpha1.UserSignup
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.UserSignup{}
@@ -687,13 +677,13 @@ func (a *HostAwaitility) WaitAndVerifyThatUserSignupIsNotCreated(name string) {
 		return true, nil
 	})
 	if err == nil {
-		require.Fail(a.T, fmt.Sprintf("UserSignup '%s' should not be created, but it was found: %v", name, userSignup))
+		require.Fail(t, fmt.Sprintf("UserSignup '%s' should not be created, but it was found: %v", name, userSignup))
 	}
 }
 
 // WaitForBannedUser waits until there is a BannedUser available with the given email
-func (a *HostAwaitility) WaitForBannedUser(email string) (*toolchainv1alpha1.BannedUser, error) {
-	a.T.Logf("waiting for BannedUser for user '%s' in namespace '%s'", email, a.Namespace)
+func (a *HostAwaitility) WaitForBannedUser(t *testing.T, email string) (*toolchainv1alpha1.BannedUser, error) {
+	t.Logf("waiting for BannedUser for user '%s' in namespace '%s'", email, a.Namespace)
 	var bannedUser *toolchainv1alpha1.BannedUser
 	labels := map[string]string{toolchainv1alpha1.BannedUserEmailHashLabelKey: hash.EncodeString(email)}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
@@ -709,14 +699,14 @@ func (a *HostAwaitility) WaitForBannedUser(email string) (*toolchainv1alpha1.Ban
 	})
 	// log message if an error occurred
 	if err != nil {
-		a.T.Logf("failed to find Banned for email address '%s': %v", email, err)
+		t.Logf("failed to find Banned for email address '%s': %v", email, err)
 	}
 	return bannedUser, err
 }
 
 // DeleteToolchainStatus deletes the ToolchainStatus resource with the given name and in the host operator namespace
-func (a *HostAwaitility) DeleteToolchainStatus(name string) error {
-	a.T.Logf("deleting ToolchainStatus '%s' in namespace '%s'", name, a.Namespace)
+func (a *HostAwaitility) DeleteToolchainStatus(t *testing.T, name string) error {
+	t.Logf("deleting ToolchainStatus '%s' in namespace '%s'", name, a.Namespace)
 	toolchainstatus := &toolchainv1alpha1.ToolchainStatus{}
 	if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, toolchainstatus); err != nil {
 		if errors.IsNotFound(err) {
@@ -728,8 +718,8 @@ func (a *HostAwaitility) DeleteToolchainStatus(name string) error {
 }
 
 // WaitUntilBannedUserDeleted waits until the BannedUser with the given name is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilBannedUserDeleted(name string) error {
-	a.T.Logf("waiting until BannedUser '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *HostAwaitility) WaitUntilBannedUserDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until BannedUser '%s' in namespace '%s' is deleted", name, a.Namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		user := &toolchainv1alpha1.BannedUser{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, user); err != nil {
@@ -743,8 +733,8 @@ func (a *HostAwaitility) WaitUntilBannedUserDeleted(name string) error {
 }
 
 // WaitUntilUserSignupDeleted waits until the UserSignup with the given name is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilUserSignupDeleted(name string) error {
-	a.T.Logf("waiting until UserSignup '%s' in namespace '%s is deleted", name, a.Namespace)
+func (a *HostAwaitility) WaitUntilUserSignupDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until UserSignup '%s' in namespace '%s is deleted", name, a.Namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		userSignup := &toolchainv1alpha1.UserSignup{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, userSignup); err != nil {
@@ -758,14 +748,14 @@ func (a *HostAwaitility) WaitUntilUserSignupDeleted(name string) error {
 }
 
 // WaitUntilMasterUserRecordAndSpaceBindingsDeleted waits until the MUR with the given name and its associated SpaceBindings are deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilMasterUserRecordAndSpaceBindingsDeleted(name string) error {
-	a.T.Logf("waiting until MasterUserRecord '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *HostAwaitility) WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until MasterUserRecord '%s' in namespace '%s' is deleted", name, a.Namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		mur := &toolchainv1alpha1.MasterUserRecord{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, mur); err != nil {
 			if errors.IsNotFound(err) {
 				// once the MUR is deleted, wait for the associated spacebindings to be deleted as well
-				if err := a.WaitUntilSpaceBindingsWithLabelDeleted(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, name); err != nil {
+				if err := a.WaitUntilSpaceBindingsWithLabelDeleted(t, toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, name); err != nil {
 					return false, err
 				}
 				return true, nil
@@ -777,8 +767,8 @@ func (a *HostAwaitility) WaitUntilMasterUserRecordAndSpaceBindingsDeleted(name s
 }
 
 // CheckMasterUserRecordIsDeleted checks that the MUR with the given name is not present and won't be created in the next 2 seconds
-func (a *HostAwaitility) CheckMasterUserRecordIsDeleted(name string) {
-	a.T.Logf("checking that MasterUserRecord '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *HostAwaitility) CheckMasterUserRecordIsDeleted(t *testing.T, name string) {
+	t.Logf("checking that MasterUserRecord '%s' in namespace '%s' is deleted", name, a.Namespace)
 	err := wait.Poll(a.RetryInterval, 2*time.Second, func() (done bool, err error) {
 		mur := &toolchainv1alpha1.MasterUserRecord{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, mur); err != nil {
@@ -789,7 +779,7 @@ func (a *HostAwaitility) CheckMasterUserRecordIsDeleted(name string) {
 		}
 		return false, fmt.Errorf("the MasterUserRecord '%s' should not be present, but it is", name)
 	})
-	require.Equal(a.T, wait.ErrWaitTimeout, err)
+	require.Equal(t, wait.ErrWaitTimeout, err)
 }
 
 func containsUserAccountStatus(uaStatuses []toolchainv1alpha1.UserAccountStatusEmbedded, uaStatus toolchainv1alpha1.UserAccountStatusEmbedded) bool {
@@ -803,8 +793,8 @@ func containsUserAccountStatus(uaStatuses []toolchainv1alpha1.UserAccountStatusE
 }
 
 // WaitForUserTier waits until an UserTier with the given name exists and matches any given criteria
-func (a *HostAwaitility) WaitForUserTier(name string, criteria ...UserTierWaitCriterion) (*toolchainv1alpha1.UserTier, error) {
-	a.T.Logf("waiting until UserTier '%s' in namespace '%s' matches criteria", name, a.Namespace)
+func (a *HostAwaitility) WaitForUserTier(t *testing.T, name string, criteria ...UserTierWaitCriterion) (*toolchainv1alpha1.UserTier, error) {
+	t.Logf("waiting until UserTier '%s' in namespace '%s' matches criteria", name, a.Namespace)
 	tier := &toolchainv1alpha1.UserTier{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.UserTier{}
@@ -821,7 +811,7 @@ func (a *HostAwaitility) WaitForUserTier(name string, criteria ...UserTierWaitCr
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printUserTierWaitCriterionDiffs(tier, criteria...)
+		a.printUserTierWaitCriterionDiffs(t, tier, criteria...)
 	}
 	return tier, err
 }
@@ -842,7 +832,7 @@ func matchUserTierWaitCriterion(actual *toolchainv1alpha1.UserTier, criteria ...
 	return true
 }
 
-func (a *HostAwaitility) printUserTierWaitCriterionDiffs(actual *toolchainv1alpha1.UserTier, criteria ...UserTierWaitCriterion) {
+func (a *HostAwaitility) printUserTierWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.UserTier, criteria ...UserTierWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find UserTier\n")
@@ -861,7 +851,7 @@ func (a *HostAwaitility) printUserTierWaitCriterionDiffs(actual *toolchainv1alph
 		}
 	}
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilUserTierHasDeactivationTimeoutDays verify that the UserTier status.Updates has the specified number of entries
@@ -876,19 +866,19 @@ func UntilUserTierHasDeactivationTimeoutDays(expected int) UserTierWaitCriterion
 	}
 }
 
-func (a *HostAwaitility) WaitUntilBaseUserTierIsUpdated() error {
-	_, err := a.WaitForUserTier("deactivate30", UntilUserTierHasDeactivationTimeoutDays(30))
+func (a *HostAwaitility) WaitUntilBaseUserTierIsUpdated(t *testing.T) error {
+	_, err := a.WaitForUserTier(t, "deactivate30", UntilUserTierHasDeactivationTimeoutDays(30))
 	return err
 }
 
-func (a *HostAwaitility) WaitUntilBaseNSTemplateTierIsUpdated() error {
-	_, err := a.WaitForNSTemplateTier("base", UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
+func (a *HostAwaitility) WaitUntilBaseNSTemplateTierIsUpdated(t *testing.T) error {
+	_, err := a.WaitForNSTemplateTier(t, "base", UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
 	return err
 }
 
 // WaitForNSTemplateTier waits until an NSTemplateTier with the given name exists and matches the given conditions
-func (a *HostAwaitility) WaitForNSTemplateTier(name string, criteria ...NSTemplateTierWaitCriterion) (*toolchainv1alpha1.NSTemplateTier, error) {
-	a.T.Logf("waiting until NSTemplateTier '%s' in namespace '%s' matches criteria", name, a.Namespace)
+func (a *HostAwaitility) WaitForNSTemplateTier(t *testing.T, name string, criteria ...NSTemplateTierWaitCriterion) (*toolchainv1alpha1.NSTemplateTier, error) {
+	t.Logf("waiting until NSTemplateTier '%s' in namespace '%s' matches criteria", name, a.Namespace)
 	tier := &toolchainv1alpha1.NSTemplateTier{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.NSTemplateTier{}
@@ -905,14 +895,14 @@ func (a *HostAwaitility) WaitForNSTemplateTier(name string, criteria ...NSTempla
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNSTemplateTierWaitCriterionDiffs(tier, criteria...)
+		a.printNSTemplateTierWaitCriterionDiffs(t, tier, criteria...)
 	}
 	return tier, err
 }
 
 // WaitForNSTemplateTierAndCheckTemplates waits until an NSTemplateTier with the given name exists matching the given conditions and then it verifies that all expected templates exist
-func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(name string, criteria ...NSTemplateTierWaitCriterion) (*toolchainv1alpha1.NSTemplateTier, error) {
-	tier, err := a.WaitForNSTemplateTier(name, criteria...)
+func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(t *testing.T, name string, criteria ...NSTemplateTierWaitCriterion) (*toolchainv1alpha1.NSTemplateTier, error) {
+	tier, err := a.WaitForNSTemplateTier(t, name, criteria...)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +913,7 @@ func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(name string, cri
 		if ns.TemplateRef == "" {
 			return nil, fmt.Errorf("missing 'templateRef' in namespace #%d in NSTemplateTier '%s'", i, tier.Name)
 		}
-		if _, err := a.WaitForTierTemplate(ns.TemplateRef); err != nil {
+		if _, err := a.WaitForTierTemplate(t, ns.TemplateRef); err != nil {
 			return nil, err
 		}
 	}
@@ -931,7 +921,7 @@ func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(name string, cri
 		if tier.Spec.ClusterResources.TemplateRef == "" {
 			return nil, fmt.Errorf("missing 'templateRef' for the cluster resources in NSTemplateTier '%s'", tier.Name)
 		}
-		if _, err := a.WaitForTierTemplate(tier.Spec.ClusterResources.TemplateRef); err != nil {
+		if _, err := a.WaitForTierTemplate(t, tier.Spec.ClusterResources.TemplateRef); err != nil {
 			return nil, err
 		}
 	}
@@ -940,9 +930,9 @@ func (a *HostAwaitility) WaitForNSTemplateTierAndCheckTemplates(name string, cri
 
 // WaitForTierTemplate waits until a TierTemplate with the given name exists
 // Returns an error if the resource did not exist (or something wrong happened)
-func (a *HostAwaitility) WaitForTierTemplate(name string) (*toolchainv1alpha1.TierTemplate, error) { // nolint:unparam
+func (a *HostAwaitility) WaitForTierTemplate(t *testing.T, name string) (*toolchainv1alpha1.TierTemplate, error) { // nolint:unparam
 	tierTemplate := &toolchainv1alpha1.TierTemplate{}
-	a.T.Logf("waiting until TierTemplate '%s' exists in namespace '%s'...", name, a.Namespace)
+	t.Logf("waiting until TierTemplate '%s' exists in namespace '%s'...", name, a.Namespace)
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.TierTemplate{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, obj); err != nil {
@@ -956,7 +946,7 @@ func (a *HostAwaitility) WaitForTierTemplate(name string) (*toolchainv1alpha1.Ti
 	})
 	// log message if an error occurred
 	if err != nil {
-		a.T.Logf("failed to find TierTemplate '%s': %v", name, err)
+		t.Logf("failed to find TierTemplate '%s': %v", name, err)
 	}
 	return tierTemplate, err
 }
@@ -977,7 +967,7 @@ func matchNSTemplateTierWaitCriterion(actual *toolchainv1alpha1.NSTemplateTier, 
 	return true
 }
 
-func (a *HostAwaitility) printNSTemplateTierWaitCriterionDiffs(actual *toolchainv1alpha1.NSTemplateTier, criteria ...NSTemplateTierWaitCriterion) {
+func (a *HostAwaitility) printNSTemplateTierWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.NSTemplateTier, criteria ...NSTemplateTierWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find NSTemplateTier\n")
@@ -998,7 +988,7 @@ func (a *HostAwaitility) printNSTemplateTierWaitCriterionDiffs(actual *toolchain
 	// also include other resources relevant in the host namespace, to help troubleshooting
 	buf.WriteString(a.sprintAllResources())
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // NSTemplateTierSpecMatcher a struct to compare with an expected NSTemplateTierSpec
@@ -1081,7 +1071,7 @@ func matchNotificationWaitCriterion(actual []toolchainv1alpha1.Notification, cri
 	return true
 }
 
-func (a *HostAwaitility) printNotificationWaitCriterionDiffs(actual []toolchainv1alpha1.Notification, criteria ...NotificationWaitCriterion) {
+func (a *HostAwaitility) printNotificationWaitCriterionDiffs(t *testing.T, actual []toolchainv1alpha1.Notification, criteria ...NotificationWaitCriterion) {
 	buf := &strings.Builder{}
 	if len(actual) == 0 {
 		buf.WriteString("no notification found\n")
@@ -1106,12 +1096,12 @@ func (a *HostAwaitility) printNotificationWaitCriterionDiffs(actual []toolchainv
 	// also include other resources relevant in the host namespace, to help troubleshooting
 	buf.WriteString(a.sprintAllResources())
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForNotifications waits until there is an expected number of Notifications available for the provided user and with the notification type and which match the conditions (if provided).
-func (a *HostAwaitility) WaitForNotifications(username, notificationType string, numberOfNotifications int, criteria ...NotificationWaitCriterion) ([]toolchainv1alpha1.Notification, error) {
-	a.T.Logf("waiting for notifications to match criteria for user '%s'", username)
+func (a *HostAwaitility) WaitForNotifications(t *testing.T, username, notificationType string, numberOfNotifications int, criteria ...NotificationWaitCriterion) ([]toolchainv1alpha1.Notification, error) {
+	t.Logf("waiting for notifications to match criteria for user '%s'", username)
 	var notifications []toolchainv1alpha1.Notification
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{toolchainv1alpha1.NotificationUserNameLabelKey: username, toolchainv1alpha1.NotificationTypeLabelKey: notificationType}
@@ -1128,14 +1118,14 @@ func (a *HostAwaitility) WaitForNotifications(username, notificationType string,
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNotificationWaitCriterionDiffs(notifications, criteria...)
+		a.printNotificationWaitCriterionDiffs(t, notifications, criteria...)
 	}
 	return notifications, err
 }
 
 // WaitForNotificationWithName waits until there is an expected Notifications available with the provided name and with the notification type and which match the conditions (if provided).
-func (a *HostAwaitility) WaitForNotificationWithName(notificationName, notificationType string, criteria ...NotificationWaitCriterion) (toolchainv1alpha1.Notification, error) {
-	a.T.Logf("waiting for notification with name '%s'", notificationName)
+func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationName, notificationType string, criteria ...NotificationWaitCriterion) (toolchainv1alpha1.Notification, error) {
+	t.Logf("waiting for notification with name '%s'", notificationName)
 	var notification toolchainv1alpha1.Notification
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, &notification); err != nil {
@@ -1151,14 +1141,14 @@ func (a *HostAwaitility) WaitForNotificationWithName(notificationName, notificat
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNotificationWaitCriterionDiffs([]toolchainv1alpha1.Notification{notification}, criteria...)
+		a.printNotificationWaitCriterionDiffs(t, []toolchainv1alpha1.Notification{notification}, criteria...)
 	}
 	return notification, err
 }
 
 // WaitUntilNotificationsDeleted waits until the Notification for the given user is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilNotificationsDeleted(username, notificationType string) error {
-	a.T.Logf("waiting until notifications have been deleted for user '%s'", username)
+func (a *HostAwaitility) WaitUntilNotificationsDeleted(t *testing.T, username, notificationType string) error {
+	t.Logf("waiting until notifications have been deleted for user '%s'", username)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{toolchainv1alpha1.NotificationUserNameLabelKey: username, toolchainv1alpha1.NotificationTypeLabelKey: notificationType}
 		opts := client.MatchingLabels(labels)
@@ -1171,8 +1161,8 @@ func (a *HostAwaitility) WaitUntilNotificationsDeleted(username, notificationTyp
 }
 
 // WaitUntilNotificationWithNameDeleted waits until the Notification with the given name is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilNotificationWithNameDeleted(notificationName string) error {
-	a.T.Logf("waiting for notification with name '%s' to get deleted", notificationName)
+func (a *HostAwaitility) WaitUntilNotificationWithNameDeleted(t *testing.T, notificationName string) error {
+	t.Logf("waiting for notification with name '%s' to get deleted", notificationName)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		notification := &toolchainv1alpha1.Notification{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, notification); err != nil {
@@ -1212,7 +1202,7 @@ func matchToolchainStatusWaitCriterion(actual *toolchainv1alpha1.ToolchainStatus
 	return true
 }
 
-func (a *HostAwaitility) printToolchainStatusWaitCriterionDiffs(actual *toolchainv1alpha1.ToolchainStatus, criteria ...ToolchainStatusWaitCriterion) {
+func (a *HostAwaitility) printToolchainStatusWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.ToolchainStatus, criteria ...ToolchainStatusWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Toolchainstatus\n")
@@ -1233,7 +1223,7 @@ func (a *HostAwaitility) printToolchainStatusWaitCriterionDiffs(actual *toolchai
 	// also include other resources relevant in the host namespace, to help troubleshooting
 	buf.WriteString(a.sprintAllResources())
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilToolchainStatusHasConditions returns a `ToolchainStatusWaitCriterion` which checks that the given
@@ -1338,7 +1328,7 @@ func UntilHasMurCount(domain string, expectedCount int) ToolchainStatusWaitCrite
 }
 
 // WaitForToolchainStatus waits until the ToolchainStatus is available with the provided criteria, if any
-func (a *HostAwaitility) WaitForToolchainStatus(criteria ...ToolchainStatusWaitCriterion) (*toolchainv1alpha1.ToolchainStatus, error) {
+func (a *HostAwaitility) WaitForToolchainStatus(t *testing.T, criteria ...ToolchainStatusWaitCriterion) (*toolchainv1alpha1.ToolchainStatus, error) {
 	// there should only be one toolchain status with the name toolchain-status
 	name := "toolchain-status"
 	toolchainStatus := &toolchainv1alpha1.ToolchainStatus{}
@@ -1362,19 +1352,19 @@ func (a *HostAwaitility) WaitForToolchainStatus(criteria ...ToolchainStatusWaitC
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printToolchainStatusWaitCriterionDiffs(toolchainStatus, criteria...)
+		a.printToolchainStatusWaitCriterionDiffs(t, toolchainStatus, criteria...)
 	}
 	return toolchainStatus, err
 }
 
 // GetToolchainConfig returns ToolchainConfig instance, nil if not found
-func (a *HostAwaitility) GetToolchainConfig() *toolchainv1alpha1.ToolchainConfig {
+func (a *HostAwaitility) GetToolchainConfig(t *testing.T) *toolchainv1alpha1.ToolchainConfig {
 	config := &toolchainv1alpha1.ToolchainConfig{}
 	if err := a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, "config"), config); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		require.NoError(a.T, err)
+		require.NoError(t, err)
 	}
 	return config
 }
@@ -1394,7 +1384,7 @@ func matchToolchainConfigWaitCriterion(actual *toolchainv1alpha1.ToolchainConfig
 	return true
 }
 
-func (a *HostAwaitility) printToolchainConfigWaitCriterionDiffs(actual *toolchainv1alpha1.ToolchainConfig, criteria ...ToolchainConfigWaitCriterion) {
+func (a *HostAwaitility) printToolchainConfigWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.ToolchainConfig, criteria ...ToolchainConfigWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find ToolchainConfig\n")
@@ -1415,7 +1405,7 @@ func (a *HostAwaitility) printToolchainConfigWaitCriterionDiffs(actual *toolchai
 	// also include other resources relevant in the host namespace, to help troubleshooting
 	buf.WriteString(a.sprintAllResources())
 
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 func UntilToolchainConfigHasSyncedStatus(expected toolchainv1alpha1.Condition) ToolchainConfigWaitCriterion {
@@ -1432,7 +1422,7 @@ func UntilToolchainConfigHasSyncedStatus(expected toolchainv1alpha1.Condition) T
 }
 
 // WaitForToolchainConfig waits until the ToolchainConfig is available with the provided criteria, if any
-func (a *HostAwaitility) WaitForToolchainConfig(criteria ...ToolchainConfigWaitCriterion) (*toolchainv1alpha1.ToolchainConfig, error) {
+func (a *HostAwaitility) WaitForToolchainConfig(t *testing.T, criteria ...ToolchainConfigWaitCriterion) (*toolchainv1alpha1.ToolchainConfig, error) {
 	// there should only be one ToolchainConfig with the name "config"
 	name := "config"
 	var toolchainConfig *toolchainv1alpha1.ToolchainConfig
@@ -1455,7 +1445,7 @@ func (a *HostAwaitility) WaitForToolchainConfig(criteria ...ToolchainConfigWaitC
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printToolchainConfigWaitCriterionDiffs(toolchainConfig, criteria...)
+		a.printToolchainConfigWaitCriterionDiffs(t, toolchainConfig, criteria...)
 	}
 	return toolchainConfig, err
 }
@@ -1463,10 +1453,10 @@ func (a *HostAwaitility) WaitForToolchainConfig(criteria ...ToolchainConfigWaitC
 // UpdateToolchainConfig updates the current resource of the ToolchainConfig CR with the given options.
 // If there is no existing resource already, then it creates a new one.
 // At the end of the test it returns the resource back to the original value/state.
-func (a *HostAwaitility) UpdateToolchainConfig(options ...testconfig.ToolchainConfigOption) {
+func (a *HostAwaitility) UpdateToolchainConfig(t *testing.T, options ...testconfig.ToolchainConfigOption) {
 	var originalConfig *toolchainv1alpha1.ToolchainConfig
 	// try to get the current ToolchainConfig
-	config := a.GetToolchainConfig()
+	config := a.GetToolchainConfig(t)
 	if config == nil {
 		// if it doesn't exist, then create a new one
 		config = &toolchainv1alpha1.ToolchainConfig{
@@ -1489,36 +1479,36 @@ func (a *HostAwaitility) UpdateToolchainConfig(options ...testconfig.ToolchainCo
 	if originalConfig == nil {
 		// then create a new one
 		err := a.Client.Create(context.TODO(), config)
-		require.NoError(a.T, err)
+		require.NoError(t, err)
 
 		// and as a cleanup function delete it at the end of the test
-		a.T.Cleanup(func() {
+		t.Cleanup(func() {
 			err := a.Client.Delete(context.TODO(), config)
 			if err != nil && !errors.IsNotFound(err) {
-				require.NoError(a.T, err)
+				require.NoError(t, err)
 			}
 		})
 		return
 	}
 
 	// if the config did exist before the tests, then update it
-	err := a.updateToolchainConfigWithRetry(config)
-	require.NoError(a.T, err)
+	err := a.updateToolchainConfigWithRetry(t, config)
+	require.NoError(t, err)
 
 	// and as a cleanup function update it back to the original value
-	a.T.Cleanup(func() {
-		config := a.GetToolchainConfig()
+	t.Cleanup(func() {
+		config := a.GetToolchainConfig(t)
 		// if the current config wasn't found
 		if config == nil {
 			if originalConfig != nil {
 				// then create it back with the original values
 				err := a.Client.Create(context.TODO(), originalConfig)
-				require.NoError(a.T, err)
+				require.NoError(t, err)
 			}
 		} else {
 			// otherwise just update it
-			err := a.updateToolchainConfigWithRetry(originalConfig)
-			require.NoError(a.T, err)
+			err := a.updateToolchainConfigWithRetry(t, originalConfig)
+			require.NoError(t, err)
 		}
 	})
 }
@@ -1526,12 +1516,12 @@ func (a *HostAwaitility) UpdateToolchainConfig(options ...testconfig.ToolchainCo
 // updateToolchainConfigWithRetry attempts to update the toolchainconfig, helpful because the toolchainconfig controller updates the toolchainconfig
 // resource periodically which can cause errors like `Operation cannot be fulfilled on toolchainconfigs.toolchain.dev.openshift.com "config": the object has been modified; please apply your changes to the latest version and try again`
 // in some cases. Retrying mitigates the potential for test flakiness due to this behaviour.
-func (a *HostAwaitility) updateToolchainConfigWithRetry(updatedConfig *toolchainv1alpha1.ToolchainConfig) error {
+func (a *HostAwaitility) updateToolchainConfigWithRetry(t *testing.T, updatedConfig *toolchainv1alpha1.ToolchainConfig) error {
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		config := a.GetToolchainConfig()
+		config := a.GetToolchainConfig(t)
 		config.Spec = updatedConfig.Spec
 		if err := a.Client.Update(context.TODO(), config); err != nil {
-			a.T.Logf("Retrying ToolchainConfig update due to error: %s", err.Error())
+			t.Logf("Retrying ToolchainConfig update due to error: %s", err.Error())
 			return false, nil
 		}
 		return true, nil
@@ -1552,15 +1542,15 @@ func (a *HostAwaitility) GetHostOperatorPod() (corev1.Pod, error) {
 }
 
 // CreateAPIProxyClient creates a client to the appstudio api proxy using the given user token
-func (a *HostAwaitility) CreateAPIProxyClient(usertoken string) client.Client {
+func (a *HostAwaitility) CreateAPIProxyClient(t *testing.T, usertoken string) client.Client {
 	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	defaultConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 
 	s := scheme.Scheme
 	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme)
-	require.NoError(a.T, builder.AddToScheme(s))
+	require.NoError(t, builder.AddToScheme(s))
 
 	proxyKubeConfig := &rest.Config{
 		Host:            a.APIProxyURL,
@@ -1570,7 +1560,7 @@ func (a *HostAwaitility) CreateAPIProxyClient(usertoken string) client.Client {
 	proxyCl, err := client.New(proxyKubeConfig, client.Options{
 		Scheme: s,
 	})
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	return proxyCl
 }
 
@@ -1589,8 +1579,8 @@ func matchSpaceWaitCriterion(actual *toolchainv1alpha1.Space, criteria ...SpaceW
 }
 
 // WaitForSpace waits until the Space with the given name is available with the provided criteria, if any
-func (a *HostAwaitility) WaitForSpace(name string, criteria ...SpaceWaitCriterion) (*toolchainv1alpha1.Space, error) {
-	a.T.Logf("waiting for Space '%s' with matching criteria", name)
+func (a *HostAwaitility) WaitForSpace(t *testing.T, name string, criteria ...SpaceWaitCriterion) (*toolchainv1alpha1.Space, error) {
+	t.Logf("waiting for Space '%s' with matching criteria", name)
 	var space *toolchainv1alpha1.Space
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Space{}
@@ -1611,12 +1601,12 @@ func (a *HostAwaitility) WaitForSpace(name string, criteria ...SpaceWaitCriterio
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printSpaceWaitCriterionDiffs(space, criteria...)
+		a.printSpaceWaitCriterionDiffs(t, space, criteria...)
 	}
 	return space, err
 }
 
-func (a *HostAwaitility) printSpaceWaitCriterionDiffs(actual *toolchainv1alpha1.Space, criteria ...SpaceWaitCriterion) {
+func (a *HostAwaitility) printSpaceWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.Space, criteria ...SpaceWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Space\n")
@@ -1636,8 +1626,8 @@ func (a *HostAwaitility) printSpaceWaitCriterionDiffs(actual *toolchainv1alpha1.
 		}
 	}
 	// also include Spaces resources in the host namespace, to help troubleshooting
-	a.listAndPrint("Spaces", a.Namespace, &toolchainv1alpha1.SpaceList{})
-	a.T.Log(buf.String())
+	a.listAndPrint(t, "Spaces", a.Namespace, &toolchainv1alpha1.SpaceList{})
+	t.Log(buf.String())
 }
 
 // UntilSpaceIsBeingDeleted checks if Space has Deletion Timestamp
@@ -1772,8 +1762,8 @@ func UntilSpaceHasStatusTargetCluster(expected string) SpaceWaitCriterion {
 }
 
 // WaitUntilSpaceAndSpaceBindingsDeleted waits until the Space with the given name and its associated SpaceBindings are deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilSpaceAndSpaceBindingsDeleted(name string) error {
-	a.T.Logf("waiting until Space '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *HostAwaitility) WaitUntilSpaceAndSpaceBindingsDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until Space '%s' in namespace '%s' is deleted", name, a.Namespace)
 	var s *toolchainv1alpha1.Space
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Space{}
@@ -1784,7 +1774,7 @@ func (a *HostAwaitility) WaitUntilSpaceAndSpaceBindingsDeleted(name string) erro
 			}, obj); err != nil {
 			if errors.IsNotFound(err) {
 				// once the space is deleted, wait for the associated spacebindings to be deleted as well
-				if err := a.WaitUntilSpaceBindingsWithLabelDeleted(toolchainv1alpha1.SpaceBindingSpaceLabelKey, name); err != nil {
+				if err := a.WaitUntilSpaceBindingsWithLabelDeleted(t, toolchainv1alpha1.SpaceBindingSpaceLabelKey, name); err != nil {
 					return false, err
 				}
 				return true, nil
@@ -1796,7 +1786,7 @@ func (a *HostAwaitility) WaitUntilSpaceAndSpaceBindingsDeleted(name string) erro
 	})
 	if err != nil {
 		y, _ := yaml.Marshal(s)
-		a.T.Logf("Space '%s' was not deleted as expected: %s", name, y)
+		t.Logf("Space '%s' was not deleted as expected: %s", name, y)
 		return err
 	}
 	return nil
@@ -1817,9 +1807,9 @@ func (a *HostAwaitility) WaitUntilSpaceBindingDeleted(name string) error {
 }
 
 // WaitUntilSpaceBindingsWithLabelDeleted waits until there are no SpaceBindings listed using the given labels
-func (a *HostAwaitility) WaitUntilSpaceBindingsWithLabelDeleted(key, value string) error {
+func (a *HostAwaitility) WaitUntilSpaceBindingsWithLabelDeleted(t *testing.T, key, value string) error {
 	labels := map[string]string{key: value}
-	a.T.Logf("waiting until SpaceBindings with labels '%v' in namespace '%s' are deleted", labels, a.Namespace)
+	t.Logf("waiting until SpaceBindings with labels '%v' in namespace '%s' are deleted", labels, a.Namespace)
 	var spaceBindingList *toolchainv1alpha1.SpaceBindingList
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
 		// retrieve the SpaceBinding from the host namespace
@@ -1857,7 +1847,7 @@ func matchSpaceBindingWaitCriterion(actual *toolchainv1alpha1.SpaceBinding, crit
 }
 
 // WaitForSpaceBinding waits until the SpaceBinding with the given MUR and Space names is available with the provided criteria, if any
-func (a *HostAwaitility) WaitForSpaceBinding(murName, spaceName string, criteria ...SpaceBindingWaitCriterion) (*toolchainv1alpha1.SpaceBinding, error) {
+func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName string, criteria ...SpaceBindingWaitCriterion) (*toolchainv1alpha1.SpaceBinding, error) {
 	var spacebinding *toolchainv1alpha1.SpaceBinding
 	labels := map[string]string{
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName,
@@ -1881,12 +1871,12 @@ func (a *HostAwaitility) WaitForSpaceBinding(murName, spaceName string, criteria
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printSpaceBindingWaitCriterionDiffs(spacebinding, criteria...)
+		a.printSpaceBindingWaitCriterionDiffs(t, spacebinding, criteria...)
 	}
 	return spacebinding, err
 }
 
-func (a *HostAwaitility) printSpaceBindingWaitCriterionDiffs(actual *toolchainv1alpha1.SpaceBinding, criteria ...SpaceBindingWaitCriterion) {
+func (a *HostAwaitility) printSpaceBindingWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.SpaceBinding, criteria ...SpaceBindingWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find SpaceBinding\n")
@@ -1906,8 +1896,8 @@ func (a *HostAwaitility) printSpaceBindingWaitCriterionDiffs(actual *toolchainv1
 		}
 	}
 	// also include SpaceBindings resources in the host namespace, to help troubleshooting
-	a.listAndPrint("SpaceBindings", a.Namespace, &toolchainv1alpha1.SpaceBindingList{})
-	a.T.Log(buf.String())
+	a.listAndPrint(t, "SpaceBindings", a.Namespace, &toolchainv1alpha1.SpaceBindingList{})
+	t.Log(buf.String())
 }
 
 func (a *HostAwaitility) ListSpaceBindings(spaceName string) ([]toolchainv1alpha1.SpaceBinding, error) {
@@ -1973,8 +1963,8 @@ func matchSocialEventWaitCriterion(actual *toolchainv1alpha1.SocialEvent, criter
 	return true
 }
 
-func (a *HostAwaitility) WaitForSocialEvent(name string, criteria ...SocialEventWaitCriterion) (*toolchainv1alpha1.SocialEvent, error) {
-	a.T.Logf("waiting for SocialEvent '%s' in namespace '%s' to match criteria", name, a.Namespace)
+func (a *HostAwaitility) WaitForSocialEvent(t *testing.T, name string, criteria ...SocialEventWaitCriterion) (*toolchainv1alpha1.SocialEvent, error) {
+	t.Logf("waiting for SocialEvent '%s' in namespace '%s' to match criteria", name, a.Namespace)
 	var event *toolchainv1alpha1.SocialEvent
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.SocialEvent{}
@@ -1995,7 +1985,7 @@ func (a *HostAwaitility) WaitForSocialEvent(name string, criteria ...SocialEvent
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printSocialEventWaitCriterionDiffs(event, criteria...)
+		a.printSocialEventWaitCriterionDiffs(t, event, criteria...)
 	}
 	return event, err
 }
@@ -2026,7 +2016,7 @@ func UntilSocialEventHasConditions(expected ...toolchainv1alpha1.Condition) Soci
 	}
 }
 
-func (a *HostAwaitility) printSocialEventWaitCriterionDiffs(actual *toolchainv1alpha1.SocialEvent, criteria ...SocialEventWaitCriterion) {
+func (a *HostAwaitility) printSocialEventWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.SocialEvent, criteria ...SocialEventWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find SocialEvent\n")
@@ -2046,8 +2036,8 @@ func (a *HostAwaitility) printSocialEventWaitCriterionDiffs(actual *toolchainv1a
 		}
 	}
 	// also include SocialEvents resources in the host namespace, to help troubleshooting
-	a.listAndPrint("SocialEvents", a.Namespace, &toolchainv1alpha1.SocialEventList{})
-	a.T.Log(buf.String())
+	a.listAndPrint(t, "SocialEvents", a.Namespace, &toolchainv1alpha1.SocialEventList{})
+	t.Log(buf.String())
 }
 
 const (

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -41,7 +41,7 @@ type HostAwaitility struct {
 }
 
 // NewHostAwaitility initializes a HostAwaitility
-func NewHostAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns string, registrationServiceNs string) *HostAwaitility {
+func NewHostAwaitility(cfg *rest.Config, cl client.Client, ns string, registrationServiceNs string) *HostAwaitility {
 	return &HostAwaitility{
 		Awaitility: &Awaitility{
 			Client:        cl,

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1328,7 +1328,7 @@ func UntilHasMurCount(domain string, expectedCount int) ToolchainStatusWaitCrite
 }
 
 // UntilHasSpaceCount returns a `ToolchainStatusWaitCriterion` which checks that the given
-// ToolchainStatus has the given count of MasterUserRecords
+// ToolchainStatus has the given count of Spaces
 func UntilHasSpaceCount(clusterName string, expectedCount int) ToolchainStatusWaitCriterion {
 	return ToolchainStatusWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.ToolchainStatus) bool {

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -53,7 +53,7 @@ type MemberAwaitility struct {
 	*Awaitility
 }
 
-func NewMemberAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns, clusterName string) *MemberAwaitility {
+func NewMemberAwaitility(cfg *rest.Config, cl client.Client, ns, clusterName string) *MemberAwaitility {
 	return &MemberAwaitility{
 		Awaitility: &Awaitility{
 			Client:        cl,

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -59,18 +59,11 @@ func NewMemberAwaitility(t *testing.T, cfg *rest.Config, cl client.Client, ns, c
 			Client:        cl,
 			RestConfig:    cfg,
 			ClusterName:   clusterName,
-			T:             t,
 			Namespace:     ns,
 			Type:          cluster.Member,
 			RetryInterval: DefaultRetryInterval,
 			Timeout:       DefaultTimeout,
 		},
-	}
-}
-
-func (a *MemberAwaitility) ForTest(t *testing.T) *MemberAwaitility {
-	return &MemberAwaitility{
-		Awaitility: a.Awaitility.ForTest(t),
 	}
 }
 
@@ -95,7 +88,7 @@ func matchUserAccountWaitCriterion(actual *toolchainv1alpha1.UserAccount, criter
 	return true
 }
 
-func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(actual *toolchainv1alpha1.UserAccount, criteria ...UserAccountWaitCriterion) {
+func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.UserAccount, criteria ...UserAccountWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find UserAccount\n")
@@ -115,7 +108,7 @@ func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(actual *toolchainv
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilUserAccountHasLabelWithValue returns a `UserAccountWaitCriterion` which checks that the given
@@ -232,7 +225,7 @@ func UntilUserAccountIsCreatedAfter(timestamp metav1.Time) UserAccountWaitCriter
 }
 
 // WaitForUserAccount waits until there is a UserAccount available with the given name, expected spec and the set of status conditions
-func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccountWaitCriterion) (*toolchainv1alpha1.UserAccount, error) {
+func (a *MemberAwaitility) WaitForUserAccount(t *testing.T, name string, criteria ...UserAccountWaitCriterion) (*toolchainv1alpha1.UserAccount, error) {
 	var userAccount *toolchainv1alpha1.UserAccount
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.UserAccount{}
@@ -247,7 +240,7 @@ func (a *MemberAwaitility) WaitForUserAccount(name string, criteria ...UserAccou
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printUserAccountWaitCriterionDiffs(userAccount, criteria...)
+		a.printUserAccountWaitCriterionDiffs(t, userAccount, criteria...)
 	}
 	return userAccount, err
 }
@@ -267,7 +260,7 @@ func matchNSTemplateSetWaitCriterion(actual *toolchainv1alpha1.NSTemplateSet, cr
 	return true
 }
 
-func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(actual *toolchainv1alpha1.NSTemplateSet, criteria ...NSTemplateSetWaitCriterion) {
+func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.NSTemplateSet, criteria ...NSTemplateSetWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find NSTemplateSet at all\n")
@@ -287,7 +280,7 @@ func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(actual *toolchai
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilNSTemplateSetHasNoOwnerReferences returns a `NSTemplateSetWaitCriterion` which checks that the given
@@ -390,8 +383,8 @@ func UntilNSTemplateSetHasTier(expected string) NSTemplateSetWaitCriterion {
 }
 
 // WaitForNSTmplSet wait until the NSTemplateSet with the given name and conditions exists
-func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateSetWaitCriterion) (*toolchainv1alpha1.NSTemplateSet, error) {
-	a.T.Logf("waiting for NSTemplateSet '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForNSTmplSet(t *testing.T, name string, criteria ...NSTemplateSetWaitCriterion) (*toolchainv1alpha1.NSTemplateSet, error) {
+	t.Logf("waiting for NSTemplateSet '%s' to match criteria", name)
 	var nsTmplSet *toolchainv1alpha1.NSTemplateSet
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.NSTemplateSet{}
@@ -406,14 +399,14 @@ func (a *MemberAwaitility) WaitForNSTmplSet(name string, criteria ...NSTemplateS
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNSTemplateSetWaitCriterionDiffs(nsTmplSet, criteria...)
+		a.printNSTemplateSetWaitCriterionDiffs(t, nsTmplSet, criteria...)
 	}
 	return nsTmplSet, err
 }
 
 // WaitUntilNSTemplateSetDeleted waits until the NSTemplateSet with the given name is deleted (ie, is not found)
-func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(name string) error {
-	a.T.Logf("waiting for until NSTemplateSet '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *MemberAwaitility) WaitUntilNSTemplateSetDeleted(t *testing.T, name string) error {
+	t.Logf("waiting for until NSTemplateSet '%s' in namespace '%s' is deleted", name, a.Namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		nsTmplSet := &toolchainv1alpha1.NSTemplateSet{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, nsTmplSet); err != nil {
@@ -490,7 +483,7 @@ func matchNamespaceWaitCriteria(actual *corev1.Namespace, criteria ...NamespaceW
 }
 
 // WaitForNamespace waits until a namespace with the given owner (username), type, revision and tier labels exists
-func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, criteria ...NamespaceWaitCriterion) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespace(t *testing.T, owner, tmplRef, tierName string, criteria ...NamespaceWaitCriterion) (*corev1.Namespace, error) {
 	_, kind, _, err := Split(tmplRef)
 	if err != nil {
 		return nil, err
@@ -502,7 +495,7 @@ func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, cri
 		"toolchain.dev.openshift.com/type":        kind,
 		"toolchain.dev.openshift.com/provider":    "codeready-toolchain",
 	}
-	a.T.Logf("waiting for namespace with custom criteria and labels %v", labels)
+	t.Logf("waiting for namespace with custom criteria and labels %v", labels)
 	var ns *corev1.Namespace
 	err = wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		nss := &corev1.NamespaceList{}
@@ -517,17 +510,17 @@ func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, cri
 		return matchNamespaceWaitCriteria(ns, criteria...), nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for namespace with labels: %v", labels)
+		t.Logf("failed to wait for namespace with labels: %v", labels)
 		opts := client.MatchingLabels(map[string]string{
 			"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 		})
-		a.listAndPrint("Namespaces", "", &corev1.NamespaceList{}, opts)
+		a.listAndPrint(t, "Namespaces", "", &corev1.NamespaceList{}, opts)
 		if ns == nil {
-			a.T.Logf("a namespace with the following labels was not found: %v", labels)
+			t.Logf("a namespace with the following labels was not found: %v", labels)
 			return nil, err
 		}
 		for _, c := range criteria {
-			a.T.Logf(c.Diff(ns))
+			t.Logf(c.Diff(ns))
 		}
 		return nil, err
 	}
@@ -535,7 +528,7 @@ func (a *MemberAwaitility) WaitForNamespace(owner, tmplRef, tierName string, cri
 }
 
 // WaitForNamespaceWithName waits until a namespace with the given name
-func (a *MemberAwaitility) WaitForNamespaceWithName(name string, criteria ...LabelWaitCriterion) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespaceWithName(t *testing.T, name string, criteria ...LabelWaitCriterion) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Namespace{}
@@ -549,8 +542,8 @@ func (a *MemberAwaitility) WaitForNamespaceWithName(name string, criteria ...Lab
 		return matchLabelWaitCriteria(ns.ObjectMeta, criteria...), nil
 	})
 	if err != nil {
-		a.T.Log("failed to wait for namespace")
-		a.printNamespaceLabelCriterionDiffs(ns, criteria...)
+		t.Log("failed to wait for namespace")
+		a.printNamespaceLabelCriterionDiffs(t, ns, criteria...)
 		return nil, err
 	}
 	return ns, nil
@@ -565,7 +558,7 @@ func matchLabelWaitCriteria(actual metav1.ObjectMeta, criteria ...LabelWaitCrite
 	return true
 }
 
-func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(actual *corev1.Namespace, criteria ...LabelWaitCriterion) {
+func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(t *testing.T, actual *corev1.Namespace, criteria ...LabelWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Namespace\n")
@@ -585,11 +578,11 @@ func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(actual *corev1.Name
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForNamespaceInTerminating waits until a namespace with the given name has a deletion timestamp and in Terminating Phase
-func (a *MemberAwaitility) WaitForNamespaceInTerminating(nsName string) (*corev1.Namespace, error) {
+func (a *MemberAwaitility) WaitForNamespaceInTerminating(t *testing.T, nsName string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Namespace{}
@@ -603,15 +596,15 @@ func (a *MemberAwaitility) WaitForNamespaceInTerminating(nsName string) (*corev1
 		return obj.DeletionTimestamp != nil && obj.Status.Phase == corev1.NamespaceTerminating, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for namespace '%s' to be in 'Terminating' phase", nsName)
+		t.Logf("failed to wait for namespace '%s' to be in 'Terminating' phase", nsName)
 		return nil, err
 	}
 	return ns, nil
 }
 
 // WaitForRoleBinding waits until a RoleBinding with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForRoleBinding(namespace *corev1.Namespace, name string) (*rbacv1.RoleBinding, error) {
-	a.T.Logf("waiting for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForRoleBinding(t *testing.T, namespace *corev1.Namespace, name string) (*rbacv1.RoleBinding, error) {
+	t.Logf("waiting for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
 	roleBinding := &rbacv1.RoleBinding{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &rbacv1.RoleBinding{}
@@ -629,15 +622,15 @@ func (a *MemberAwaitility) WaitForRoleBinding(namespace *corev1.Namespace, name 
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for RoleBinding '%s' in namespace '%s'", name, namespace.Name)
 		return nil, err
 	}
 	return roleBinding, err
 }
 
 // WaitUntilRoleBindingDeleted waits until a RoleBinding with the given name does not exist anymore in the given namespace
-func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(namespace *corev1.Namespace, name string) error {
-	a.T.Logf("waiting for RoleBinding '%s' in namespace '%s' to be deleted", name, namespace.Name)
+func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(t *testing.T, namespace *corev1.Namespace, name string) error {
+	t.Logf("waiting for RoleBinding '%s' in namespace '%s' to be deleted", name, namespace.Name)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		roleBinding := &rbacv1.RoleBinding{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, roleBinding); err != nil {
@@ -650,8 +643,8 @@ func (a *MemberAwaitility) WaitUntilRoleBindingDeleted(namespace *corev1.Namespa
 	})
 }
 
-func (a *MemberAwaitility) WaitForServiceAccount(namespace string, name string) (*corev1.ServiceAccount, error) {
-	a.T.Logf("waiting for ServiceAccount '%s' in namespace '%s'", name, namespace)
+func (a *MemberAwaitility) WaitForServiceAccount(t *testing.T, namespace string, name string) (*corev1.ServiceAccount, error) {
+	t.Logf("waiting for ServiceAccount '%s' in namespace '%s'", name, namespace)
 	serviceAccount := &corev1.ServiceAccount{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ServiceAccount{}
@@ -665,15 +658,15 @@ func (a *MemberAwaitility) WaitForServiceAccount(namespace string, name string) 
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for ServiceAccount '%s' in namespace '%s'.", name, namespace)
+		t.Logf("failed to wait for ServiceAccount '%s' in namespace '%s'.", name, namespace)
 		return nil, err
 	}
 	return serviceAccount, err
 }
 
 // WaitForLimitRange waits until a LimitRange with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForLimitRange(namespace *corev1.Namespace, name string) (*corev1.LimitRange, error) {
-	a.T.Logf("waiting for LimitRange '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForLimitRange(t *testing.T, namespace *corev1.Namespace, name string) (*corev1.LimitRange, error) {
+	t.Logf("waiting for LimitRange '%s' in namespace '%s'", name, namespace.Name)
 	lr := &corev1.LimitRange{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.LimitRange{}
@@ -691,14 +684,14 @@ func (a *MemberAwaitility) WaitForLimitRange(namespace *corev1.Namespace, name s
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for LimitRange '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for LimitRange '%s' in namespace '%s'", name, namespace.Name)
 	}
 	return lr, err
 }
 
 // WaitForNetworkPolicy waits until a NetworkPolicy with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForNetworkPolicy(namespace *corev1.Namespace, name string) (*netv1.NetworkPolicy, error) {
-	a.T.Logf("waiting for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForNetworkPolicy(t *testing.T, namespace *corev1.Namespace, name string) (*netv1.NetworkPolicy, error) {
+	t.Logf("waiting for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
 	np := &netv1.NetworkPolicy{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &netv1.NetworkPolicy{}
@@ -716,14 +709,14 @@ func (a *MemberAwaitility) WaitForNetworkPolicy(namespace *corev1.Namespace, nam
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for NetworkPolicy '%s' in namespace '%s'", name, namespace.Name)
 	}
 	return np, err
 }
 
 // WaitForRole waits until a Role with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForRole(namespace *corev1.Namespace, name string) (*rbacv1.Role, error) {
-	a.T.Logf("waiting for Role '%s' in namespace '%s'", name, namespace.Name)
+func (a *MemberAwaitility) WaitForRole(t *testing.T, namespace *corev1.Namespace, name string) (*rbacv1.Role, error) {
+	t.Logf("waiting for Role '%s' in namespace '%s'", name, namespace.Name)
 	role := &rbacv1.Role{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &rbacv1.Role{}
@@ -741,14 +734,14 @@ func (a *MemberAwaitility) WaitForRole(namespace *corev1.Namespace, name string)
 		return true, nil
 	})
 	if err != nil {
-		a.T.Logf("failed to wait for Role '%s' in namespace '%s'", name, namespace.Name)
+		t.Logf("failed to wait for Role '%s' in namespace '%s'", name, namespace.Name)
 	}
 	return role, err
 }
 
 // WaitUntilRoleDeleted waits until a Role with the given name does not exist anymore in the given namespace
-func (a *MemberAwaitility) WaitUntilRoleDeleted(namespace *corev1.Namespace, name string) error {
-	a.T.Logf("waiting for Role '%s' in namespace '%s' to be deleted", name, namespace.Name)
+func (a *MemberAwaitility) WaitUntilRoleDeleted(t *testing.T, namespace *corev1.Namespace, name string) error {
+	t.Logf("waiting for Role '%s' in namespace '%s' to be deleted", name, namespace.Name)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		role := &rbacv1.Role{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: a.Namespace}, role); err != nil {
@@ -776,7 +769,7 @@ func matchClusterResourceQuotaWaitCriteria(actual *quotav1.ClusterResourceQuota,
 	return true
 }
 
-func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(actual *quotav1.ClusterResourceQuota, criteria ...ClusterResourceQuotaWaitCriterion) {
+func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(t *testing.T, actual *quotav1.ClusterResourceQuota, criteria ...ClusterResourceQuotaWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find ClusterResourceQuota\n")
@@ -796,12 +789,12 @@ func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(actual *q
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForClusterResourceQuota waits until a ClusterResourceQuota with the given name exists
-func (a *MemberAwaitility) WaitForClusterResourceQuota(name string, criteria ...ClusterResourceQuotaWaitCriterion) (*quotav1.ClusterResourceQuota, error) {
-	a.T.Logf("waiting for ClusterResourceQuota '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForClusterResourceQuota(t *testing.T, name string, criteria ...ClusterResourceQuotaWaitCriterion) (*quotav1.ClusterResourceQuota, error) {
+	t.Logf("waiting for ClusterResourceQuota '%s' to match criteria", name)
 	quota := &quotav1.ClusterResourceQuota{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &quotav1.ClusterResourceQuota{}
@@ -821,7 +814,7 @@ func (a *MemberAwaitility) WaitForClusterResourceQuota(name string, criteria ...
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printClusterResourceQuotaWaitCriterionDiffs(quota, criteria...)
+		a.printClusterResourceQuotaWaitCriterionDiffs(t, quota, criteria...)
 	}
 	return quota, err
 }
@@ -841,7 +834,7 @@ func matchResourceQuotaWaitCriteria(actual *corev1.ResourceQuota, criteria ...Re
 	return true
 }
 
-func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(actual *corev1.ResourceQuota, criteria ...ResourceQuotaWaitCriterion) {
+func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(t *testing.T, actual *corev1.ResourceQuota, criteria ...ResourceQuotaWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find ResourceQuota\n")
@@ -861,12 +854,12 @@ func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(actual *corev1.R
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForResourceQuota waits until a ResourceQuota with the given name exists
-func (a *MemberAwaitility) WaitForResourceQuota(namespace, name string, criteria ...ResourceQuotaWaitCriterion) (*corev1.ResourceQuota, error) {
-	a.T.Logf("waiting for ResourceQuota '%s' in %s to match criteria", name, namespace)
+func (a *MemberAwaitility) WaitForResourceQuota(t *testing.T, namespace, name string, criteria ...ResourceQuotaWaitCriterion) (*corev1.ResourceQuota, error) {
+	t.Logf("waiting for ResourceQuota '%s' in %s to match criteria", name, namespace)
 	quota := &corev1.ResourceQuota{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ResourceQuota{}
@@ -881,7 +874,7 @@ func (a *MemberAwaitility) WaitForResourceQuota(namespace, name string, criteria
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printResourceQuotaWaitCriterionDiffs(quota, criteria...)
+		a.printResourceQuotaWaitCriterionDiffs(t, quota, criteria...)
 	}
 	return quota, err
 }
@@ -902,7 +895,7 @@ func matchIdlerWaitCriteria(actual *toolchainv1alpha1.Idler, criteria ...IdlerWa
 	return true
 }
 
-func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(actual *toolchainv1alpha1.Idler, criteria ...IdlerWaitCriterion) {
+func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(t *testing.T, actual *toolchainv1alpha1.Idler, criteria ...IdlerWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Idler\n")
@@ -924,7 +917,7 @@ func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(actual *toolchainv1alpha1
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // IdlerConditions returns a `IdlerWaitCriterion` which checks that the given
@@ -965,8 +958,8 @@ func IdlerHasTier(expected string) IdlerWaitCriterion {
 }
 
 // WaitForIdler waits until an Idler with the given name exists
-func (a *MemberAwaitility) WaitForIdler(name string, criteria ...IdlerWaitCriterion) (*toolchainv1alpha1.Idler, error) {
-	a.T.Logf("waiting for Idler '%s' to match criteria", name)
+func (a *MemberAwaitility) WaitForIdler(t *testing.T, name string, criteria ...IdlerWaitCriterion) (*toolchainv1alpha1.Idler, error) {
+	t.Logf("waiting for Idler '%s' to match criteria", name)
 	idler := &toolchainv1alpha1.Idler{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Idler{}
@@ -981,13 +974,13 @@ func (a *MemberAwaitility) WaitForIdler(name string, criteria ...IdlerWaitCriter
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printIdlerWaitCriteriaDiffs(idler, criteria...)
+		a.printIdlerWaitCriteriaDiffs(t, idler, criteria...)
 	}
 	return idler, err
 }
 
 // UpdateIdlerSpec tries to update the Idler.Spec until success
-func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*toolchainv1alpha1.Idler, error) {
+func (a *MemberAwaitility) UpdateIdlerSpec(t *testing.T, idler *toolchainv1alpha1.Idler) (*toolchainv1alpha1.Idler, error) {
 	var result *toolchainv1alpha1.Idler
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &toolchainv1alpha1.Idler{}
@@ -996,7 +989,7 @@ func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*too
 		}
 		obj.Spec = idler.Spec
 		if err := a.Client.Update(context.TODO(), obj); err != nil {
-			a.T.Logf("trying to update Idler %s. Error: %s. Will try to update again.", idler.Name, err.Error())
+			t.Logf("trying to update Idler %s. Error: %s. Will try to update again.", idler.Name, err.Error())
 			return false, nil
 		}
 		result = obj
@@ -1008,7 +1001,7 @@ func (a *MemberAwaitility) UpdateIdlerSpec(idler *toolchainv1alpha1.Idler) (*too
 // UpdateNSTemplateSet tries to update the Spec of the given NSTemplateSet
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated NSTemplateSet
-func (a *MemberAwaitility) UpdateNSTemplateSet(spaceName string, modifyNSTemplateSet func(nsTmplSet *toolchainv1alpha1.NSTemplateSet)) (*toolchainv1alpha1.NSTemplateSet, error) {
+func (a *MemberAwaitility) UpdateNSTemplateSet(t *testing.T, spaceName string, modifyNSTemplateSet func(nsTmplSet *toolchainv1alpha1.NSTemplateSet)) (*toolchainv1alpha1.NSTemplateSet, error) {
 	var nsTmplSet *toolchainv1alpha1.NSTemplateSet
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshNSTmplSet := &toolchainv1alpha1.NSTemplateSet{}
@@ -1017,7 +1010,7 @@ func (a *MemberAwaitility) UpdateNSTemplateSet(spaceName string, modifyNSTemplat
 		}
 		modifyNSTemplateSet(freshNSTmplSet)
 		if err := a.Client.Update(context.TODO(), freshNSTmplSet); err != nil {
-			a.T.Logf("error updating NSTemplateSet '%s': %s. Will retry again...", spaceName, err.Error())
+			t.Logf("error updating NSTemplateSet '%s': %s. Will retry again...", spaceName, err.Error())
 			return false, nil
 		}
 		nsTmplSet = freshNSTmplSet
@@ -1028,10 +1021,10 @@ func (a *MemberAwaitility) UpdateNSTemplateSet(spaceName string, modifyNSTemplat
 
 // Create tries to create the object until success
 // Workaround for https://github.com/kubernetes/kubernetes/issues/67761
-func (a *MemberAwaitility) Create(obj client.Object) error {
+func (a *MemberAwaitility) Create(t *testing.T, obj client.Object) error {
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		if err := a.Client.Create(context.TODO(), obj); err != nil {
-			a.T.Logf("trying to create %+v. Error: %s. Will try to create again.", obj, err.Error())
+			t.Logf("trying to create %+v. Error: %s. Will try to create again.", obj, err.Error())
 			return false, nil
 		}
 		return true, nil
@@ -1053,7 +1046,7 @@ func matchPodWaitCriterion(actual *corev1.Pod, criteria ...PodWaitCriterion) boo
 	return true
 }
 
-func (a *MemberAwaitility) printPodWaitCriterionDiffs(actual *corev1.Pod, ns string, criteria ...PodWaitCriterion) {
+func (a *MemberAwaitility) printPodWaitCriterionDiffs(t *testing.T, actual *corev1.Pod, ns string, criteria ...PodWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find Pod\n")
@@ -1067,12 +1060,12 @@ func (a *MemberAwaitility) printPodWaitCriterionDiffs(actual *corev1.Pod, ns str
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForPod waits until a pod with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForPod(namespace, name string, criteria ...PodWaitCriterion) (*corev1.Pod, error) {
-	a.T.Logf("waiting for Pod '%s' in namespace '%s' with matching criteria", name, namespace)
+func (a *MemberAwaitility) WaitForPod(t *testing.T, namespace, name string, criteria ...PodWaitCriterion) (*corev1.Pod, error) {
+	t.Logf("waiting for Pod '%s' in namespace '%s' with matching criteria", name, namespace)
 	var pod *corev1.Pod
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Pod{}
@@ -1092,14 +1085,14 @@ func (a *MemberAwaitility) WaitForPod(namespace, name string, criteria ...PodWai
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printPodWaitCriterionDiffs(pod, namespace, criteria...)
+		a.printPodWaitCriterionDiffs(t, pod, namespace, criteria...)
 	}
 	return pod, err
 }
 
 // WaitForConfigMap waits until a ConfigMap with the given name exists in the given namespace
-func (a *MemberAwaitility) WaitForConfigMap(namespace, name string) (*corev1.ConfigMap, error) {
-	a.T.Logf("waiting for ConfigMap '%s' in namespace '%s'", name, namespace)
+func (a *MemberAwaitility) WaitForConfigMap(t *testing.T, namespace, name string) (*corev1.ConfigMap, error) {
+	t.Logf("waiting for ConfigMap '%s' in namespace '%s'", name, namespace)
 	var cm *corev1.ConfigMap
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ConfigMap{}
@@ -1121,8 +1114,8 @@ func (a *MemberAwaitility) WaitForConfigMap(namespace, name string) (*corev1.Con
 }
 
 // WaitForPods waits until "n" number of pods exist in the given namespace
-func (a *MemberAwaitility) WaitForPods(namespace string, n int, criteria ...PodWaitCriterion) ([]corev1.Pod, error) {
-	a.T.Logf("waiting for Pods in namespace '%s' with matching criteria", namespace)
+func (a *MemberAwaitility) WaitForPods(t *testing.T, namespace string, n int, criteria ...PodWaitCriterion) ([]corev1.Pod, error) {
+	t.Logf("waiting for Pods in namespace '%s' with matching criteria", namespace)
 	pods := make([]corev1.Pod, 0, n)
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		pds := make([]corev1.Pod, 0, n)
@@ -1149,8 +1142,8 @@ func (a *MemberAwaitility) WaitForPods(namespace string, n int, criteria ...PodW
 }
 
 // WaitUntilPodsDeleted waits until the pods are deleted from the given namespace
-func (a *MemberAwaitility) WaitUntilPodsDeleted(namespace string, criteria ...PodWaitCriterion) error {
-	a.T.Logf("waiting until Pods with matching criteria in namespace '%s' are deleted", namespace)
+func (a *MemberAwaitility) WaitUntilPodsDeleted(t *testing.T, namespace string, criteria ...PodWaitCriterion) error {
+	t.Logf("waiting until Pods with matching criteria in namespace '%s' are deleted", namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		foundPods := &corev1.PodList{}
 		if err := a.Client.List(context.TODO(), foundPods, &client.ListOptions{Namespace: namespace}); err != nil {
@@ -1170,8 +1163,8 @@ func (a *MemberAwaitility) WaitUntilPodsDeleted(namespace string, criteria ...Po
 }
 
 // WaitUntilPodDeleted waits until the pod with the given name is deleted from the given namespace
-func (a *MemberAwaitility) WaitUntilPodDeleted(namespace, name string) error {
-	a.T.Logf("waiting until Pod '%s' in namespace '%s' is deleted", name, namespace)
+func (a *MemberAwaitility) WaitUntilPodDeleted(t *testing.T, namespace, name string) error {
+	t.Logf("waiting until Pod '%s' in namespace '%s' is deleted", name, namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.Pod{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, obj); err != nil {
@@ -1256,8 +1249,8 @@ func checkPriorityClass(pod *corev1.Pod, name string, priority int) bool {
 }
 
 // WaitUntilNamespaceDeleted waits until the namespace with the given name is deleted (ie, is not found)
-func (a *MemberAwaitility) WaitUntilNamespaceDeleted(username, typeName string) error {
-	a.T.Logf("waiting until namespace for user '%s' and type '%s' is deleted", username, typeName)
+func (a *MemberAwaitility) WaitUntilNamespaceDeleted(t *testing.T, username, typeName string) error {
+	t.Logf("waiting until namespace for user '%s' and type '%s' is deleted", username, typeName)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{
 			"toolchain.dev.openshift.com/owner": username,
@@ -1290,7 +1283,7 @@ func matchUserWaitCriterion(actual *userv1.User, criteria ...UserWaitCriterion) 
 	return true
 }
 
-func (a *MemberAwaitility) printUserWaitCriterionDiffs(actual *userv1.User, criteria ...UserWaitCriterion) {
+func (a *MemberAwaitility) printUserWaitCriterionDiffs(t *testing.T, actual *userv1.User, criteria ...UserWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find User\n")
@@ -1304,12 +1297,12 @@ func (a *MemberAwaitility) printUserWaitCriterionDiffs(actual *userv1.User, crit
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // WaitForUser waits until there is a User with the given name available
-func (a *MemberAwaitility) WaitForUser(name string, criteria ...UserWaitCriterion) (*userv1.User, error) {
-	a.T.Logf("waiting for User '%s'", name)
+func (a *MemberAwaitility) WaitForUser(t *testing.T, name string, criteria ...UserWaitCriterion) (*userv1.User, error) {
+	t.Logf("waiting for User '%s'", name)
 	user := &userv1.User{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		user = &userv1.User{}
@@ -1328,7 +1321,7 @@ func (a *MemberAwaitility) WaitForUser(name string, criteria ...UserWaitCriterio
 		return false, nil
 	})
 	if err != nil {
-		a.printUserWaitCriterionDiffs(user, criteria...)
+		a.printUserWaitCriterionDiffs(t, user, criteria...)
 	}
 	return user, err
 }
@@ -1374,8 +1367,8 @@ func matchIdentityWaitCriterion(actual *userv1.Identity, criteria ...IdentityWai
 }
 
 // WaitForIdentity waits until there is an Identity with the given name available
-func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWaitCriterion) (*userv1.Identity, error) {
-	a.T.Logf("waiting for Identity '%s'", name)
+func (a *MemberAwaitility) WaitForIdentity(t *testing.T, name string, criteria ...IdentityWaitCriterion) (*userv1.Identity, error) {
+	t.Logf("waiting for Identity '%s'", name)
 	identity := &userv1.Identity{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		identity = &userv1.Identity{}
@@ -1394,16 +1387,16 @@ func (a *MemberAwaitility) WaitForIdentity(name string, criteria ...IdentityWait
 		return false, nil
 	})
 	if err != nil {
-		a.printIdentities(name)
+		a.printIdentities(t, name)
 	}
 	return identity, err
 }
 
-func (a *MemberAwaitility) printIdentities(expectedName string) {
+func (a *MemberAwaitility) printIdentities(t *testing.T, expectedName string) {
 	buf := &strings.Builder{}
 	buf.WriteString(fmt.Sprintf("failed to find Identity '%s'\n", expectedName))
 	buf.WriteString(a.listAndReturnContent("Identity", "", &userv1.IdentityList{}))
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilIdentityHasLabel checks if the Identity has the expected label
@@ -1419,8 +1412,8 @@ func UntilIdentityHasLabel(key, value string) IdentityWaitCriterion {
 }
 
 // WaitUntilUserAccountDeleted waits until the UserAccount with the given name is not found
-func (a *MemberAwaitility) WaitUntilUserAccountDeleted(name string) error {
-	a.T.Logf("waiting until UserAccount '%s' in namespace '%s' is deleted", name, a.Namespace)
+func (a *MemberAwaitility) WaitUntilUserAccountDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until UserAccount '%s' in namespace '%s' is deleted", name, a.Namespace)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		ua := &toolchainv1alpha1.UserAccount{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: name}, ua); err != nil {
@@ -1434,8 +1427,8 @@ func (a *MemberAwaitility) WaitUntilUserAccountDeleted(name string) error {
 }
 
 // WaitUntilUserDeleted waits until the User with the given name is not found
-func (a *MemberAwaitility) WaitUntilUserDeleted(name string) error {
-	a.T.Logf("waiting until User is deleted '%s'", name)
+func (a *MemberAwaitility) WaitUntilUserDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until User is deleted '%s'", name)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		user := &userv1.User{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, user); err != nil {
@@ -1452,8 +1445,8 @@ func (a *MemberAwaitility) WaitUntilUserDeleted(name string) error {
 }
 
 // WaitUntilIdentityDeleted waits until the Identity with the given name is not found
-func (a *MemberAwaitility) WaitUntilIdentityDeleted(name string) error {
-	a.T.Logf("waiting until Identity is deleted '%s'", name)
+func (a *MemberAwaitility) WaitUntilIdentityDeleted(t *testing.T, name string) error {
+	t.Logf("waiting until Identity is deleted '%s'", name)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		identity := &userv1.Identity{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, identity); err != nil {
@@ -1470,17 +1463,17 @@ func (a *MemberAwaitility) WaitUntilIdentityDeleted(name string) error {
 }
 
 // GetConsoleURL retrieves Web Console Route and returns its URL
-func (a *MemberAwaitility) GetConsoleURL() string {
+func (a *MemberAwaitility) GetConsoleURL(t *testing.T) string {
 	route := &routev1.Route{}
 	namespacedName := types.NamespacedName{Namespace: "openshift-console", Name: "console"}
 	err := a.Client.Get(context.TODO(), namespacedName, route)
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 	return fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
 }
 
 // WaitUntilClusterResourceQuotasDeleted waits until all ClusterResourceQuotas with the given owner label are deleted (ie, none is found)
-func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(username string) error {
-	a.T.Logf("waiting for deletion of ClusterResourceQuotas for user '%s'", username)
+func (a *MemberAwaitility) WaitUntilClusterResourceQuotasDeleted(t *testing.T, username string) error {
+	t.Logf("waiting for deletion of ClusterResourceQuotas for user '%s'", username)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		labels := map[string]string{"toolchain.dev.openshift.com/owner": username}
 		opts := client.MatchingLabels(labels)
@@ -1510,7 +1503,7 @@ func matchMemberStatusWaitCriterion(actual *toolchainv1alpha1.MemberStatus, crit
 	return true
 }
 
-func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(actual *toolchainv1alpha1.MemberStatus, criteria ...MemberStatusWaitCriterion) {
+func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.MemberStatus, criteria ...MemberStatusWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
 		buf.WriteString("failed to find MemberStatus\n")
@@ -1531,7 +1524,7 @@ func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(actual *toolchain
 			}
 		}
 	}
-	a.T.Log(buf.String())
+	t.Log(buf.String())
 }
 
 // UntilMemberStatusHasConditions returns a `MemberStatusWaitCriterion` which checks that the given
@@ -1583,9 +1576,9 @@ func UntilMemberStatusHasConsoleURLSet(expectedURL string, expectedCondition too
 }
 
 // WaitForMemberStatus waits until the MemberStatus is available with the provided criteria, if any
-func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCriterion) error {
+func (a *MemberAwaitility) WaitForMemberStatus(t *testing.T, criteria ...MemberStatusWaitCriterion) error {
 	name := "toolchain-member-status"
-	a.T.Logf("waiting for MemberStatus '%s' to match criteria", name)
+	t.Logf("waiting for MemberStatus '%s' to match criteria", name)
 	// there should only be one member status with the name toolchain-member-status
 	var memberStatus *toolchainv1alpha1.MemberStatus
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
@@ -1607,19 +1600,19 @@ func (a *MemberAwaitility) WaitForMemberStatus(criteria ...MemberStatusWaitCrite
 		return matchMemberStatusWaitCriterion(obj, criteria...), nil
 	})
 	if err != nil {
-		a.printMemberStatusWaitCriterionDiffs(memberStatus, criteria...)
+		a.printMemberStatusWaitCriterionDiffs(t, memberStatus, criteria...)
 	}
 	return err
 }
 
 // GetMemberOperatorConfig returns MemberOperatorConfig instance, nil if not found
-func (a *MemberAwaitility) GetMemberOperatorConfig() *toolchainv1alpha1.MemberOperatorConfig {
+func (a *MemberAwaitility) GetMemberOperatorConfig(t *testing.T) *toolchainv1alpha1.MemberOperatorConfig {
 	config := &toolchainv1alpha1.MemberOperatorConfig{}
 	if err := a.Client.Get(context.TODO(), test.NamespacedName(a.Namespace, "config"), config); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		require.NoError(a.T, err)
+		require.NoError(t, err)
 	}
 	return config
 }
@@ -1636,10 +1629,10 @@ func UntilMemberConfigMatches(expectedMemberOperatorConfigSpec toolchainv1alpha1
 }
 
 // WaitForMemberOperatorConfig waits until the MemberOperatorConfig is available with the provided criteria, if any
-func (a *MemberAwaitility) WaitForMemberOperatorConfig(hostAwait *HostAwaitility, criteria ...MemberOperatorConfigWaitCriterion) (*toolchainv1alpha1.MemberOperatorConfig, error) {
+func (a *MemberAwaitility) WaitForMemberOperatorConfig(t *testing.T, hostAwait *HostAwaitility, criteria ...MemberOperatorConfigWaitCriterion) (*toolchainv1alpha1.MemberOperatorConfig, error) {
 	// there should only be one MemberOperatorConfig with the name config
 	name := "config"
-	a.T.Logf("waiting for MemberOperatorConfig '%s'", name)
+	t.Logf("waiting for MemberOperatorConfig '%s'", name)
 	memberOperatorConfig := &toolchainv1alpha1.MemberOperatorConfig{}
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
 		memberOperatorConfig = &toolchainv1alpha1.MemberOperatorConfig{}
@@ -1678,27 +1671,27 @@ func (a *MemberAwaitility) GetMemberOperatorPod() (corev1.Pod, error) {
 	return pods.Items[0], nil
 }
 
-func (a *MemberAwaitility) WaitForMemberWebhooks(image string) {
-	a.waitForUsersPodPriorityClass()
-	a.waitForService()
-	a.waitForWebhookDeployment(image)
-	ca := a.verifySecret()
-	a.verifyUserPodWebhookConfig(ca)
-	a.verifyUsersRolebindingsWebhookConfig(ca)
+func (a *MemberAwaitility) WaitForMemberWebhooks(t *testing.T, image string) {
+	a.waitForUsersPodPriorityClass(t)
+	a.waitForService(t)
+	a.waitForWebhookDeployment(t, image)
+	ca := a.verifySecret(t)
+	a.verifyUserPodWebhookConfig(t, ca)
+	a.verifyUsersRolebindingsWebhookConfig(t, ca)
 }
 
-func (a *MemberAwaitility) waitForUsersPodPriorityClass() {
-	a.T.Logf("checking PrioritiyClass resource '%s'", "sandbox-users-pods")
+func (a *MemberAwaitility) waitForUsersPodPriorityClass(t *testing.T) {
+	t.Logf("checking PrioritiyClass resource '%s'", "sandbox-users-pods")
 	actualPrioClass := &schedulingv1.PriorityClass{}
-	a.waitForResource("", "sandbox-users-pods", actualPrioClass)
+	a.waitForResource(t, "", "sandbox-users-pods", actualPrioClass)
 
-	assert.Equal(a.T, codereadyToolchainProviderLabel, actualPrioClass.Labels)
-	assert.Equal(a.T, int32(-3), actualPrioClass.Value)
-	assert.False(a.T, actualPrioClass.GlobalDefault)
-	assert.Equal(a.T, "Priority class for pods in users' namespaces", actualPrioClass.Description)
+	assert.Equal(t, codereadyToolchainProviderLabel, actualPrioClass.Labels)
+	assert.Equal(t, int32(-3), actualPrioClass.Value)
+	assert.False(t, actualPrioClass.GlobalDefault)
+	assert.Equal(t, "Priority class for pods in users' namespaces", actualPrioClass.Description)
 }
 
-func (a *MemberAwaitility) waitForResource(namespace, name string, object client.Object) {
+func (a *MemberAwaitility) waitForResource(t *testing.T, namespace, name string, object client.Object) {
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		if err := a.Client.Get(context.TODO(), test.NamespacedName(namespace, name), object); err != nil {
 			if errors.IsNotFound(err) {
@@ -1708,213 +1701,213 @@ func (a *MemberAwaitility) waitForResource(namespace, name string, object client
 		}
 		return true, nil
 	})
-	require.NoError(a.T, err)
+	require.NoError(t, err)
 }
 
-func (a *MemberAwaitility) waitForService() {
-	a.T.Logf("waiting for Service '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
+func (a *MemberAwaitility) waitForService(t *testing.T) {
+	t.Logf("waiting for Service '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
 	actualService := &corev1.Service{}
-	a.waitForResource(a.Namespace, "member-operator-webhook", actualService)
-	assert.Equal(a.T, map[string]string{
+	a.waitForResource(t, a.Namespace, "member-operator-webhook", actualService)
+	assert.Equal(t, map[string]string{
 		"app":                                  "member-operator-webhook",
 		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 	}, actualService.Labels)
-	require.Len(a.T, actualService.Spec.Ports, 1)
-	assert.Equal(a.T, int32(443), actualService.Spec.Ports[0].Port)
-	assert.Equal(a.T, intstr.IntOrString{
+	require.Len(t, actualService.Spec.Ports, 1)
+	assert.Equal(t, int32(443), actualService.Spec.Ports[0].Port)
+	assert.Equal(t, intstr.IntOrString{
 		IntVal: 8443,
 	}, actualService.Spec.Ports[0].TargetPort)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualService.Spec.Selector)
+	assert.Equal(t, appMemberOperatorWebhookLabel, actualService.Spec.Selector)
 }
 
-func (a *MemberAwaitility) waitForWebhookDeployment(image string) {
-	a.T.Logf("checking Deployment '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
-	actualDeployment := a.WaitForDeploymentToGetReady("member-operator-webhook", 1,
+func (a *MemberAwaitility) waitForWebhookDeployment(t *testing.T, image string) {
+	t.Logf("checking Deployment '%s' in namespace '%s'", "member-operator-webhook", a.Namespace)
+	actualDeployment := a.WaitForDeploymentToGetReady(t, "member-operator-webhook", 1,
 		DeploymentHasContainerWithImage("mutator", image))
 
-	assert.Equal(a.T, bothWebhookLabels, actualDeployment.Labels)
-	assert.Equal(a.T, int32(1), *actualDeployment.Spec.Replicas)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
+	assert.Equal(t, bothWebhookLabels, actualDeployment.Labels)
+	assert.Equal(t, int32(1), *actualDeployment.Spec.Replicas)
+	assert.Equal(t, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
 
 	template := actualDeployment.Spec.Template
-	assert.Equal(a.T, "member-operator-webhook", template.ObjectMeta.Name)
-	assert.Equal(a.T, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
-	require.Len(a.T, template.Spec.Volumes, 1)
-	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Name)
-	assert.Equal(a.T, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
-	require.Len(a.T, template.Spec.Containers, 1)
+	assert.Equal(t, "member-operator-webhook", template.ObjectMeta.Name)
+	assert.Equal(t, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
+	require.Len(t, template.Spec.Volumes, 1)
+	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Name)
+	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
+	require.Len(t, template.Spec.Containers, 1)
 
 	container := template.Spec.Containers[0]
-	assert.Equal(a.T, "mutator", container.Name)
-	assert.NotEmpty(a.T, container.Image)
-	assert.Equal(a.T, []string{"member-operator-webhook"}, container.Command)
-	assert.Equal(a.T, corev1.PullIfNotPresent, container.ImagePullPolicy)
-	assert.NotEmpty(a.T, container.Resources)
+	assert.Equal(t, "mutator", container.Name)
+	assert.NotEmpty(t, container.Image)
+	assert.Equal(t, []string{"member-operator-webhook"}, container.Command)
+	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.NotEmpty(t, container.Resources)
 
-	assert.Len(a.T, container.VolumeMounts, 1)
-	assert.Equal(a.T, "webhook-certs", container.VolumeMounts[0].Name)
-	assert.Equal(a.T, "/etc/webhook/certs", container.VolumeMounts[0].MountPath)
-	assert.True(a.T, container.VolumeMounts[0].ReadOnly)
+	assert.Len(t, container.VolumeMounts, 1)
+	assert.Equal(t, "webhook-certs", container.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/webhook/certs", container.VolumeMounts[0].MountPath)
+	assert.True(t, container.VolumeMounts[0].ReadOnly)
 
-	a.WaitForDeploymentToGetReady("member-operator-webhook", 1)
+	a.WaitForDeploymentToGetReady(t, "member-operator-webhook", 1)
 }
 
-func (a *MemberAwaitility) verifySecret() []byte {
-	a.T.Logf("checking Secret '%s' in namespace '%s'", "webhook-certs", a.Namespace)
+func (a *MemberAwaitility) verifySecret(t *testing.T) []byte {
+	t.Logf("checking Secret '%s' in namespace '%s'", "webhook-certs", a.Namespace)
 	secret := &corev1.Secret{}
-	a.waitForResource(a.Namespace, "webhook-certs", secret)
-	assert.NotEmpty(a.T, secret.Data["server-key.pem"])
-	assert.NotEmpty(a.T, secret.Data["server-cert.pem"])
+	a.waitForResource(t, a.Namespace, "webhook-certs", secret)
+	assert.NotEmpty(t, secret.Data["server-key.pem"])
+	assert.NotEmpty(t, secret.Data["server-cert.pem"])
 	ca := secret.Data["ca-cert.pem"]
-	assert.NotEmpty(a.T, ca)
+	assert.NotEmpty(t, ca)
 	return ca
 }
 
-func (a *MemberAwaitility) verifyUserPodWebhookConfig(ca []byte) {
-	a.T.Logf("checking MutatingWebhookConfiguration '%s'", "sandbox-users-pods")
+func (a *MemberAwaitility) verifyUserPodWebhookConfig(t *testing.T, ca []byte) {
+	t.Logf("checking MutatingWebhookConfiguration '%s'", "sandbox-users-pods")
 	actualMutWbhConf := &admv1.MutatingWebhookConfiguration{}
-	a.waitForResource("", "member-operator-webhook", actualMutWbhConf)
-	assert.Equal(a.T, bothWebhookLabels, actualMutWbhConf.Labels)
-	require.Len(a.T, actualMutWbhConf.Webhooks, 1)
+	a.waitForResource(t, "", "member-operator-webhook", actualMutWbhConf)
+	assert.Equal(t, bothWebhookLabels, actualMutWbhConf.Labels)
+	require.Len(t, actualMutWbhConf.Webhooks, 1)
 
 	webhook := actualMutWbhConf.Webhooks[0]
-	assert.Equal(a.T, "users.pods.webhook.sandbox", webhook.Name)
-	assert.Equal(a.T, []string{"v1"}, webhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *webhook.SideEffects)
-	assert.Equal(a.T, int32(5), *webhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
-	assert.Equal(a.T, admv1.Ignore, *webhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *webhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, webhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, webhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", webhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, webhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/mutate-users-pods", *webhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *webhook.ClientConfig.Service.Port)
-	require.Len(a.T, webhook.Rules, 1)
+	assert.Equal(t, "users.pods.webhook.sandbox", webhook.Name)
+	assert.Equal(t, []string{"v1"}, webhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *webhook.SideEffects)
+	assert.Equal(t, int32(5), *webhook.TimeoutSeconds)
+	assert.Equal(t, admv1.NeverReinvocationPolicy, *webhook.ReinvocationPolicy)
+	assert.Equal(t, admv1.Ignore, *webhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *webhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, webhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, webhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", webhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, webhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/mutate-users-pods", *webhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *webhook.ClientConfig.Service.Port)
+	require.Len(t, webhook.Rules, 1)
 
 	rule := webhook.Rules[0]
-	//assert.Equal(a.T, []admv1.OperationType{admv1.Create}, rule.Operations)
-	assert.Equal(a.T, []string{""}, rule.APIGroups)
-	assert.Equal(a.T, []string{"v1"}, rule.APIVersions)
-	assert.Equal(a.T, []string{"pods"}, rule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *rule.Scope)
+	//assert.Equal(t, []admv1.OperationType{admv1.Create}, rule.Operations)
+	assert.Equal(t, []string{""}, rule.APIGroups)
+	assert.Equal(t, []string{"v1"}, rule.APIVersions)
+	assert.Equal(t, []string{"pods"}, rule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *rule.Scope)
 }
 
-func (a *MemberAwaitility) verifyUsersRolebindingsWebhookConfig(ca []byte) {
-	a.T.Logf("checking ValidatingWebhookConfiguration '%s'", "member-operator-validating-webhook")
+func (a *MemberAwaitility) verifyUsersRolebindingsWebhookConfig(t *testing.T, ca []byte) {
+	t.Logf("checking ValidatingWebhookConfiguration '%s'", "member-operator-validating-webhook")
 	actualValWbhConf := &admv1.ValidatingWebhookConfiguration{}
-	a.waitForResource("", "member-operator-validating-webhook", actualValWbhConf)
-	assert.Equal(a.T, bothWebhookLabels, actualValWbhConf.Labels)
-	// require.Len(a.T, actualValWbhConf.Webhooks, 2)
+	a.waitForResource(t, "", "member-operator-validating-webhook", actualValWbhConf)
+	assert.Equal(t, bothWebhookLabels, actualValWbhConf.Labels)
+	// require.Len(t, actualValWbhConf.Webhooks, 2)
 
 	rolebindingWebhook := actualValWbhConf.Webhooks[0]
-	assert.Equal(a.T, "users.rolebindings.webhook.sandbox", rolebindingWebhook.Name)
-	assert.Equal(a.T, []string{"v1"}, rolebindingWebhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *rolebindingWebhook.SideEffects)
-	assert.Equal(a.T, int32(5), *rolebindingWebhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.Ignore, *rolebindingWebhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *rolebindingWebhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, rolebindingWebhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, rolebindingWebhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", rolebindingWebhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, rolebindingWebhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/validate-users-rolebindings", *rolebindingWebhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *rolebindingWebhook.ClientConfig.Service.Port)
-	require.Len(a.T, rolebindingWebhook.Rules, 1)
+	assert.Equal(t, "users.rolebindings.webhook.sandbox", rolebindingWebhook.Name)
+	assert.Equal(t, []string{"v1"}, rolebindingWebhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *rolebindingWebhook.SideEffects)
+	assert.Equal(t, int32(5), *rolebindingWebhook.TimeoutSeconds)
+	assert.Equal(t, admv1.Ignore, *rolebindingWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *rolebindingWebhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, rolebindingWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, rolebindingWebhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", rolebindingWebhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, rolebindingWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/validate-users-rolebindings", *rolebindingWebhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *rolebindingWebhook.ClientConfig.Service.Port)
+	require.Len(t, rolebindingWebhook.Rules, 1)
 
 	rolebindingRule := rolebindingWebhook.Rules[0]
-	assert.Equal(a.T, []admv1.OperationType{admv1.Create, admv1.Update}, rolebindingRule.Operations)
-	assert.Equal(a.T, []string{"rbac.authorization.k8s.io", "authorization.openshift.io"}, rolebindingRule.APIGroups)
-	assert.Equal(a.T, []string{"v1"}, rolebindingRule.APIVersions)
-	assert.Equal(a.T, []string{"rolebindings"}, rolebindingRule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *rolebindingRule.Scope)
+	assert.Equal(t, []admv1.OperationType{admv1.Create, admv1.Update}, rolebindingRule.Operations)
+	assert.Equal(t, []string{"rbac.authorization.k8s.io", "authorization.openshift.io"}, rolebindingRule.APIGroups)
+	assert.Equal(t, []string{"v1"}, rolebindingRule.APIVersions)
+	assert.Equal(t, []string{"rolebindings"}, rolebindingRule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *rolebindingRule.Scope)
 
 	checlusterWebhook := actualValWbhConf.Webhooks[1]
-	assert.Equal(a.T, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
-	assert.Equal(a.T, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
-	assert.Equal(a.T, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
-	assert.Equal(a.T, int32(5), *checlusterWebhook.TimeoutSeconds)
-	assert.Equal(a.T, admv1.Ignore, *checlusterWebhook.FailurePolicy)
-	assert.Equal(a.T, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
-	assert.Equal(a.T, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
-	assert.Equal(a.T, ca, checlusterWebhook.ClientConfig.CABundle)
-	assert.Equal(a.T, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
-	assert.Equal(a.T, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
-	assert.Equal(a.T, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
-	assert.Equal(a.T, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
-	require.Len(a.T, checlusterWebhook.Rules, 1)
+	assert.Equal(t, "users.checlusters.webhook.sandbox", checlusterWebhook.Name)
+	assert.Equal(t, []string{"v1"}, checlusterWebhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *checlusterWebhook.SideEffects)
+	assert.Equal(t, int32(5), *checlusterWebhook.TimeoutSeconds)
+	assert.Equal(t, admv1.Ignore, *checlusterWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *checlusterWebhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, checlusterWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, checlusterWebhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", checlusterWebhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, checlusterWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/validate-users-checlusters", *checlusterWebhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *checlusterWebhook.ClientConfig.Service.Port)
+	require.Len(t, checlusterWebhook.Rules, 1)
 
 	checlusterRule := checlusterWebhook.Rules[0]
-	assert.Equal(a.T, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
-	assert.Equal(a.T, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
-	assert.Equal(a.T, []string{"v2"}, checlusterRule.APIVersions)
-	assert.Equal(a.T, []string{"checlusters"}, checlusterRule.Resources)
-	assert.Equal(a.T, admv1.NamespacedScope, *checlusterRule.Scope)
+	assert.Equal(t, []admv1.OperationType{admv1.Create}, checlusterRule.Operations)
+	assert.Equal(t, []string{"org.eclipse.che"}, checlusterRule.APIGroups)
+	assert.Equal(t, []string{"v2"}, checlusterRule.APIVersions)
+	assert.Equal(t, []string{"checlusters"}, checlusterRule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *checlusterRule.Scope)
 
 }
 
-func (a *MemberAwaitility) WaitForAutoscalingBufferApp() {
-	a.verifyAutoscalingBufferPriorityClass()
-	a.verifyAutoscalingBufferDeployment()
+func (a *MemberAwaitility) WaitForAutoscalingBufferApp(t *testing.T) {
+	a.verifyAutoscalingBufferPriorityClass(t)
+	a.verifyAutoscalingBufferDeployment(t)
 }
 
-func (a *MemberAwaitility) verifyAutoscalingBufferPriorityClass() {
-	a.T.Logf("checking PrioritiyClass '%s'", "member-operator-autoscaling-buffer")
+func (a *MemberAwaitility) verifyAutoscalingBufferPriorityClass(t *testing.T) {
+	t.Logf("checking PrioritiyClass '%s'", "member-operator-autoscaling-buffer")
 	actualPrioClass := &schedulingv1.PriorityClass{}
-	a.waitForResource("", "member-operator-autoscaling-buffer", actualPrioClass)
+	a.waitForResource(t, "", "member-operator-autoscaling-buffer", actualPrioClass)
 
-	assert.Equal(a.T, codereadyToolchainProviderLabel, actualPrioClass.Labels)
-	assert.Equal(a.T, int32(-5), actualPrioClass.Value)
-	assert.False(a.T, actualPrioClass.GlobalDefault)
-	assert.Equal(a.T, "This priority class is to be used by the autoscaling buffer pod only", actualPrioClass.Description)
+	assert.Equal(t, codereadyToolchainProviderLabel, actualPrioClass.Labels)
+	assert.Equal(t, int32(-5), actualPrioClass.Value)
+	assert.False(t, actualPrioClass.GlobalDefault)
+	assert.Equal(t, "This priority class is to be used by the autoscaling buffer pod only", actualPrioClass.Description)
 }
 
-func (a *MemberAwaitility) verifyAutoscalingBufferDeployment() {
-	a.T.Logf("checking Deployment '%s' in namespace '%s'", "autoscaling-buffer", a.Namespace)
+func (a *MemberAwaitility) verifyAutoscalingBufferDeployment(t *testing.T) {
+	t.Logf("checking Deployment '%s' in namespace '%s'", "autoscaling-buffer", a.Namespace)
 	actualDeployment := &appsv1.Deployment{}
-	a.waitForResource(a.Namespace, "autoscaling-buffer", actualDeployment)
+	a.waitForResource(t, a.Namespace, "autoscaling-buffer", actualDeployment)
 
-	assert.Equal(a.T, map[string]string{
+	assert.Equal(t, map[string]string{
 		"app":                                  "autoscaling-buffer",
 		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
 	}, actualDeployment.Labels)
-	assert.Equal(a.T, int32(2), *actualDeployment.Spec.Replicas)
-	assert.Equal(a.T, map[string]string{"app": "autoscaling-buffer"}, actualDeployment.Spec.Selector.MatchLabels)
+	assert.Equal(t, int32(2), *actualDeployment.Spec.Replicas)
+	assert.Equal(t, map[string]string{"app": "autoscaling-buffer"}, actualDeployment.Spec.Selector.MatchLabels)
 
 	template := actualDeployment.Spec.Template
-	assert.Equal(a.T, map[string]string{"app": "autoscaling-buffer"}, template.ObjectMeta.Labels)
+	assert.Equal(t, map[string]string{"app": "autoscaling-buffer"}, template.ObjectMeta.Labels)
 
-	assert.Equal(a.T, "member-operator-autoscaling-buffer", template.Spec.PriorityClassName)
-	assert.Equal(a.T, int64(0), *template.Spec.TerminationGracePeriodSeconds)
+	assert.Equal(t, "member-operator-autoscaling-buffer", template.Spec.PriorityClassName)
+	assert.Equal(t, int64(0), *template.Spec.TerminationGracePeriodSeconds)
 
-	require.Len(a.T, template.Spec.Containers, 1)
+	require.Len(t, template.Spec.Containers, 1)
 	container := template.Spec.Containers[0]
-	assert.Equal(a.T, "autoscaling-buffer", container.Name)
-	assert.Equal(a.T, "gcr.io/google_containers/pause-amd64:3.2", container.Image)
-	assert.Equal(a.T, corev1.PullIfNotPresent, container.ImagePullPolicy)
+	assert.Equal(t, "autoscaling-buffer", container.Name)
+	assert.Equal(t, "gcr.io/google_containers/pause-amd64:3.2", container.Image)
+	assert.Equal(t, corev1.PullIfNotPresent, container.ImagePullPolicy)
 
 	expectedMemory, err := resource.ParseQuantity("50Mi")
-	require.NoError(a.T, err)
-	assert.True(a.T, container.Resources.Requests.Memory().Equal(expectedMemory))
-	assert.True(a.T, container.Resources.Limits.Memory().Equal(expectedMemory))
+	require.NoError(t, err)
+	assert.True(t, container.Resources.Requests.Memory().Equal(expectedMemory))
+	assert.True(t, container.Resources.Limits.Memory().Equal(expectedMemory))
 
-	a.WaitForDeploymentToGetReady("autoscaling-buffer", 2)
+	a.WaitForDeploymentToGetReady(t, "autoscaling-buffer", 2)
 }
 
 // WaitForExpectedNumberOfResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfResources(namespace, kind string, expected int, list func() (int, error)) error {
+func (a *MemberAwaitility) WaitForExpectedNumberOfResources(t *testing.T, namespace, kind string, expected int, list func() (int, error)) error {
 	if actual, err := a.waitForExpectedNumberOfResources(expected, list); err != nil {
-		a.T.Logf("expected number of resources of kind '%s' in namespace '%s' to be %d but it was %d", kind, namespace, expected, actual)
+		t.Logf("expected number of resources of kind '%s' in namespace '%s' to be %d but it was %d", kind, namespace, expected, actual)
 		return err
 	}
 	return nil
 }
 
 // WaitForExpectedNumberOfClusterResources waits until the number of resources matches the expected count
-func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(kind string, expected int, list func() (int, error)) error {
+func (a *MemberAwaitility) WaitForExpectedNumberOfClusterResources(t *testing.T, kind string, expected int, list func() (int, error)) error {
 	if actual, err := a.waitForExpectedNumberOfResources(expected, list); err != nil {
-		a.T.Logf("expected number of resources of kind '%s' to be %d but it was %d", kind, expected, actual)
+		t.Logf("expected number of resources of kind '%s' to be %d but it was %d", kind, expected, actual)
 		return err
 	}
 	return nil
@@ -1933,7 +1926,7 @@ func (a *MemberAwaitility) waitForExpectedNumberOfResources(expected int, list f
 	return actual, err
 }
 
-func (a *MemberAwaitility) UpdatePod(namespace, podName string, modifyPod func(pod *corev1.Pod)) (*corev1.Pod, error) {
+func (a *MemberAwaitility) UpdatePod(t *testing.T, namespace, podName string, modifyPod func(pod *corev1.Pod)) (*corev1.Pod, error) {
 	var m *corev1.Pod
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		freshPod := &corev1.Pod{}
@@ -1943,7 +1936,7 @@ func (a *MemberAwaitility) UpdatePod(namespace, podName string, modifyPod func(p
 
 		modifyPod(freshPod)
 		if err := a.Client.Update(context.TODO(), freshPod); err != nil {
-			a.T.Logf("error updating Pod '%s' Will retry again...", podName)
+			t.Logf("error updating Pod '%s' Will retry again...", podName)
 			return false, nil // nolint:nilerr
 		}
 		m = freshPod
@@ -1952,7 +1945,7 @@ func (a *MemberAwaitility) UpdatePod(namespace, podName string, modifyPod func(p
 	return m, err
 }
 
-func (a *MemberAwaitility) UpdateConfigMap(namespace, cmName string, modifyCM func(*corev1.ConfigMap)) (*corev1.ConfigMap, error) {
+func (a *MemberAwaitility) UpdateConfigMap(t *testing.T, namespace, cmName string, modifyCM func(*corev1.ConfigMap)) (*corev1.ConfigMap, error) {
 	var cm *corev1.ConfigMap
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		obj := &corev1.ConfigMap{}
@@ -1964,7 +1957,7 @@ func (a *MemberAwaitility) UpdateConfigMap(namespace, cmName string, modifyCM fu
 		}
 		modifyCM(obj)
 		if err := a.Client.Update(context.TODO(), obj); err != nil {
-			a.T.Logf("error updating ConfigMap '%s' Will retry again...", cmName)
+			t.Logf("error updating ConfigMap '%s' Will retry again...", cmName)
 			return false, nil // nolint:nilerr
 		}
 		cm = obj


### PR DESCRIPTION
Pass `t` explicitely in all calls.

Consequently, when running tests (with an intended failure), the output will be:

```
=== RUN   
TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready
    member.go:1592: waiting for MemberStatus 'toolchain-member-status' to match criteria
    member.go:1538: failed to find MemberStatus with matching criteria:
...

--- FAIL: TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready (241.23s)
```

instead of:

```
=== CONT  TestE2EFlow
    member.go:1588: waiting for MemberStatus 'toolchain-member-status' to match criteria
    member.go:1534: failed to find MemberStatus with matching criteria
...

--- FAIL: TestE2EFlow/verify_MemberOperatorConfigs_synced_from_ToolchainConfig_to_member_clusters/verify_updated_toolchainconfig_is_synced_-_go_to_unready/verify_member_and_toolchain_status_go_back_to_ready
```

ie, `=== CONT` now becomes `=== RUN` with the actual test name in logs, which is more explicit (IMO)


Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
