### PR TITLE
fix: add wait for NSTemplateSet to have space roles populated

### DIFF
--- a/testsupport/tiers/nstemplateset.go
+++ b/testsupport/tiers/nstemplateset.go
@@ -17,7 +17,7 @@ func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwa
 	t.Logf("verifying NSTemplateSet '%s' and its resources", nsTmplSet.Name)
 	expectedTemplateRefs := checks.GetExpectedTemplateRefs(t, hostAwait)
 
-	_, err := memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name, UntilNSTemplateSetHasTemplateRefs(expectedTemplateRefs))
+	_, err := memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name, UntilNSTemplateSetHasTemplateRefs(expectedTemplateRefs), wait.UntilNSTemplateSetHasAnySpaceRoles())
 	require.NoError(t, err)
 
 	// save the names of the namespaces provisioned by the NSTemplateSet,

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -525,7 +525,7 @@ func UntilNSTemplateSetHasAnySpaceRoles() NSTemplateSetWaitCriterion {
 			return len(actual.Spec.SpaceRoles) > 0
 		},
 		Diff: func(actual *toolchainv1alpha1.NSTemplateSet) string {
-			return fmt.Sprintf("expected space roles to not be empty.")
+			return "expected space roles to not be empty."
 		},
 	}
 }

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -517,6 +517,19 @@ func UntilNSTemplateSetHasSpaceRolesFromBindings(tier *toolchainv1alpha1.NSTempl
 	}
 }
 
+// UntilNSTemplateSetHasAnySpaceRoles returns a `NSTemplateSetWaitCriterion` which checks that the given
+// NSTemplateSet has any space roles set.
+func UntilNSTemplateSetHasAnySpaceRoles() NSTemplateSetWaitCriterion {
+	return NSTemplateSetWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.NSTemplateSet) bool {
+			return len(actual.Spec.SpaceRoles) > 0
+		},
+		Diff: func(actual *toolchainv1alpha1.NSTemplateSet) string {
+			return fmt.Sprintf("expected space roles to not be empty.")
+		},
+	}
+}
+
 func SpaceRole(templateRef string, usernames ...string) toolchainv1alpha1.NSTemplateSetSpaceRole {
 	return toolchainv1alpha1.NSTemplateSetSpaceRole{
 		TemplateRef: templateRef,


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/CRT-1797

I was not able to reproduce the failure locally yet, but I've noticed that when `VerifyNSTemplateSet` is called here https://github.com/codeready-toolchain/toolchain-e2e/blob/cd125effc00c1f1235ad4383f778b81ecfb7e951/testsupport/space.go#L208-L215 there is not wait check for the `SpaceRoles` to be populated in the `NSTemplateSet`, while there is when invoked here https://github.com/codeready-toolchain/toolchain-e2e/blob/cd125effc00c1f1235ad4383f778b81ecfb7e951/testsupport/user_assertions.go#L190-L197

So my guess is that space roles are not  populated yet when `VerifyNSTemplateSet` is invoked by space.go:215 , causing less expected spaceroles then the actual ones:

```
member.go:2130: expected number of resources of kind 'RoleBindings' in namespace 'mig-m2-space-dev' to be 2 but it was 4
checks.go:1337: found 4 role bindings: ([]string) (len=4 cap=4) {
(string) (len=13) "crtadmin-pods",
(string) (len=13) "crtadmin-view",
(string) (len=17) "mig-m2-space-edit",
(string) (len=22) "mig-m2-space-rbac-edit"
}
member.go:554: waiting for NSTemplateSet 'mig-m2-space' to match criteria
member.go:2130: expected number of resources of kind 'Roles' in namespace 'mig-m2-space-dev' to be 1 but it was 2
checks.go:1315: found 2 roles: ([]string) (len=2 cap=2) {
(string) (len=9) "exec-pods",
(string) (len=9) "rbac-edit"
}
```

