### PR TITLE
PLNSRVCE-1166: add proxy plugin e2e test accessing the console route

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -271,6 +271,7 @@ func TestProxyFlow(t *testing.T) {
 				var resp *http.Response
 				resp, err = client.Do(request)
 				require.NoError(t, err)
+				defer resp.Body.Close()
 				var body []byte
 				body, err = io.ReadAll(resp.Body)
 				require.NoError(t, err)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -275,8 +275,12 @@ func TestProxyFlow(t *testing.T) {
 				var body []byte
 				body, err = io.ReadAll(resp.Body)
 				require.NoError(t, err)
+				bodyStr := string(body)
 				if resp.StatusCode != http.StatusOK {
-					t.Errorf("unexpected http return code of %d with body text %s", resp.StatusCode, string(body))
+					t.Errorf("unexpected http return code of %d with body text %s", resp.StatusCode, bodyStr)
+				}
+				if !strings.Contains(bodyStr, "Red") || !strings.Contains(bodyStr, "Open") {
+					t.Errorf("unexpected http response body %s", bodyStr)
 				}
 			}) // end of successful workspace context request with proxy plugin
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -267,7 +267,7 @@ func TestProxyFlow(t *testing.T) {
 				request, err := http.NewRequest("GET", proxyPluginWorkspaceURL, nil)
 				require.NoError(t, err)
 
-				request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", user.token))
+				request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.token))
 				var resp *http.Response
 				resp, err = client.Do(request)
 				require.NoError(t, err)

--- a/testsupport/proxyplugin.go
+++ b/testsupport/proxyplugin.go
@@ -1,0 +1,37 @@
+package testsupport
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func VerifyProxyPlugin(t *testing.T, hostAwait *wait.HostAwaitility, proxyPluginName string) *toolchainv1alpha1.ProxyPlugin {
+	proxyPlugin, err := hostAwait.WaitForProxyPlugin(t, proxyPluginName)
+	require.NoError(t, err)
+	return proxyPlugin
+}
+
+func CreateProxyPluginWithCleanup(t *testing.T, hostAwait *wait.HostAwaitility, proxyPluginName, routeNamespace, routeName string) *toolchainv1alpha1.ProxyPlugin {
+	proxyPlugin := NewProxyPlugin(hostAwait.Namespace, proxyPluginName, routeNamespace, routeName)
+	err := hostAwait.CreateWithCleanup(t, proxyPlugin)
+	require.NoError(t, err)
+	return proxyPlugin
+}
+
+func NewProxyPlugin(proxyPluginNamespace, proxyPluginName, routeNamespace, routeName string) *toolchainv1alpha1.ProxyPlugin {
+	return &toolchainv1alpha1.ProxyPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: proxyPluginNamespace,
+			Name:      proxyPluginName,
+		},
+		Spec: toolchainv1alpha1.ProxyPluginSpec{
+			OpenShiftRouteTargetEndpoint: &toolchainv1alpha1.OpenShiftRouteTarget{
+				Namespace: routeNamespace,
+				Name:      routeName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
paired with https://github.com/codeready-toolchain/registration-service/pull/311