### PR TITLE
Add test for read access to additional Core GitOps APIs

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1283,7 +1283,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
 					Resources: []string{"gitopsdeployments", "gitopsdeploymentmanagedenvironments", "gitopsdeploymentrepositorycredentials", "gitopsdeploymentsyncruns"},
-					Verbs:     []string{"get", "list", "watch"},
+					Verbs:     []string{"*"},
 				},
 				{
 					APIGroups: []string{"tekton.dev"},

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1282,7 +1282,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				},
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
-					Resources: []string{"gitopsdeployments"},
+					Resources: []string{"gitopsdeployments", "gitopsdeploymentmanagedenvironments", "gitopsdeploymentrepositorycredentials", "gitopsdeploymentsyncruns"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
@@ -1359,7 +1359,7 @@ func appstudioMaintainerUserActionsRole() spaceRoleObjectsCheck {
 				},
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
-					Resources: []string{"gitopsdeployments"},
+					Resources: []string{"gitopsdeployments", "gitopsdeploymentmanagedenvironments", "gitopsdeploymentrepositorycredentials", "gitopsdeploymentsyncruns"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
@@ -1440,7 +1440,7 @@ func appstudioContributorUserActionsRole() spaceRoleObjectsCheck {
 				},
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
-					Resources: []string{"gitopsdeployments"},
+					Resources: []string{"gitopsdeployments", "gitopsdeploymentmanagedenvironments", "gitopsdeploymentrepositorycredentials", "gitopsdeploymentsyncruns"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{


### PR DESCRIPTION
Updates test for readonly access for appstudio users to gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncrun APIs.

Corresponding host-operator PR: https://github.com/codeready-toolchain/host-operator/pull/781
Corresponding book PR: https://github.com/redhat-appstudio/book/pull/90