### PR TITLE
Fix test automatic cluster assignment

### DIFF
--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -61,23 +61,12 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 
 		t.Run("increment the max number of spaces and expect that first space will be provisioned.", func(t *testing.T) {
 			// when
-			toolchainStatus, err := hostAwait.WaitForToolchainStatus(
-				wait.UntilToolchainStatusUpdatedAfter(time.Now()))
-			require.NoError(t, err)
-			spaceLimitsM1, spaceLimitsM2 := 0, 0
-			for _, m := range toolchainStatus.Status.Members {
-				if memberAwait1.ClusterName == m.ClusterName {
-					spaceLimitsM1 = m.SpaceCount
-				} else if memberAwait2.ClusterName == m.ClusterName {
-					spaceLimitsM2 = m.SpaceCount
-				}
-			}
 			hostAwait.UpdateToolchainConfig(
 				testconfig.CapacityThresholds().
 					MaxNumberOfSpaces(
 						// increment max spaces only on member1
-						testconfig.PerMemberCluster(memberAwait1.ClusterName, spaceLimitsM1+1),
-						testconfig.PerMemberCluster(memberAwait2.ClusterName, spaceLimitsM2),
+						testconfig.PerMemberCluster(memberAwait1.ClusterName, 2),
+						testconfig.PerMemberCluster(memberAwait2.ClusterName, 1),
 					),
 			)
 

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -43,8 +43,8 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(
-					testconfig.PerMemberCluster(memberAwait1.ClusterName, 1),
-					testconfig.PerMemberCluster(memberAwait2.ClusterName, 1),
+					testconfig.PerMemberCluster(memberAwait1.ClusterName, -1),
+					testconfig.PerMemberCluster(memberAwait2.ClusterName, -1),
 				),
 		)
 
@@ -66,7 +66,7 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 					MaxNumberOfSpaces(
 						// increment max spaces only on member1
 						testconfig.PerMemberCluster(memberAwait1.ClusterName, 2),
-						testconfig.PerMemberCluster(memberAwait2.ClusterName, 1),
+						testconfig.PerMemberCluster(memberAwait2.ClusterName, -1),
 					),
 			)
 

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -38,30 +38,6 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 		Execute()
 	hostAwait.UpdateToolchainConfig(testconfig.Tiers().DefaultSpaceTier("appstudio"))
 
-	t.Run("set low capacity threshold and expect that space will have default tier, but won't have target cluster so it won't be provisioned", func(t *testing.T) {
-		// given
-		hostAwait.UpdateToolchainConfig(
-			testconfig.CapacityThresholds().ResourceCapacityThreshold(1),
-		)
-		// some short time to get the cache populated with the change
-		time.Sleep(1 * time.Second)
-
-		// when
-		space, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithTierName(""))
-
-		// then
-		space = waitUntilSpaceIsPendingCluster(t, hostAwait, space.Name)
-		assert.Equal(t, "appstudio", space.Spec.TierName)
-
-		t.Run("reset the threshold and expect the space will be have the targetCluster set and will be also provisioned", func(t *testing.T) {
-			// when
-			hostAwait.UpdateToolchainConfig(testconfig.CapacityThresholds().ResourceCapacityThreshold(80))
-
-			// then
-			VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
-		})
-	})
-
 	t.Run("set low max number of spaces and expect that space won't be provisioned but added on waiting list", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(
@@ -122,6 +98,30 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 				// then
 				VerifyResourcesProvisionedForSpace(t, awaitilities, space2.Name)
 			})
+		})
+	})
+
+	t.Run("set low capacity threshold and expect that space will have default tier, but won't have target cluster so it won't be provisioned", func(t *testing.T) {
+		// given
+		hostAwait.UpdateToolchainConfig(
+			testconfig.CapacityThresholds().ResourceCapacityThreshold(1),
+		)
+		// some short time to get the cache populated with the change
+		time.Sleep(1 * time.Second)
+
+		// when
+		space, _ := CreateSpaceWithBinding(t, awaitilities, mur, WithTierName(""))
+
+		// then
+		space = waitUntilSpaceIsPendingCluster(t, hostAwait, space.Name)
+		assert.Equal(t, "appstudio", space.Spec.TierName)
+
+		t.Run("reset the threshold and expect the space will be have the targetCluster set and will be also provisioned", func(t *testing.T) {
+			// when
+			hostAwait.UpdateToolchainConfig(testconfig.CapacityThresholds().ResourceCapacityThreshold(80))
+
+			// then
+			VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
 		})
 	})
 


### PR DESCRIPTION
This PR fixes failure:
```
--- FAIL: TestAutomaticClusterAssignment (278.00s)
    --- FAIL: TestAutomaticClusterAssignment/set_low_max_number_of_spaces_and_expect_that_space_won't_be_provisioned_but_added_on_waiting_list (248.01s)
        --- FAIL: TestAutomaticClusterAssignment/set_low_max_number_of_spaces_and_expect_that_space_won't_be_provisioned_but_added_on_waiting_list/increment_the_max_number_of_spaces_and_expect_that_first_space_will_be_provisioned. (246.06s)
FAIL
FAIL	github.com/codeready-toolchain/toolchain-e2e/test/e2e	1087.098s
```
link to failed build:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/636/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1604807795008344064

- invert set low capacity threshold with set low max number of spaces as per [user signup manual approval](https://github.com/codeready-toolchain/toolchain-e2e/pull/637)

- also set fixed number of spaces instead of _dynamic ones_, since sometimes the toolchainstatus may not be up to date.