### PR TITLE
CRC console doesn't contain .apps. substring

### DIFF
--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -805,8 +805,8 @@ func assertGetSignupReturnsNotFound(t *testing.T, await wait.Awaitilities, beare
 }
 
 func assertRHODSClusterURL(t *testing.T, memberAwait *wait.MemberAwaitility, response map[string]interface{}) {
-	require.Containsf(t, memberAwait.GetConsoleURL(t), ".apps.", "expected to find .apps. in the console URL %s", memberAwait.GetConsoleURL(t))
-	index := strings.Index(memberAwait.GetConsoleURL(t), ".apps.")
+	require.Containsf(t, memberAwait.GetConsoleURL(t), ".apps", "expected to find .apps in the console URL %s", memberAwait.GetConsoleURL(t))
+	index := strings.Index(memberAwait.GetConsoleURL(t), ".apps")
 	appsURL := memberAwait.GetConsoleURL(t)[index:]
 	assert.Equal(t, fmt.Sprintf("https://%s%s", "rhods-dashboard-redhat-ods-applications", appsURL), response["rhodsMemberURL"])
 }


### PR DESCRIPTION
the crc console URL is:
https://console-openshift-console.apps-crc.testing/

paired PR https://github.com/codeready-toolchain/registration-service/pull/349