### PR TITLE
feat: Implement "copy secret" functionality in SpaceRequest controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
-require sigs.k8s.io/yaml v1.3.0
-
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -106,6 +104,7 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 go 1.19

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
+require sigs.k8s.io/yaml v1.3.0
+
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -104,7 +106,8 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 go 1.19
+
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230413235928-1b4923254e3e

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230406073419-4f8108d3a1c6 h1:zF4fWYcqgYK2SdJl5uJS5nP1ebaFm1iYRms0zZn8Elk=
-github.com/codeready-toolchain/api v0.0.0-20230406073419-4f8108d3a1c6/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230406074039-c486d404e698 h1:ZZywos8WFDg1QauH/PdQ2/JDg/PfiCA6w16fj3iAj7w=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230406074039-c486d404e698/go.mod h1:vEOtsQaR6ugislmL6fho1ErnKjONdPGzJ8atk12p+4w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -440,6 +438,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/api v0.0.0-20230413235928-1b4923254e3e h1:4FwJOBuH/I/LtwkZzjpLCZF0L8mrWeHRIMXrCL6F9Qg=
+github.com/mfrancisc/api v0.0.0-20230413235928-1b4923254e3e/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37/go.mod h1:dYWq+UWoFCDY1TndvFUQuhBbIYmZpjreC8adEAx93zE=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=

--- a/make/run-cicd-script.mk
+++ b/make/run-cicd-script.mk
@@ -1,5 +1,5 @@
 
-OWNER_AND_BRANCH_LOCATION=codeready-toolchain/toolchain-cicd/master
+OWNER_AND_BRANCH_LOCATION=codeready-toolchain/mfrancisc/ASC-258_sr_secret
 GH_SCRIPTS_URL=https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}
 USE_LOCAL_SCRIPTS=false
 

--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -8,8 +8,15 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestCreateSpaceRequest(t *testing.T) {
@@ -27,29 +34,35 @@ func TestCreateSpaceRequest(t *testing.T) {
 		// when
 		targetClusterRoles := []string{cluster.RoleLabel(cluster.Tenant)}
 		spaceRequest, parentSpace := CreateSpaceRequest(t, awaitilities, memberAwait.ClusterName,
-			WithSpecTierName("appstudio"),
+			WithSpecTierName("appstudio-env"),
 			WithSpecTargetClusterRoles(targetClusterRoles))
 
 		// then
 		// check for the subSpace creation
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
 			UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-			UntilSpaceHasTier("appstudio"),
+			UntilSpaceHasTier("appstudio-env"),
 			UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint))
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+			UntilSpaceRequestHasNamespaceAccess(),
+		)
 		require.NoError(t, err)
+		// verify secret containing kubeconfig was provisioned
+		kubeClient, namespaceAccessSecret := newKubeClientFromSecret(t, memberAwait, spaceRequest.Namespace, spaceRequest.Status.NamespaceAccess[0].SecretRef)
+		// check that kubeconfig is valid
+		validateKubeClient(t, kubeClient, spaceRequest)
 
 		t.Run("subSpace is recreated if deleted ", func(t *testing.T) {
 			// now, delete the subSpace, along with its associated namespace,
 			// but a new Space will be provisioned by the SpaceRequest.
 
 			// when
-			err := memberAwait.Client.Delete(context.TODO(), subSpace)
+			err := hostAwait.Client.Delete(context.TODO(), subSpace)
 
 			// then
 			require.NoError(t, err)
@@ -57,12 +70,12 @@ func TestCreateSpaceRequest(t *testing.T) {
 			require.NoError(t, err)
 			err = memberAwait.WaitUntilNSTemplateSetDeleted(t, subSpace.Name)
 			require.NoError(t, err)
-			err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio")
+			err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio-env")
 			require.NoError(t, err)
 			// a new subSpace is created
 			subSpace, err = awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
 				UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-				UntilSpaceHasTier("appstudio"),
+				UntilSpaceHasTier("appstudio-env"),
 				UntilSpaceHasAnyProvisionedNamespaces(),
 			)
 			require.NoError(t, err)
@@ -80,28 +93,50 @@ func TestCreateSpaceRequest(t *testing.T) {
 				// then
 				// spaceRequest should reset back the tierName
 				_, err = awaitilities.Host().WaitForSpace(t, subSpace.GetName(),
-					UntilSpaceHasTier("appstudio"), // tierName is back as the one on spaceRequest
+					UntilSpaceHasTier("appstudio-env"), // tierName is back as the one on spaceRequest
 					UntilSpaceHasTargetClusterRoles(targetClusterRoles),
 					UntilSpaceHasAnyProvisionedNamespaces(),
 				)
 				require.NoError(t, err)
 
-				t.Run("delete space request", func(t *testing.T) {
-					// now, delete the SpaceRequest and expect that the Space will be deleted as well,
-					// along with its associated namespace
-
+				t.Run("namespace access secret is recreated if deleted ", func(t *testing.T) {
+					// now, delete the namespace access secret
 					// when
-					err := memberAwait.Client.Delete(context.TODO(), spaceRequest)
+					err := memberAwait.Client.Delete(context.TODO(), namespaceAccessSecret)
 
 					// then
-					// subSpace should be deleted as well
 					require.NoError(t, err)
-					err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio")
+					err = memberAwait.WaitUntilSecretDeleted(t, namespaceAccessSecret)
 					require.NoError(t, err)
-					err = memberAwait.WaitUntilNSTemplateSetDeleted(t, subSpace.Name)
+					// a new secret should be created
+					spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
+						UntilSpaceRequestHasConditions(Provisioned()),
+						UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+						UntilSpaceRequestHasNamespaceAccess(),
+					)
 					require.NoError(t, err)
-					err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, subSpace.Name)
-					require.NoError(t, err)
+					// verify secret containing kubeconfig was provisioned
+					kubeClient, _ = newKubeClientFromSecret(t, memberAwait, spaceRequest.Namespace, spaceRequest.Status.NamespaceAccess[0].SecretRef)
+					// check that kubeconfig is valid
+					validateKubeClient(t, kubeClient, spaceRequest)
+
+					t.Run("delete space request", func(t *testing.T) {
+						// now, delete the SpaceRequest and expect that the Space will be deleted as well,
+						// along with its associated namespace
+
+						// when
+						err := memberAwait.Client.Delete(context.TODO(), spaceRequest)
+
+						// then
+						// subSpace should be deleted as well
+						require.NoError(t, err)
+						err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio-env")
+						require.NoError(t, err)
+						err = memberAwait.WaitUntilNSTemplateSetDeleted(t, subSpace.Name)
+						require.NoError(t, err)
+						err = hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, subSpace.Name)
+						require.NoError(t, err)
+					})
 				})
 			})
 		})
@@ -110,14 +145,14 @@ func TestCreateSpaceRequest(t *testing.T) {
 	t.Run("subSpace has parentSpace target cluster when target roles are empty", func(t *testing.T) {
 		// when
 		spaceRequest, parentSpace := CreateSpaceRequest(t, awaitilities, memberAwait.ClusterName,
-			WithSpecTierName("appstudio"))
+			WithSpecTierName("appstudio-env"))
 
 		// then
 		// check for the subSpace creation with same target cluster as parent one
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
 			UntilSpaceHasTargetClusterRoles([]string(nil)),                     // empty target cluster roles
 			UntilSpaceHasStatusTargetCluster(parentSpace.Status.TargetCluster), // subSpace should have same target cluster as parent space
-			UntilSpaceHasTier("appstudio"),
+			UntilSpaceHasTier("appstudio-env"),
 			UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
@@ -137,7 +172,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			// then
 			// subSpace should be deleted as well
 			require.NoError(t, err)
-			err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio")
+			err = memberAwait.WaitUntilNamespaceDeleted(t, subSpace.Name, "appstudio-env")
 			require.NoError(t, err)
 			err = memberAwait.WaitUntilNSTemplateSetDeleted(t, subSpace.Name)
 			require.NoError(t, err)
@@ -224,4 +259,38 @@ func TestUpdateSpaceRequest(t *testing.T) {
 			UntilSpaceHasConditions(Provisioned()))
 		require.NoError(t, err)
 	})
+}
+
+func newKubeClientFromSecret(t *testing.T, member *MemberAwaitility, ns, secretName string) (client.Client, *corev1.Secret) {
+	adminSecret := &corev1.Secret{}
+	// retrieve the secret containing the kubeconfig
+	require.NoError(t, member.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: ns,
+		Name:      secretName,
+	}, adminSecret))
+	assert.NotEmpty(t, adminSecret.Data["kubeconfig"])
+	apiConfig, err := clientcmd.Load(adminSecret.Data["kubeconfig"])
+	require.NoError(t, err)
+	require.False(t, api.IsConfigEmpty(apiConfig))
+
+	// create a new client with the given kubeconfig
+	kubeconfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	require.NoError(t, err)
+	s := scheme.Scheme
+	builder := append(runtime.SchemeBuilder{},
+		corev1.AddToScheme,
+	)
+	require.NoError(t, builder.AddToScheme(s))
+	namespaceAccessClient, err := client.New(kubeconfig, client.Options{
+		Scheme: s,
+	})
+	require.NoError(t, err)
+	return namespaceAccessClient, adminSecret
+}
+
+func validateKubeClient(t *testing.T, namespaceAccessClient client.Client, spaceRequest *toolchainv1alpha1.SpaceRequest) {
+	// validate for example that the client can list secrets in the namespace
+	secretsList := &corev1.SecretList{}
+	require.NoError(t, namespaceAccessClient.List(context.TODO(), secretsList, client.InNamespace(spaceRequest.Status.NamespaceAccess[0].Name)))
+	require.NotEmpty(t, secretsList)
 }

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1553,11 +1553,11 @@ func memberOperatorSaReadRoleBinding() namespaceObjectsCheck {
 
 func namespaceManagerSaEditRoleBinding() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		rb, err := memberAwait.WaitForRoleBinding(t, ns, "namespace-manager")
+		rb, err := memberAwait.WaitForRoleBinding(t, ns, toolchainv1alpha1.AdminServiceAccountName)
 		require.NoError(t, err)
 		assert.Len(t, rb.Subjects, 1)
 		assert.Equal(t, "ServiceAccount", rb.Subjects[0].Kind)
-		assert.Equal(t, "namespace-manager", rb.Subjects[0].Name)
+		assert.Equal(t, toolchainv1alpha1.AdminServiceAccountName, rb.Subjects[0].Name)
 		assert.Equal(t, "edit", rb.RoleRef.Name)
 		assert.Equal(t, "ClusterRole", rb.RoleRef.Kind)
 		assert.Equal(t, "rbac.authorization.k8s.io", rb.RoleRef.APIGroup)
@@ -1591,7 +1591,7 @@ func toolchainSaReadRole() namespaceObjectsCheck {
 
 func namespaceManagerSA() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		serviceAccount, err := memberAwait.WaitForServiceAccount(t, ns.Name, "namespace-manager")
+		serviceAccount, err := memberAwait.WaitForServiceAccount(t, ns.Name, toolchainv1alpha1.AdminServiceAccountName)
 		require.NoError(t, err)
 		assert.Equal(t, "codeready-toolchain", serviceAccount.ObjectMeta.Labels["toolchain.dev.openshift.com/provider"])
 	}


### PR DESCRIPTION
Update spacerequest e2e tests to check and validate namespace access secret creation.

Jira: https://issues.redhat.com/browse/ASC-258

Paired with:
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/789

Related PRs:
- api: https://github.com/codeready-toolchain/api/pull/357
- cicd: https://github.com/codeready-toolchain/toolchain-cicd/pull/91