### PR TITLE
Remove starting CSVs to improve perf tooling setup

### DIFF
--- a/setup/operators/installtemplates/devspaces.yaml
+++ b/setup/operators/installtemplates/devspaces.yaml
@@ -23,7 +23,6 @@ objects:
       name: devspaces
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: devspacesoperator.v3.3.0-0.1673528130.p
 parameters:
   - name: DEVSPACES_OPERATOR_NAMESPACE
     value: crw

--- a/setup/operators/installtemplates/devworkspace-operator.yaml
+++ b/setup/operators/installtemplates/devworkspace-operator.yaml
@@ -24,7 +24,6 @@ objects:
       name: devworkspace-operator
       source: devworkspace-operator-catalog
       sourceNamespace: ${DWO_NAMESPACE}
-      startingCSV: devworkspace-operator.v0.15.2
 parameters:
   - name: DWO_NAMESPACE
     value: openshift-operators

--- a/setup/operators/installtemplates/gitops-primer-template.yaml
+++ b/setup/operators/installtemplates/gitops-primer-template.yaml
@@ -23,7 +23,6 @@ objects:
       name: gitops-primer
       source: community-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: gitops-primer.v0.0.11
 parameters:
   - name: GITOPS_PRIMER_OPERATOR_NAMESPACE
     value: gitops-primer-system

--- a/setup/operators/installtemplates/kiali.yaml
+++ b/setup/operators/installtemplates/kiali.yaml
@@ -14,7 +14,6 @@ objects:
       name: kiali-ossm
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: kiali-operator.v1.57.3
 parameters:
   - name: KIALI_NAMESPACE
     value: openshift-operators

--- a/setup/operators/installtemplates/openvino.yaml
+++ b/setup/operators/installtemplates/openvino.yaml
@@ -14,7 +14,6 @@ objects:
     name: ovms-operator
     source: certified-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: openvino-operator.v1.0.0
 parameters:
 - name: INTEL_NAMESPACE
   value: openshift-operators

--- a/setup/operators/installtemplates/rhoas.yaml
+++ b/setup/operators/installtemplates/rhoas.yaml
@@ -23,7 +23,6 @@ objects:
     name: rhoas-operator
     source: community-operators
     sourceNamespace: openshift-marketplace
-    startingCSV: rhoas-operator.0.9.6
 parameters:
 - name: RHOAS_NAMESPACE
   value: rhoas-operator

--- a/setup/operators/installtemplates/sbo.yaml
+++ b/setup/operators/installtemplates/sbo.yaml
@@ -23,7 +23,6 @@ objects:
       name: rh-service-binding-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: service-binding-operator.v1.3.3
       config:
         resources:
           requests:

--- a/setup/operators/installtemplates/serverless-operator.yaml
+++ b/setup/operators/installtemplates/serverless-operator.yaml
@@ -23,7 +23,6 @@ objects:
       name: serverless-operator
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: serverless-operator.v1.25.0
 parameters:
   - name: SERVERLESS_OPERATOR_NAMESPACE
     value: serverless-operator

--- a/setup/operators/installtemplates/web-terminal-operator.yaml
+++ b/setup/operators/installtemplates/web-terminal-operator.yaml
@@ -14,7 +14,6 @@ objects:
       name: web-terminal
       source: redhat-operators
       sourceNamespace: openshift-marketplace
-      startingCSV: web-terminal.v1.5.1-0.1661829403.p
 parameters:
   - name: WTO_NAMESPACE
     value: openshift-operators


### PR DESCRIPTION
We don't really care about startingCSV for perf testing, so we can remove them to speed up the initial setup and reduce the maintenance work of updating startingCSV fields in subscriptions.

I verified the setup completes fine with these changes.