### PR TITLE
feat: Implement public API that will open SpaceBindings to end users through proxy part 1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,4 +122,4 @@ require (
 
 go 1.19
 
-replace github.com/codeready-toolchain/toolchain-common => /Users/fmuntean/go/src/github.com/codeready-toolchain/toolchain-common
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20230823083409-fe9ca973d9a9
+	github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230823084119-693476668406
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.12.0
@@ -121,3 +121,5 @@ require (
 )
 
 go 1.19
+
+replace github.com/codeready-toolchain/toolchain-common => /Users/fmuntean/go/src/github.com/codeready-toolchain/toolchain-common

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20230823084119-693476668406
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20231002120847-bf3a59c8351b
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.12.0
 	github.com/ghodss/yaml v1.0.0
@@ -121,5 +121,3 @@ require (
 )
 
 go 1.19
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4

--- a/go.mod
+++ b/go.mod
@@ -122,4 +122,4 @@ require (
 
 go 1.19
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d
+replace github.com/codeready-toolchain/toolchain-common => github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d h1:IjiA1gvkGR7fZDuelLrOS80JobW7FZaeIpGRu8s1lRw=
-github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
+github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4 h1:XIw5csoJ0Ydw0Aoeg9heZv031pujrDgeSv9S5h3OUEE=
+github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d h1:IjiA1gvkGR7fZDuelLrOS80JobW7FZaeIpGRu8s1lRw=
+github.com/mfrancisc/toolchain-common v0.0.0-20230920161730-cbaf858a894d/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -123,10 +123,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230823083409-fe9ca973d9a9 h1:ytFqNSSEvgevqvwMilmmqlrrDH1O/qUwzg8bO3CxCiY=
-github.com/codeready-toolchain/api v0.0.0-20230823083409-fe9ca973d9a9/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230823084119-693476668406 h1:AkBhFV2tJhQaejTjntIhFC7r1FeLlQEiAL2gcn5/oW0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230823084119-693476668406/go.mod h1:wvbndymhFMqyc8syiaanid91GsywkDfuVyiTjdyiqNM=
+github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33 h1:hxXfcFq2JgFISVxrkISg8m9DZMzpcPWRjPspx3M3Sxo=
+github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33 h1:hxXfcFq2JgFISVxrkISg8m9DZMzpcPWRjPspx3M3Sxo=
 github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231002120847-bf3a59c8351b h1:3nk69kWcILOiu6Ul9DZZTRmx4pItVit+9uOAmjrYCfM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231002120847-bf3a59c8351b/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -471,8 +473,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4 h1:XIw5csoJ0Ydw0Aoeg9heZv031pujrDgeSv9S5h3OUEE=
-github.com/mfrancisc/toolchain-common v0.0.0-20230920171626-876ba9b0d3c4/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -683,7 +683,7 @@ func TestSpaceLister(t *testing.T) {
 		// then
 		// car should see only car's workspace
 		require.Len(t, workspaces, 1)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], commonproxy.WithType("home")), workspaces...)
 	})
 
 	t.Run("car gets workspaces", func(t *testing.T) {
@@ -693,7 +693,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true, appStudioTierRolesWSOption), *workspace)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], commonproxy.WithType("home"), appStudioTierRolesWSOption), *workspace)
 		})
 
 		t.Run("cannot get bus workspace", func(t *testing.T) {
@@ -713,8 +713,8 @@ func TestSpaceLister(t *testing.T) {
 		// then
 		// bus should see both its own and car's workspace
 		require.Len(t, workspaces, 2)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true), workspaces...)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], commonproxy.WithType("home")), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"]), workspaces...)
 	})
 
 	t.Run("bus gets workspaces", func(t *testing.T) {
@@ -724,7 +724,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true, appStudioTierRolesWSOption), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], commonproxy.WithType("home"), appStudioTierRolesWSOption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -733,7 +733,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSOption), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], appStudioTierRolesWSOption), *carWS)
 		})
 	})
 
@@ -744,9 +744,9 @@ func TestSpaceLister(t *testing.T) {
 		// then
 		// car should see only car's workspace
 		require.Len(t, workspaces, 3)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true), workspaces...)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false), workspaces...)
-		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], commonproxy.WithType("home")), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"]), workspaces...)
+		verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"]), workspaces...)
 	})
 
 	t.Run("bicycle gets workspaces", func(t *testing.T) {
@@ -756,7 +756,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false, appStudioTierRolesWSOption), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], appStudioTierRolesWSOption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -765,7 +765,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSOption), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], appStudioTierRolesWSOption), *carWS)
 		})
 
 		t.Run("can get bicycle workspace", func(t *testing.T) {
@@ -774,14 +774,14 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true, appStudioTierRolesWSOption), *bicycleWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], commonproxy.WithType("home"), appStudioTierRolesWSOption), *bicycleWS)
 		})
 	})
 
 	t.Run("other workspace actions not permitted", func(t *testing.T) {
 		t.Run("create not allowed", func(t *testing.T) {
 			// given
-			workspaceToCreate := expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false)
+			workspaceToCreate := expectedWorkspaceFor(t, awaitilities.Host(), users["bus"])
 			bicycleCl, err := hostAwait.CreateAPIProxyClient(t, users["bicycle"].token, hostAwait.APIProxyURL)
 			require.NoError(t, err)
 
@@ -809,7 +809,7 @@ func TestSpaceLister(t *testing.T) {
 
 		t.Run("update not allowed", func(t *testing.T) {
 			// when
-			workspaceToUpdate := expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true)
+			workspaceToUpdate := expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], commonproxy.WithType("home"))
 			bicycleCl, err := hostAwait.CreateAPIProxyClient(t, users["bicycle"].token, hostAwait.APIProxyURL)
 			require.NoError(t, err)
 
@@ -1056,7 +1056,7 @@ func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha
 	t.Errorf("expected workspace %s not found", expectedWorkspace.Name)
 }
 
-func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *proxyUser, isHomeWorkspace bool, additionalWSOptions ...commonproxy.WorkspaceOption) toolchainv1alpha1.Workspace {
+func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *proxyUser, additionalWSOptions ...commonproxy.WorkspaceOption) toolchainv1alpha1.Workspace {
 	space, err := hostAwait.WaitForSpace(t, user.compliantUsername, wait.UntilSpaceHasAnyTargetClusterSet(), wait.UntilSpaceHasAnyTierNameSet())
 	require.NoError(t, err)
 
@@ -1074,10 +1074,6 @@ func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *pr
 	ws := commonproxy.NewWorkspace(user.compliantUsername,
 		append(commonWSoptions, additionalWSOptions...)...,
 	)
-	// if the user is the same as the one who created the workspace, then expect type should be "home"
-	if isHomeWorkspace {
-		ws.Status.Type = "home"
-	}
 	return *ws
 }
 

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -665,6 +665,7 @@ func TestSpaceLister(t *testing.T) {
 			identityID:            uuid.Must(uuid.NewV4()),
 		},
 	}
+	appStudioTierRolesWSoption := commonproxy.WithAvailableRoles([]string{"admin", "contributor", "maintainer"})
 
 	// create the users before the subtests, so they exist for the duration of the whole test
 	for _, user := range users {
@@ -692,7 +693,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true), *workspace)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true, appStudioTierRolesWSoption), *workspace)
 		})
 
 		t.Run("cannot get bus workspace", func(t *testing.T) {
@@ -723,7 +724,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true, appStudioTierRolesWSoption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -732,7 +733,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSoption), *carWS)
 		})
 	})
 
@@ -755,7 +756,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false, appStudioTierRolesWSoption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -764,7 +765,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSoption), *carWS)
 		})
 
 		t.Run("can get bicycle workspace", func(t *testing.T) {
@@ -773,7 +774,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true), *bicycleWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true, appStudioTierRolesWSoption), *bicycleWS)
 		})
 	})
 
@@ -1055,11 +1056,11 @@ func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha
 	t.Errorf("expected workspace %s not found", expectedWorkspace.Name)
 }
 
-func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *proxyUser, isHomeWorkspace bool) toolchainv1alpha1.Workspace {
+func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *proxyUser, isHomeWorkspace bool, additionalWSOptions ...commonproxy.WorkspaceOption) toolchainv1alpha1.Workspace {
 	space, err := hostAwait.WaitForSpace(t, user.compliantUsername, wait.UntilSpaceHasAnyTargetClusterSet(), wait.UntilSpaceHasAnyTierNameSet())
 	require.NoError(t, err)
 
-	ws := commonproxy.NewWorkspace(user.compliantUsername,
+	commonWSoptions := []commonproxy.WorkspaceOption{
 		commonproxy.WithObjectMetaFrom(space.ObjectMeta),
 		commonproxy.WithNamespaces([]toolchainv1alpha1.SpaceNamespace{
 			{
@@ -1069,6 +1070,9 @@ func expectedWorkspaceFor(t *testing.T, hostAwait *wait.HostAwaitility, user *pr
 		}),
 		commonproxy.WithOwner(user.signup.Name),
 		commonproxy.WithRole("admin"),
+	}
+	ws := commonproxy.NewWorkspace(user.compliantUsername,
+		append(commonWSoptions, additionalWSOptions...)...,
 	)
 	// if the user is the same as the one who created the workspace, then expect type should be "home"
 	if isHomeWorkspace {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -665,7 +665,7 @@ func TestSpaceLister(t *testing.T) {
 			identityID:            uuid.Must(uuid.NewV4()),
 		},
 	}
-	appStudioTierRolesWSoption := commonproxy.WithAvailableRoles([]string{"admin", "contributor", "maintainer"})
+	appStudioTierRolesWSOption := commonproxy.WithAvailableRoles([]string{"admin", "contributor", "maintainer"})
 
 	// create the users before the subtests, so they exist for the duration of the whole test
 	for _, user := range users {
@@ -693,7 +693,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true, appStudioTierRolesWSoption), *workspace)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], true, appStudioTierRolesWSOption), *workspace)
 		})
 
 		t.Run("cannot get bus workspace", func(t *testing.T) {
@@ -724,7 +724,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true, appStudioTierRolesWSoption), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], true, appStudioTierRolesWSOption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -733,7 +733,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSoption), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSOption), *carWS)
 		})
 	})
 
@@ -756,7 +756,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false, appStudioTierRolesWSoption), *busWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bus"], false, appStudioTierRolesWSOption), *busWS)
 		})
 
 		t.Run("can get car workspace", func(t *testing.T) {
@@ -765,7 +765,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSoption), *carWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["car"], false, appStudioTierRolesWSOption), *carWS)
 		})
 
 		t.Run("can get bicycle workspace", func(t *testing.T) {
@@ -774,7 +774,7 @@ func TestSpaceLister(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true, appStudioTierRolesWSoption), *bicycleWS)
+			verifyHasExpectedWorkspace(t, expectedWorkspaceFor(t, awaitilities.Host(), users["bicycle"], true, appStudioTierRolesWSOption), *bicycleWS)
 		})
 	})
 


### PR DESCRIPTION
Update proxy (spacelister) e2e tests to check for the newly added `workspace.Status.AvailableRoles` field. The field should contain the Space roles for the NSTemplateTier. 
For example in the case of `appstudio` tier the list should be: `admin, maintainer, contributor`

Jira story: https://issues.redhat.com/browse/ASC-410

Related PRs:
- https://github.com/codeready-toolchain/toolchain-common/pull/327

Paired with: 
- https://github.com/codeready-toolchain/registration-service/pull/348