### PR TITLE
fix: invalid number of subSpaces issue

### DIFF
--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -61,6 +61,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			// then
 			// a new subSpace is created
 			// with the same name but creation timestamp should be greater (more recent).
+			require.NoError(t, err)
 			subSpace, err = awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
 				UntilSpaceHasTargetClusterRoles(targetClusterRoles),
 				UntilSpaceHasTier("appstudio-env"),

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1750,6 +1750,19 @@ func UntilSpaceHasCreationTimestampOlderThan(expectedElapsedTime time.Duration) 
 	}
 }
 
+// UntilSpaceHasCreationTimestampGreaterThan returns a `SpaceWaitCriterion` which checks that the given
+// Space was created after a given creationTimestamp
+func UntilSpaceHasCreationTimestampGreaterThan(creationTimestamp time.Time) SpaceWaitCriterion {
+	return SpaceWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.Space) bool {
+			return actual.CreationTimestamp.Time.After(creationTimestamp)
+		},
+		Diff: func(actual *toolchainv1alpha1.Space) string {
+			return fmt.Sprintf("expected space to be created after %s; Actual creation timestamp %s", creationTimestamp.String(), actual.CreationTimestamp.String())
+		},
+	}
+}
+
 // UntilSpaceHasTier returns a `SpaceWaitCriterion` which checks that the given
 // Space has the expected tier name set in its Spec
 func UntilSpaceHasTier(expected string) SpaceWaitCriterion {


### PR DESCRIPTION
Since subSpaces now are recreated with same name, the space controller was very quick at provisioning a new subSpace and the test was failing while trying to wait for it to be deleted.

This PR checks that a new subSpace was recreated by comparing the creationTimestamp fields.

Jira bug: https://issues.redhat.com/browse/SANDBOX-52

Paired with: https://github.com/codeready-toolchain/host-operator/pull/809