### PR TITLE
fix: get Space & SpaceBinding directly in a loop

### DIFF
--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -27,7 +27,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 	t.Run("for SpaceBinding", func(t *testing.T) {
 		t.Run("when space is deleted", func(t *testing.T) {
 			// given
-			space, _, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "joe", "redhat")
+			space, _, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "joe", "for-redhat")
 
 			// when
 			err := hostAwait.Client.Delete(context.TODO(), space)
@@ -40,7 +40,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 		t.Run("when mur is deleted", func(t *testing.T) {
 			// given
-			_, userSignup, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "lara", "ibm")
+			_, userSignup, spaceBinding := setupForSpaceBindingCleanupTest(t, awaitilities, memberAwait, "lara", "for-ibm")
 
 			// when
 			// deactivate the UserSignup so that the MUR will be deleted

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2244,13 +2244,14 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 	var spaceCreated *toolchainv1alpha1.Space
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		// create the space
-		if err := a.CreateWithCleanup(t, space.DeepCopy()); err != nil {
+		spaceToCreate := space.DeepCopy()
+		if err := a.CreateWithCleanup(t, spaceToCreate); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return false, err
 			}
 		}
 		// create spacebinding request immediately after ...
-		spaceBinding = spacebinding.NewSpaceBinding(mur, space, spaceRole)
+		spaceBinding = spacebinding.NewSpaceBinding(mur, spaceToCreate, spaceRole)
 		if err := a.CreateWithCleanup(t, spaceBinding); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return false, err
@@ -2258,7 +2259,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		}
 		// let's see if space was provisioned as expected
 		spaceCreated = &toolchainv1alpha1.Space{}
-		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(space), spaceCreated)
+		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2007,7 +2007,7 @@ func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName st
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (bool, error) {
 		// retrieve the SpaceBinding from the host namespace
 		var err error
-		if spaceBinding, err = a.GetSpaceBinding(t, murName, spaceName); err != nil {
+		if spaceBinding, err = a.GetSpaceBinding(murName, spaceName); err != nil {
 			return false, err
 		}
 		return matchSpaceBindingWaitCriterion(spaceBinding, criteria...), nil
@@ -2020,7 +2020,7 @@ func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName st
 }
 
 // GetSpaceBinding lists all available SpaceBinding with the given MUR and Space names set as labels. If none is found, then it returns nil, nil
-func (a *HostAwaitility) GetSpaceBinding(t *testing.T, murName, spaceName string) (*toolchainv1alpha1.SpaceBinding, error) {
+func (a *HostAwaitility) GetSpaceBinding(murName, spaceName string) (*toolchainv1alpha1.SpaceBinding, error) {
 	labels := map[string]string{
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            spaceName,
@@ -2267,7 +2267,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			return false, a.WaitUntilSpaceAndSpaceBindingsDeleted(t, spaceCreated.Name)
 		}
 		// let's see if SpaceBinding was provisioned as expected
-		spaceBinding, err = a.GetSpaceBinding(t, mur.Name, spaceCreated.Name)
+		spaceBinding, err = a.GetSpaceBinding(mur.Name, spaceCreated.Name)
 		if err != nil {
 			return false, err
 		}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2244,7 +2244,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 	var spaceCreated *toolchainv1alpha1.Space
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		// create the space
-		if err := a.CreateWithCleanup(t, space); err != nil {
+		if err := a.CreateWithCleanup(t, space.DeepCopy()); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return false, err
 			}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2002,32 +2002,41 @@ func (a *HostAwaitility) WaitForSubSpace(t *testing.T, spaceRequestName, spaceRe
 
 // WaitForSpaceBinding waits until the SpaceBinding with the given MUR and Space names is available with the provided criteria, if any
 func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName string, criteria ...SpaceBindingWaitCriterion) (*toolchainv1alpha1.SpaceBinding, error) {
-	var spacebinding *toolchainv1alpha1.SpaceBinding
+	var spaceBinding *toolchainv1alpha1.SpaceBinding
+
+	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (bool, error) {
+		// retrieve the SpaceBinding from the host namespace
+		var err error
+		if spaceBinding, err = a.GetSpaceBinding(t, murName, spaceName); err != nil {
+			return false, err
+		}
+		return matchSpaceBindingWaitCriterion(spaceBinding, criteria...), nil
+	})
+	// no match found, print the diffs
+	if err != nil {
+		a.printSpaceBindingWaitCriterionDiffs(t, spaceBinding, criteria...)
+	}
+	return spaceBinding, err
+}
+
+// GetSpaceBinding lists all available SpaceBinding with the given MUR and Space names set as labels. If none is found, then it returns nil, nil
+func (a *HostAwaitility) GetSpaceBinding(t *testing.T, murName, spaceName string) (*toolchainv1alpha1.SpaceBinding, error) {
 	labels := map[string]string{
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            spaceName,
 	}
 
-	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
-		// retrieve the SpaceBinding from the host namespace
-		spaceBindingList := &toolchainv1alpha1.SpaceBindingList{}
-		if err = a.Client.List(context.TODO(), spaceBindingList, client.MatchingLabels(labels), client.InNamespace(a.Namespace)); err != nil {
-			return false, err
-		}
-		if len(spaceBindingList.Items) == 0 {
-			return false, nil
-		}
-		if len(spaceBindingList.Items) > 1 {
-			return false, fmt.Errorf("more than 1 binding for MasterUserRecord '%s' to Space '%s'", murName, spaceName)
-		}
-		spacebinding = &spaceBindingList.Items[0]
-		return matchSpaceBindingWaitCriterion(spacebinding, criteria...), nil
-	})
-	// no match found, print the diffs
-	if err != nil {
-		a.printSpaceBindingWaitCriterionDiffs(t, spacebinding, criteria...)
+	spaceBindingList := &toolchainv1alpha1.SpaceBindingList{}
+	if err := a.Client.List(context.TODO(), spaceBindingList, client.MatchingLabels(labels), client.InNamespace(a.Namespace)); err != nil {
+		return nil, err
 	}
-	return spacebinding, err
+	if len(spaceBindingList.Items) == 0 {
+		return nil, nil
+	}
+	if len(spaceBindingList.Items) > 1 {
+		return nil, fmt.Errorf("more than 1 binding for MasterUserRecord '%s' to Space '%s'", murName, spaceName)
+	}
+	return &spaceBindingList.Items[0], nil
 }
 
 func (a *HostAwaitility) printSpaceBindingWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.SpaceBinding, criteria ...SpaceBindingWaitCriterion) {
@@ -2245,7 +2254,8 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			}
 		}
 		// let's see if space was provisioned as expected
-		spaceCreated, err = a.WaitForSpace(t, space.Name)
+		spaceCreated = &toolchainv1alpha1.Space{}
+		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(space), spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -2256,13 +2266,13 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			// space is in terminating let's wait until is gone and recreate it ...
 			return false, a.WaitUntilSpaceAndSpaceBindingsDeleted(t, spaceCreated.Name)
 		}
-		// let's see if spacebinding was provisioned as expected
-		spaceBinding, err = a.WaitForSpaceBinding(t, mur.Name, spaceCreated.Name)
+		// let's see if SpaceBinding was provisioned as expected
+		spaceBinding, err = a.GetSpaceBinding(t, mur.Name, spaceCreated.Name)
 		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
 			return false, err
+		}
+		if spaceBinding == nil {
+			return false, nil
 		}
 		t.Logf("Space %s and SpaceBinding %s created", spaceCreated.Name, spaceBinding.Name)
 		return true, nil

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2007,8 +2007,11 @@ func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName st
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (bool, error) {
 		// retrieve the SpaceBinding from the host namespace
 		var err error
-		if spaceBinding, err = a.GetSpaceBinding(murName, spaceName); err != nil {
+		if spaceBinding, err = a.GetSpaceBindingByListing(murName, spaceName); err != nil {
 			return false, err
+		}
+		if spaceBinding == nil {
+			return false, nil
 		}
 		return matchSpaceBindingWaitCriterion(spaceBinding, criteria...), nil
 	})
@@ -2019,8 +2022,8 @@ func (a *HostAwaitility) WaitForSpaceBinding(t *testing.T, murName, spaceName st
 	return spaceBinding, err
 }
 
-// GetSpaceBinding lists all available SpaceBinding with the given MUR and Space names set as labels. If none is found, then it returns nil, nil
-func (a *HostAwaitility) GetSpaceBinding(murName, spaceName string) (*toolchainv1alpha1.SpaceBinding, error) {
+// GetSpaceBindingByListing lists all available SpaceBinding with the given MUR and Space names set as labels. If none is found, then it returns nil, nil
+func (a *HostAwaitility) GetSpaceBindingByListing(murName, spaceName string) (*toolchainv1alpha1.SpaceBinding, error) {
 	labels := map[string]string{
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: murName,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            spaceName,
@@ -2267,7 +2270,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			return false, a.WaitUntilSpaceAndSpaceBindingsDeleted(t, spaceCreated.Name)
 		}
 		// let's see if SpaceBinding was provisioned as expected
-		spaceBinding, err = a.GetSpaceBinding(mur.Name, spaceCreated.Name)
+		spaceBinding, err = a.GetSpaceBindingByListing(mur.Name, spaceCreated.Name)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
There are two reasons:
1. the `Wait*` functions don't return "NotFound" error if the poll times out, which results in a failed test if the Space/SpaceBinding wasn't found
2.  we don't have to wait the whole period - it's just there or not, so getting it directly is more suitable in this case

an example of the failed test: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/codeready-toolchain_toolchain-e2e/704/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1646501903141441536

```
        	Error Trace:	/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/space.go:97
        	            				/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/space_cleanup_test.go:138
        	            				/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/space_cleanup_test.go:30
        	Error:      	Received unexpected error:
        	            	timed out waiting for the condition
        	Test:       	TestSpaceAndSpaceBindingCleanup/for_SpaceBinding/when_space_is_deleted
```