### PR TITLE
drop obsolete proxy Role&RoleBinding

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -252,10 +252,11 @@ func TestProxyFlow(t *testing.T) {
 						Path:  "/spec/displayName",
 						Value: patchString,
 					}}
-					patchPayloadBytes, _ := json.Marshal(patchPayload)
+					patchPayloadBytes, err := json.Marshal(patchPayload)
+					require.NoError(t, err)
 
 					// Appply Patch
-					err := proxyCl.Patch(context.TODO(), proxyApp, client.RawPatch(types.JSONPatchType, patchPayloadBytes))
+					err = proxyCl.Patch(context.TODO(), proxyApp, client.RawPatch(types.JSONPatchType, patchPayloadBytes))
 					require.NoError(t, err)
 
 					// Get patched app and verify patched DisplayName


### PR DESCRIPTION
paired with https://github.com/codeready-toolchain/host-operator/pull/842
 * it drops the obsolete proxy Role & RoleBinding (we didn't have the SA checks in place)
 
it also fixes a linter issue in proxy_test.go