### PR TITLE
Allow only read access to GitOpsDeployments

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1171,7 +1171,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
 					Resources: []string{"gitopsdeployments"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
 					APIGroups: []string{"appstudio.redhat.com"},


### PR DESCRIPTION
This PR removes write access to GitOpsDeployment from users of Stonesoup, as the ability to create/modify a GitOpsDeployment would allow the user to bypass per-user security boundaries.

Corresponding host operator PR: https://github.com/codeready-toolchain/host-operator/pull/749

JIRA: [GITOPSRVCE-427](https://issues.redhat.com/browse/GITOPSRVCE-427)
