### PR TITLE
test(metrics): member-operator version metric

### DIFF
--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -25,9 +25,11 @@ import (
 
 func TestOperatorVersionMetrics(t *testing.T) {
 
+	// given
+	awaitilities := WaitForDeployments(t)
+
 	t.Run("host-operator", func(t *testing.T) {
 		// given
-		awaitilities := WaitForDeployments(t)
 		hostAwait := awaitilities.Host()
 		// host metrics should be available at this point
 		hostAwait.InitMetrics(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
@@ -44,7 +46,6 @@ func TestOperatorVersionMetrics(t *testing.T) {
 
 	t.Run("member-operators", func(t *testing.T) {
 		// given
-		awaitilities := WaitForDeployments(t)
 		member1Await := awaitilities.Member1()
 		// member metrics should be available at this point
 		member1Await.InitMetrics(t)

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -23,21 +23,41 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestHostOperatorVersionMetrics(t *testing.T) {
+func TestOperatorVersionMetrics(t *testing.T) {
 
-	// given
-	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host()
-	// host metrics should be available at this point
-	hostAwait.InitMetrics(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
+	t.Run("host-operator", func(t *testing.T) {
+		// given
+		awaitilities := WaitForDeployments(t)
+		hostAwait := awaitilities.Host()
+		// host metrics should be available at this point
+		hostAwait.InitMetrics(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
 
-	labels := hostAwait.GetMetricLabels(t, wait.HostOperatorVersionMetric)
+		// when
+		labels := hostAwait.GetMetricLabels(t, wait.HostOperatorVersionMetric)
 
-	// verify that the "version" metric exists for Host Operator and that it has a non-empty `commit` label
-	require.Len(t, labels, 1)
-	commit := labels[0]["commit"]
-	require.NotNil(t, commit)
-	assert.Len(t, *commit, 7)
+		// verify that the "version" metric exists for Host Operator and that it has a non-empty `commit` label
+		require.Len(t, labels, 1)
+		commit := labels[0]["commit"]
+		require.NotNil(t, commit)
+		assert.Len(t, *commit, 7)
+	})
+
+	t.Run("member-operators", func(t *testing.T) {
+		// given
+		awaitilities := WaitForDeployments(t)
+		member1Await := awaitilities.Member1()
+		// host metrics should be available at this point
+		member1Await.InitMetrics(t)
+
+		// when
+		labels := member1Await.GetMetricLabels(t, wait.MemberOperatorVersionMetric)
+
+		// verify that the "version" metric exists for Host Operator and that it has a non-empty `commit` label
+		require.Len(t, labels, 1)
+		commit := labels[0]["commit"]
+		require.NotNil(t, commit)
+		assert.Len(t, *commit, 7)
+	})
 }
 
 // TestMetricsWhenUsersManuallyApproved verifies that `UserSignupsApprovedMetric` and `UserSignupsApprovedWithMethodMetric` counters are increased when users are approved

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -47,17 +47,33 @@ func TestOperatorVersionMetrics(t *testing.T) {
 	t.Run("member-operators", func(t *testing.T) {
 		// given
 		member1Await := awaitilities.Member1()
+		member2Await := awaitilities.Member1()
 		// member metrics should be available at this point
 		member1Await.InitMetrics(t)
+		member2Await.InitMetrics(t)
 
+		// --- member1 ---
 		// when
 		labels := member1Await.GetMetricLabels(t, wait.MemberOperatorVersionMetric)
 
-		// verify that the "version" metric exists for Host Operator and that it has a non-empty `commit` label
+		// verify that the "version" metric exists for the first Member Operator and that it has a non-empty `commit` label
 		require.Len(t, labels, 1)
-		commit := labels[0]["commit"]
-		require.NotNil(t, commit)
-		assert.Len(t, *commit, 7)
+		commit1 := labels[0]["commit"]
+		require.NotNil(t, commit1)
+		assert.Len(t, *commit1, 7)
+
+		// --- member2 ---
+		// when
+		labels = member2Await.GetMetricLabels(t, wait.MemberOperatorVersionMetric)
+
+		// verify that the "version" metric exists for the second Member Operator and that it has a non-empty `commit` label
+		require.Len(t, labels, 1)
+		commit2 := labels[0]["commit"]
+		require.NotNil(t, commit2)
+		assert.Len(t, *commit2, 7)
+
+		// expect the same version on member1 and member2
+		assert.Equal(t, *commit1, *commit2)
 	})
 }
 

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -46,7 +46,7 @@ func TestOperatorVersionMetrics(t *testing.T) {
 		// given
 		awaitilities := WaitForDeployments(t)
 		member1Await := awaitilities.Member1()
-		// host metrics should be available at this point
+		// member metrics should be available at this point
 		member1Await.InitMetrics(t)
 
 		// when

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -74,6 +74,20 @@ func (a *MemberAwaitility) WaitForMetricsService(t *testing.T) {
 	require.NoError(t, err, "failed while waiting for 'member-operator-metrics-service' service")
 }
 
+// metric constants
+const (
+	MemberOperatorVersionMetric = "sandbox_member_operator_version"
+)
+
+// InitMetricsAssertion waits for any pending usersignups and then initialized the metrics assertion helper with baseline values
+func (a *MemberAwaitility) InitMetrics(t *testing.T) {
+	a.WaitForMetricsService(t)
+	// Capture baseline values
+	a.baselineValues = make(map[string]float64)
+	a.baselineValues[MemberOperatorVersionMetric] = a.GetMetricValue(t, MemberOperatorVersionMetric)
+	t.Logf("captured baselines:\n%s", spew.Sdump(a.baselineValues))
+}
+
 func (a *MemberAwaitility) WithRetryOptions(options ...RetryOption) *MemberAwaitility {
 	return &MemberAwaitility{
 		Awaitility: a.Awaitility.WithRetryOptions(options...),


### PR DESCRIPTION
e2e tests for https://github.com/codeready-toolchain/member-operator/pull/445

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>