### PR TITLE
disable phone verification in dev & appstudio environments

### DIFF
--- a/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-dev/toolchainconfig.yaml
@@ -19,12 +19,6 @@ spec:
       spaceBindingRequestEnabled: true
     registrationService:
       environment: 'dev'
-      verification:
-        secret:
-          ref: 'host-operator-secret'
-          twilioAccountSID: 'twilio.account.sid'
-          twilioAuthToken: 'twilio.auth.token'
-          twilioFromNumber: 'twilio.from_number'
   members:
     default:
       skipUserCreation: true

--- a/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
+++ b/deploy/host-operator/appstudio-e2e/toolchainconfig.yaml
@@ -23,14 +23,6 @@ spec:
       durationBeforeNotificationDeletion: '5s'
     registrationService:
       environment: 'e2e-tests'
-      verification:
-        enabled: true
-        excludedEmailDomains: 'redhat.com'
-        secret:
-          ref: 'host-operator-secret'
-          twilioAccountSID: 'twilio.account.sid'
-          twilioAuthToken: 'twilio.auth.token'
-          twilioFromNumber: 'twilio.from_number'
     toolchainStatus:
       toolchainStatusRefreshTime: '1s'
   members:

--- a/deploy/host-operator/dev/toolchainconfig.yaml
+++ b/deploy/host-operator/dev/toolchainconfig.yaml
@@ -10,13 +10,6 @@ spec:
       deactivationDomainsExcluded: '@redhat.com'
     registrationService:
       environment: 'dev'
-      verification:
-        enabled: true
-        secret:
-          ref: 'host-operator-secret'
-          twilioAccountSID: 'twilio.account.sid'
-          twilioAuthToken: 'twilio.auth.token'
-          twilioFromNumber: 'twilio.from_number'
   members:
     default:
       autoscaler:


### PR DESCRIPTION
based on latest discussions:
https://redhat-internal.slack.com/archives/CHK0J6HT6/p1693460828997409
https://redhat-internal.slack.com/archives/CHK0J6HT6/p1693337601323839?thread_ts=1693316915.769479&cid=CHK0J6HT6

let's disable the phone verification step in dev environment - you know, to simplify it for other developers.

While doing so, I also noticed that the phone verification was enabled also in appstudio-e2e environment, which doesn't make any sense at all. So I disabled it there as well cc @jkopriva @sawood14012 