### PR TITLE
Added Workspace Name Label check

### DIFF
--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -187,6 +187,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	space, err := hostAwait.WaitForSpace(t, spaceName,
 		wait.UntilSpaceHasTier(tier.Name),
 		wait.UntilSpaceHasLabelWithValue(fmt.Sprintf("toolchain.dev.openshift.com/%s-tier-hash", tier.Name), hash),
+		wait.UntilSpaceHasLabelWithValue("appstudio.redhat.com/workspace_name", tier.Name),
 		wait.UntilSpaceHasConditions(Provisioned()),
 		wait.UntilSpaceHasStateLabel(toolchainv1alpha1.SpaceStateLabelValueClusterAssigned),
 		wait.UntilSpaceHasStatusTargetCluster(targetCluster.ClusterName))

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -219,9 +219,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 		ns, err := targetCluster.WaitForNamespace(t, space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName, wait.UntilNamespaceIsActive())
 		require.NoError(t, err)
 		require.Contains(t, ns.Labels, toolchainv1alpha1.WorkspaceLabelKey)
-		require.Contains(t, ns.Labels, "appstudio.redhat.com/workspace_name")
 		assert.Equal(t, space.Name, ns.Labels[toolchainv1alpha1.WorkspaceLabelKey])
-		assert.Equal(t, space.Name, ns.Labels["appstudio.redhat.com/workspace_name"])
 	}
 	// Wait for space to have list of provisioned namespaces in Space status.
 	// the expected namespaces for `nsTmplSet.Status.ProvisionedNamespaces` are checked as part of VerifyNSTemplateSet function above.

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -187,7 +187,6 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	space, err := hostAwait.WaitForSpace(t, spaceName,
 		wait.UntilSpaceHasTier(tier.Name),
 		wait.UntilSpaceHasLabelWithValue(fmt.Sprintf("toolchain.dev.openshift.com/%s-tier-hash", tier.Name), hash),
-		wait.UntilSpaceHasLabelWithValue("appstudio.redhat.com/workspace_name", tier.Name),
 		wait.UntilSpaceHasConditions(Provisioned()),
 		wait.UntilSpaceHasStateLabel(toolchainv1alpha1.SpaceStateLabelValueClusterAssigned),
 		wait.UntilSpaceHasStatusTargetCluster(targetCluster.ClusterName))
@@ -220,7 +219,9 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 		ns, err := targetCluster.WaitForNamespace(t, space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName, wait.UntilNamespaceIsActive())
 		require.NoError(t, err)
 		require.Contains(t, ns.Labels, toolchainv1alpha1.WorkspaceLabelKey)
+		require.Contains(t, ns.Labels, "appstudio.redhat.com/workspace_name")
 		assert.Equal(t, space.Name, ns.Labels[toolchainv1alpha1.WorkspaceLabelKey])
+		assert.Equal(t, space.Name, ns.Labels["appstudio.redhat.com/workspace_name"])
 	}
 	// Wait for space to have list of provisioned namespaces in Space status.
 	// the expected namespaces for `nsTmplSet.Status.ProvisionedNamespaces` are checked as part of VerifyNSTemplateSet function above.

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1402,7 +1402,7 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 }
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
-	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner) {
+	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
 		// TODO fix for migration/existing namespaces cases
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
 		if !strings.HasPrefix(ns.Name, "migration-") {

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1405,9 +1405,8 @@ func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
 		// TODO fix for migration/existing namespaces cases
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
-		if !strings.HasPrefix(ns.Name, "migration-") {
-			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
-		}
+		labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
+
 		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)
 	}

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1403,9 +1403,11 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
+		// TODO fix for migration/existing namespaces cases
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
-		labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
-
+		if !strings.HasPrefix(ns.Name, "migration-") {
+			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
+		}
 		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)
 	}

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1403,11 +1403,10 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-		// TODO fix for migration/existing namespaces cases
+
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
-		if !strings.HasPrefix(ns.Name, "migration-") {
-			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", owner))
-		}
+		labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", owner))
+
 		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)
 	}

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -428,6 +428,7 @@ func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObje
 		toolchainSaReadRole(),
 		memberOperatorSaReadRoleBinding(),
 		gitOpsServiceLabel(),
+		appstudioWorkSpaceNameLabel(),
 		environment("development"),
 		resourceQuotaAppstudioCrds("512", "512", "512"),
 		resourceQuotaAppstudioCrdsBuild("512"),
@@ -1393,6 +1394,18 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
 		if !strings.HasPrefix(ns.Name, "migration-") {
 			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("argocd.argoproj.io/managed-by", "gitops-service-argocd"))
+		}
+		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
+		require.NoError(t, err)
+	}
+}
+
+func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
+	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
+		// TODO fix for migration/existing namespaces cases
+		labelWaitCriterion := []wait.LabelWaitCriterion{}
+		if !strings.HasPrefix(ns.Name, "migration-") {
+			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
 		}
 		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1402,11 +1402,11 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 }
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
-	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
+	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner) {
 		// TODO fix for migration/existing namespaces cases
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
 		if !strings.HasPrefix(ns.Name, "migration-") {
-			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
+			labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", owner))
 		}
 		_, err := memberAwait.WaitForNamespaceWithName(t, ns.Name, labelWaitCriterion...)
 		require.NoError(t, err)

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -528,6 +528,7 @@ func (a *appstudioEnvTierChecks) GetNamespaceObjectChecks(_ string) []namespaceO
 		namespaceManagerSA(),
 		namespaceManagerSaEditRoleBinding(),
 		gitOpsServiceLabel(),
+		appstudioWorkSpaceNameLabel(),
 	}
 
 	checks = append(checks, append(commonNetworkPolicyChecks(), networkPolicyAllowFromCRW(), numberOfNetworkPolicies(6))...)

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1403,7 +1403,6 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, _ string) {
-		// TODO fix for migration/existing namespaces cases
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
 		labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", ns.Name))
 


### PR DESCRIPTION
This PR is for checking `appstudio.redhat.com/workspace_name ` label in the namespace

Paired with https://github.com/codeready-toolchain/host-operator/pull/798