### PR TITLE
small fix on creating the toolchainCluster with expected type label

### DIFF
--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -34,7 +34,7 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 	t.Run("create new ToolchainCluster with correct data and expect to be ready for cluster type "+string(await.Type), func(t *testing.T) {
 		// given
-		name := "new-ready-" + string(await.Type)
+		name := "new-ready-" + string(otherAwait.Type)
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			clusterType(otherAwait.Type),
 			apiEndpoint(current.Spec.APIEndpoint),

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -36,7 +36,7 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		// given
 		name := "new-ready-" + string(await.Type)
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
-			clusterType(await.Type),
+			clusterType(otherAwait.Type),
 			apiEndpoint(current.Spec.APIEndpoint),
 			caBundle(current.Spec.CABundle),
 			secretRef(current.Spec.SecretRef.Name),

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -66,9 +66,9 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 	t.Run("create new ToolchainCluster with incorrect data and expect to be offline for cluster type "+string(await.Type), func(t *testing.T) {
 		// given
-		name := "new-offline-" + string(await.Type)
+		name := "new-offline-" + string(otherAwait.Type)
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
-			clusterType(await.Type),
+			clusterType(otherAwait.Type),
 			apiEndpoint("https://1.2.3.4:8443"),
 			caBundle(current.Spec.CABundle),
 			secretRef(current.Spec.SecretRef.Name),


### PR DESCRIPTION
create `toolchainCluster` resource in `await.Namespace` with `otherAwait.Type` .

In the scenario where `await.Namespace` is `toolchain-host-ns`, the type label for the `toolchainCluster` resource should be `otherAwait.Type` (so `member` in this case)