### PR TITLE
resources: increase the PVC claim limit to 30

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -439,7 +439,7 @@ func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObje
 	checks := []namespaceObjectsCheck{
 		resourceQuotaComputeDeploy("20", "32Gi", "1750m", "32Gi"),
 		resourceQuotaComputeBuild("60", "64Gi", "6", "32Gi"),
-		resourceQuotaStorage("50Gi", "50Gi", "50Gi", "12"),
+		resourceQuotaStorage("50Gi", "50Gi", "50Gi", "30"),
 		limitRange("2", "2Gi", "10m", "256Mi"),
 		numberOfLimitRanges(1),
 		gitOpsServiceLabel(),


### PR DESCRIPTION
During efforts to onboard product components to RHTAP, the PVC resource utilization limit has resulted in regular `PipelineRun` failures.

See: https://github.com/codeready-toolchain/host-operator/pull/862