### PR TITLE
make migration test usernames shorter

### DIFF
--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -16,14 +16,14 @@ import (
 )
 
 const (
-	ProvisionedUser             = "migration-provisioned"
-	DeactivatedUser             = "migration-deactivated"
-	BannedUser                  = "migration-banned-provisioned"
-	AppStudioProvisionedUser    = "migration-appstudio-provisioned"
-	SecondMemberProvisionedUser = "migration-second-member-provisioned-user"
+	ProvisionedUser             = "mgr-provisioned"
+	DeactivatedUser             = "mgr-deactivated"
+	BannedUser                  = "mgr-banned"
+	AppStudioProvisionedUser    = "mgr-appstudio"
+	SecondMemberProvisionedUser = "mgr-member2-user"
 
-	ProvisionedAppStudioSpace    = "migration-appstudio-provisioned-space"
-	SecondMemberProvisionedSpace = "migration-second-member-provisioned-space"
+	ProvisionedAppStudioSpace    = "mgr-appstudio-space"
+	SecondMemberProvisionedSpace = "mgr-member2-space"
 )
 
 type SetupMigrationRunner struct {

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	ProvisionedUser             = "mig-prov"
-	DeactivatedUser             = "mig-deact
+	DeactivatedUser             = "mig-deact"
 	BannedUser                  = "mig-banned"
 	AppStudioProvisionedUser    = "mig-appst"
 	SecondMemberProvisionedUser = "mig-m2-user"

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -16,14 +16,14 @@ import (
 )
 
 const (
-	ProvisionedUser             = "mgr-provisioned"
-	DeactivatedUser             = "mgr-deactivated"
-	BannedUser                  = "mgr-banned"
-	AppStudioProvisionedUser    = "mgr-appstudio"
-	SecondMemberProvisionedUser = "mgr-member2-user"
+	ProvisionedUser             = "mig-prov"
+	DeactivatedUser             = "mig-deact
+	BannedUser                  = "mig-banned"
+	AppStudioProvisionedUser    = "mig-appst"
+	SecondMemberProvisionedUser = "mig-m2-user"
 
-	ProvisionedAppStudioSpace    = "mgr-appstudio-space"
-	SecondMemberProvisionedSpace = "mgr-member2-space"
+	ProvisionedAppStudioSpace    = "mig-appst-space"
+	SecondMemberProvisionedSpace = "mig-m2-space"
 )
 
 type SetupMigrationRunner struct {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -96,14 +96,14 @@ func TestAfterMigration(t *testing.T) {
 
 func verifyAppStudioProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	space, _ := VerifyResourcesProvisionedForSpace(t, awaitilities, migration.ProvisionedAppStudioSpace)
-	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), fmt.Sprintf("for-space-%s", migration.ProvisionedAppStudioSpace))
+	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), migration.ProvisionedAppStudioSpace)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
 }
 
 func verifySecondMemberProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	space, _ := VerifyResourcesProvisionedForSpace(t, awaitilities, migration.SecondMemberProvisionedSpace)
-	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), fmt.Sprintf("for-space-%s", migration.SecondMemberProvisionedSpace))
+	userSignupForSpace := checkMURMigratedAndGetSignup(t, awaitilities.Host(), migration.SecondMemberProvisionedSpace)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, space)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
 }

--- a/testsupport/space.go
+++ b/testsupport/space.go
@@ -231,7 +231,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 }
 
 func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awaitilities, space *toolchainv1alpha1.Space, cleanup bool) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.MasterUserRecord, *toolchainv1alpha1.SpaceBinding) {
-	username := "for-space-" + space.Name
+	username := space.Name
 	builder := NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").


### PR DESCRIPTION
This change is needed because now usernames length is <= 20 chars, causing some of the migration test checks to fail.