### PR TITLE
Add retries when getting workspace

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -83,13 +83,14 @@ func (u *proxyUser) getWorkspace(t *testing.T, hostAwait *wait.HostAwaitility, w
 
 	workspace := &toolchainv1alpha1.Workspace{}
 	var cause error
-	pollErr := kubewait.Poll(wait.DefaultRetryInterval, wait.DefaultTimeout, func() (bool, error) {
+	// only wait up to 5 seconds because in some test cases the workspace is not expected to be found
+	_ = kubewait.Poll(wait.DefaultRetryInterval, 5*time.Second, func() (bool, error) {
 		cause = proxyCl.Get(context.TODO(), types.NamespacedName{Name: workspaceName}, workspace)
 		return cause == nil, nil
 	})
-	require.NoError(t, pollErr, cause)
 
-	return workspace, pollErr
+	// do not assert error before returning because in some test cases the workspace is not expected to be found
+	return workspace, cause
 }
 
 func (u *proxyUser) getApplication(t *testing.T, proxyClient client.Client, applicationName string) *appstudiov1.Application {


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/SANDBOX-226

This should hopefully address the flakiness.

The failure for reference:
```
=== RUN   TestSpaceLister/car_lists_workspaces
    host.go:1718: waiting for Space 'car' with matching criteria
=== RUN   TestSpaceLister/car_gets_workspaces
=== RUN   TestSpaceLister/car_gets_workspaces/can_get_car_workspace
    host.go:1718: waiting for Space 'car' with matching criteria
=== RUN   TestSpaceLister/car_gets_workspaces/cannot_get_bus_workspace
=== RUN   TestSpaceLister/bus_lists_workspaces
    host.go:1718: waiting for Space 'bus' with matching criteria
    host.go:1718: waiting for Space 'car' with matching criteria
=== RUN   TestSpaceLister/bus_gets_workspaces
=== RUN   TestSpaceLister/bus_gets_workspaces/can_get_bus_workspace
    proxy_test.go:640: 
        	Error Trace:	/tmp/toolchain-e2e/test/e2e/proxy_test.go:640
        	Error:      	Received unexpected error:
        	            	the server could not find the requested resource (get workspaces.toolchain.dev.openshift.com bus)
        	Test:       	TestSpaceLister/bus_gets_workspaces/can_get_bus_workspace 
```