### PR TITLE
test: ensure metrics are back to baseline after test

### DIFF
--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -32,6 +32,12 @@ func TestMetricsWhenUsersDeactivated(t *testing.T) {
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
+	t.Cleanup(func() {
+		// wait until metrics are back to their respective baselines
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait.ClusterName)
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait2.ClusterName)
+	})
+
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
@@ -96,6 +102,10 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
+	t.Cleanup(func() {
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait.ClusterName) // wait until counter is back to 0
+	})
+
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 
 	// when
@@ -179,6 +189,10 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
+	t.Cleanup(func() {
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait.ClusterName) // wait until counter is back to 0
+	})
+
 	usersignups := map[string]*toolchainv1alpha1.UserSignup{}
 
 	for i := 1; i <= 2; i++ {
@@ -236,6 +250,12 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	// given
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
+	t.Cleanup(func() {
+		t.Log("waiting for metrics to get back to their baseline values...")
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait.ClusterName)  // wait until counter is back to 0
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait2.ClusterName) // wait until counter is back to 0
+	})
+
 	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
 	userSignup, _ := NewSignupRequest(awaitilities).
@@ -304,6 +324,11 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	VerifyHostMetricsService(t, hostAwait)
 	VerifyMemberMetricsService(t, memberAwait)
 	metricsAssertion := InitMetricsAssertion(t, awaitilities)
+	t.Cleanup(func() {
+		t.Log("waiting for metrics to get back to their baseline values...")
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait.ClusterName)  // wait until counter is back to 0
+		metricsAssertion.WaitForMetricBaseline(t, SpacesMetric, "cluster_name", memberAwait2.ClusterName) // wait until counter is back to 0
+	})
 
 	// Create UserSignup
 	_, mur := NewSignupRequest(awaitilities).

--- a/testsupport/metrics.go
+++ b/testsupport/metrics.go
@@ -87,9 +87,15 @@ func (m *MetricsAssertionHelper) captureBaselineValues(t *testing.T, memberClust
 func (m *MetricsAssertionHelper) WaitForMetricDelta(t *testing.T, family string, delta float64, labels ...string) {
 	// The delta is relative to the starting value, eg. If there are 3 usersignups when a test is started and we are waiting
 	// for 2 more usersignups to be created (delta is +2) then the actual metric value (adjustedValue) we're waiting for is 5
-	key := m.baselineKey(t, string(family), labels...)
+	key := m.baselineKey(t, family, labels...)
 	adjustedValue := m.baselineValues[key] + delta
-	m.await.WaitUntiltMetricHasValue(t, string(family), adjustedValue, labels...)
+	m.await.WaitUntiltMetricHasValue(t, family, adjustedValue, labels...)
+}
+
+// WaitForMetricBaseline waits for the metric value to reach the baseline value back (to be used during the cleanup)
+func (m *MetricsAssertionHelper) WaitForMetricBaseline(t *testing.T, family string, labels ...string) {
+	key := m.baselineKey(t, family, labels...)
+	m.await.WaitUntiltMetricHasValue(t, family, m.baselineValues[key], labels...)
 }
 
 // generates a key to retain the baseline metric value, by joining the metric name and its labels.

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -337,7 +337,7 @@ func (a *Awaitility) WaitUntiltMetricHasValue(t *testing.T, family string, expec
 	t.Logf("waiting for metric '%s{%v}' to reach '%v'", family, labels, expectedValue)
 	var value float64
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		value, err := metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labels)
+		value, err = metrics.GetMetricValue(a.RestConfig, a.MetricsURL, family, labels)
 		// if error occurred, ignore and return `false` to keep waiting (may be due to endpoint temporarily unavailable)
 		// unless the expected value is `0`, in which case the metric is bot exposed (value==0 and err!= nil), but it's fine too.
 		return (value == expectedValue && err == nil) || (expectedValue == 0 && value == 0), nil


### PR DESCRIPTION
this should avoid assertion failures in subsequent tests, when the baseline is off by 1 or more if the metrics were not reset totally when the next test started

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
