### PR TITLE
fix(RHTAPBUGS-587): increase ResourceQuota for Snapshots

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -448,7 +448,7 @@ func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObje
 		resourceQuotaAppstudioCrds("512", "512", "512"),
 		resourceQuotaAppstudioCrdsBuild("512"),
 		resourceQuotaAppstudioCrdsGitops("512", "512", "512", "512", "512"),
-		resourceQuotaAppstudioCrdsIntegration("512", "512", "512"),
+		resourceQuotaAppstudioCrdsIntegration("512", "1024", "512"),
 		resourceQuotaAppstudioCrdsRelease("512", "512", "512", "512", "512"),
 		resourceQuotaAppstudioCrdsEnterpriseContract("512"),
 		resourceQuotaAppstudioCrdsSPI("512", "512", "512", "512", "512"),


### PR DESCRIPTION
* Snapshots are high-traffic CRs that are created for each version of the application
* The limit of 512 has been too low in practice