### PR TITLE
Remove write access to all GitOpsDeployment* resources, from all roles

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1427,7 +1427,7 @@ func appstudioUserActionsRole() spaceRoleObjectsCheck {
 				{
 					APIGroups: []string{"managed-gitops.redhat.com"},
 					Resources: []string{"gitopsdeployments", "gitopsdeploymentmanagedenvironments", "gitopsdeploymentrepositorycredentials", "gitopsdeploymentsyncruns"},
-					Verbs:     []string{"*"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 				{
 					APIGroups: []string{"tekton.dev"},


### PR DESCRIPTION
For security purposes, only the GitOps Service controllers should be able to create/modify/delete the `GitOpsDeployment*` resources, at this time.

* Note this does not effect the Environment API (Snapshots, Environments, SnapshotEnvironmentBindings, etc).

#### Corresponding PRs:
- *Book*: https://github.com/redhat-appstudio/book/pull/97
- *Host-operator*: https://github.com/codeready-toolchain/host-operator/pull/793