### PR TITLE
Allow create access for SelfSubjectAccessReview

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1241,7 +1241,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				},
 				{
 					APIGroups: []string{"authorization.k8s.io"},
-					Resources: []string{"selfsubjectaccessreview"},
+					Resources: []string{"selfsubjectaccessreviews"},
 					Verbs:     []string{"create"},
 				},
 			},

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1165,7 +1165,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		role, err := memberAwait.WaitForRole(t, ns, "appstudio-user-actions")
 		require.NoError(t, err)
-		assert.Len(t, role.Rules, 14)
+		assert.Len(t, role.Rules, 15)
 		expected := &rbacv1.Role{
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -1238,6 +1238,11 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 					Resources:     []string{"serviceaccounts"},
 					ResourceNames: []string{"pipeline"},
 					Verbs:         []string{"get", "list", "watch", "update", "patch"},
+				},
+				{
+					APIGroups: []string{"authorization.k8s.io"},
+					Resources: []string{"selfsubjectaccessreview"},
+					Verbs:     []string{"create"},
 				},
 			},
 		}


### PR DESCRIPTION
Add create permission for `SelfSubjectAccessReview` to allow for RBAC checks in UI.

Host operator PR: https://github.com/codeready-toolchain/host-operator/pull/766