### PR TITLE
update proxy test to verify NotEmpty fields in Workspace objects

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -744,6 +744,7 @@ func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha
 			return
 		}
 	}
+
 	t.Errorf("expected workspace %s not found", expectedWorkspace.Name)
 }
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -744,7 +744,6 @@ func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha
 			return
 		}
 	}
-
 	t.Errorf("expected workspace %s not found", expectedWorkspace.Name)
 }
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -736,7 +736,7 @@ func setStoneSoupConfig(t *testing.T, hostAwait *wait.HostAwaitility, memberAwai
 func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha1.Workspace, actualWorkspaces ...toolchainv1alpha1.Workspace) {
 	for _, actualWorkspace := range actualWorkspaces {
 		if actualWorkspace.Name == expectedWorkspace.Name {
-			assert.NotEmpty(t, actualWorkspace.Status, "Workspace.Status field is empty", actualWorkspace, expectedWorkspace)
+			assert.Equal(t, expectedWorkspace.Status, actualWorkspace.Status)
 			assert.NotEmpty(t, actualWorkspace.ObjectMeta.ResourceVersion, "Workspace.ObjectMeta.ResourceVersion field is empty: %#v", actualWorkspace)
 			assert.NotEmpty(t, actualWorkspace.ObjectMeta.Generation, "Workspace.ObjectMeta.Generation field is empty: %#v", actualWorkspace)
 			assert.NotEmpty(t, actualWorkspace.ObjectMeta.CreationTimestamp, "Workspace.ObjectMeta.CreationTimestamp field is empty: %#v", actualWorkspace)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -736,11 +736,11 @@ func setStoneSoupConfig(t *testing.T, hostAwait *wait.HostAwaitility, memberAwai
 func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha1.Workspace, actualWorkspaces ...toolchainv1alpha1.Workspace) {
 	for _, actualWorkspace := range actualWorkspaces {
 		if actualWorkspace.Name == expectedWorkspace.Name {
-			assert.Equal(t, expectedWorkspace.Status, actualWorkspace.Status)
-			assert.Equal(t, expectedWorkspace.ObjectMeta.ResourceVersion, actualWorkspace.ObjectMeta.ResourceVersion)
-			assert.Equal(t, expectedWorkspace.ObjectMeta.Generation, actualWorkspace.ObjectMeta.Generation)
-			assert.Equal(t, expectedWorkspace.ObjectMeta.CreationTimestamp, actualWorkspace.ObjectMeta.CreationTimestamp)
-			assert.Equal(t, expectedWorkspace.ObjectMeta.UID, actualWorkspace.ObjectMeta.UID)
+			assert.NotEmpty(t, actualWorkspace.Status, "Workspace.Status field is empty", actualWorkspace, expectedWorkspace)
+			assert.NotEmpty(t, actualWorkspace.ObjectMeta.ResourceVersion, "Workspace.ObjectMeta.ResourceVersion field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.ObjectMeta.Generation, "Workspace.ObjectMeta.Generation field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.ObjectMeta.CreationTimestamp, "Workspace.ObjectMeta.CreationTimestamp field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.ObjectMeta.UID, "Workspace.ObjectMeta.UID field is empty: %#v", actualWorkspace)
 			return
 		}
 	}


### PR DESCRIPTION
Some e2e jobs where failing while checking the match between `Workspace.ObjectMeta` fields and `Space.ObjectMeta` fields:

```
  host.go:1640: waiting for Space 'bus' with matching criteria
=== RUN   TestSpaceLister/bicycle_gets_workspaces/can_get_car_workspace
    host.go:1640: waiting for Space 'car' with matching criteria
    proxy_test.go:740: 
        	Error Trace:	/tmp/toolchain-e2e/test/e2e/proxy_test.go:740
        	            				/tmp/toolchain-e2e/test/e2e/proxy_test.go:471
        	Error:      	Not equal: 
        	            	expected: "75067"
        	            	actual  : "74984"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-75067
        	            	+74984
        	Test:       	TestSpaceLister/bicycle_gets_workspaces/can_get_car_workspace
```

Jira task: https://issues.redhat.com/browse/ASC-296