### PR TITLE
feat: create SpaceBindingRequest controller skeleton

### DIFF
--- a/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
@@ -16,6 +16,7 @@ spec:
       deactivationDomainsExcluded: '@redhat.com'
     spaceConfig:
       spaceRequestEnabled: true
+      spaceBindingRequestEnabled: true
     registrationService:
       environment: 'dev'
       verification:

--- a/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
@@ -17,6 +17,7 @@ spec:
       deactivationDomainsExcluded: '@redhat.com'
     spaceConfig:
       spaceRequestEnabled: true
+      spaceBindingRequestEnabled: true
     environment: 'e2e-tests'
     notifications:
       durationBeforeNotificationDeletion: '5s'

--- a/deploy/host-operator/e2e-tests/toolchainconfig.yaml
+++ b/deploy/host-operator/e2e-tests/toolchainconfig.yaml
@@ -26,6 +26,7 @@ spec:
           twilioFromNumber: 'twilio.from_number'
     spaceConfig:
       spaceRequestEnabled: true
+      spaceBindingRequestEnabled: true
     tiers:
       durationBeforeChangeTierRequestDeletion: '5s'
     toolchainStatus:


### PR DESCRIPTION
Enable new SpaceBindingRequest controller in e2e test and dev environments.
The controller is not performing any action on SBR resources, it just reacts when one is created and triggers a reconcile loop. The logic of the controller among with e2e tests will be implemented next.

Jira: https://issues.redhat.com/browse/ASC-395

Paired with: https://github.com/codeready-toolchain/host-operator/pull/846