### PR TITLE
Update documentation for usage with quay.io

### DIFF
--- a/quay.adoc
+++ b/quay.adoc
@@ -13,6 +13,7 @@ There is a set of images that is built and pushed to quay repositories while dep
  * https://quay.io/repository/<quay-username>/host-operator-bundle
  * https://quay.io/repository/<quay-username>/host-operator-index
  * https://quay.io/repository/<quay-username>/member-operator
+ * https://quay.io/repository/<quay-username>/member-operator-console-plugin
  * https://quay.io/repository/<quay-username>/member-operator-webhook
  * https://quay.io/repository/<quay-username>/member-operator-bundle
  * https://quay.io/repository/<quay-username>/member-operator-index
@@ -26,6 +27,7 @@ All aforementioned repositories has to be public, so make sure that the visibili
 * https://quay.io/repository/<quay-username>/host-operator-bundle?tab=settings
 * https://quay.io/repository/<quay-username>/host-operator-index?tab=settings
 * https://quay.io/repository/<quay-username>/member-operator?tab=settings
+* https://quay.io/repository/<quay-username>/member-operator-console-plugin?tab=settings
 * https://quay.io/repository/<quay-username>/member-operator-webhook?tab=settings
 * https://quay.io/repository/<quay-username>/member-operator-bundle?tab=settings
 * https://quay.io/repository/<quay-username>/member-operator-index?tab=settings


### PR DESCRIPTION
If a user intends to run end-to-end tests using quay as a repository, then the image `quay.io/<quay-username>/member-operator-console-plugin` needs to be publicly available.  Update the documentation for quay to reflect this.