### PR TITLE
fix: resource name should be in plural form

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1182,7 +1182,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				},
 				{
 					APIGroups: []string{"appstudio.redhat.com"},
-					Resources: []string{"spiaccesstokenbindings", "spiaccesschecks", "spiaccesstokens", "spifilecontentrequest"},
+					Resources: []string{"spiaccesstokenbindings", "spiaccesschecks", "spiaccesstokens", "spifilecontentrequests"},
 					Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 				},
 				{


### PR DESCRIPTION
test for https://github.com/codeready-toolchain/host-operator/pull/731