### PR TITLE
fix: drop workspace label check from space testsupport

### DIFF
--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -214,13 +214,6 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	// verify NSTemplateSet with namespace & cluster scoped resources
 	tiers.VerifyNSTemplateSet(t, hostAwait, targetCluster, nsTmplSet, checks)
 
-	if tier.Name == "appstudio" {
-		// checks that namespace exists and has the expected label(s)
-		ns, err := targetCluster.WaitForNamespace(t, space.Name, tier.Spec.Namespaces[0].TemplateRef, space.Spec.TierName, wait.UntilNamespaceIsActive())
-		require.NoError(t, err)
-		require.Contains(t, ns.Labels, toolchainv1alpha1.WorkspaceLabelKey)
-		assert.Equal(t, space.Name, ns.Labels[toolchainv1alpha1.WorkspaceLabelKey])
-	}
 	// Wait for space to have list of provisioned namespaces in Space status.
 	// the expected namespaces for `nsTmplSet.Status.ProvisionedNamespaces` are checked as part of VerifyNSTemplateSet function above.
 	_, err = hostAwait.WaitForSpace(t, spaceName,


### PR DESCRIPTION
- drop redundant check on the namespace since `VerifyNSTemplateSet` already executes `memberAwait.WaitForNamespace` , plus this check was assuming only 1 namespace (while the `VerifyNSTemplateSet` loops over the expected namespaces )
- remove workspace label check since the label will be dropped 

This is part of Jira: https://issues.redhat.com/browse/CRT-1776