### PR TITLE
Increase resource threshold for appstudio dev/e2e

### DIFF
--- a/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
@@ -9,6 +9,9 @@ spec:
       defaultSpaceTier: 'appstudio'
     automaticApproval:
       enabled: true
+    capacityThresholds:
+      resourceCapacityThreshold:
+        defaultThreshold: 90
     deactivation:
       deactivationDomainsExcluded: '@redhat.com'
     registrationService:

--- a/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
@@ -10,6 +10,9 @@ spec:
       durationBeforeChangeTierRequestDeletion: '5s'
     automaticApproval:
       enabled: true
+    capacityThresholds:
+      resourceCapacityThreshold:
+        defaultThreshold: 90
     deactivation:
       deactivationDomainsExcluded: '@redhat.com'
     environment: 'e2e-tests'


### PR DESCRIPTION
dev clusters are often quite tight on resources, increase the capacity threshold to 90