### PR TITLE
fix: enable sbr webhook check

### DIFF
--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -2318,29 +2318,27 @@ func (a *MemberAwaitility) verifyValidatingWebhookConfig(t *testing.T, ca []byte
 	assert.Equal(t, []string{"checlusters"}, checlusterRule.Resources)
 	assert.Equal(t, admv1.NamespacedScope, *checlusterRule.Scope)
 
-	// TODO: uncomment once: https://github.com/codeready-toolchain/member-operator/pull/470
-	// is merged.
-	//spacebindingrequestWebhook := actualValWbhConf.Webhooks[2]
-	//assert.Equal(t, "users.spacebindingrequests.webhook.sandbox", spacebindingrequestWebhook.Name)
-	//assert.Equal(t, []string{"v1"}, spacebindingrequestWebhook.AdmissionReviewVersions)
-	//assert.Equal(t, admv1.SideEffectClassNone, *spacebindingrequestWebhook.SideEffects)
-	//assert.Equal(t, int32(5), *spacebindingrequestWebhook.TimeoutSeconds)
-	//assert.Equal(t, admv1.Ignore, *spacebindingrequestWebhook.FailurePolicy)
-	//assert.Equal(t, admv1.Equivalent, *spacebindingrequestWebhook.MatchPolicy)
-	//assert.Equal(t, codereadyToolchainProviderLabel, spacebindingrequestWebhook.NamespaceSelector.MatchLabels)
-	//assert.Equal(t, ca, spacebindingrequestWebhook.ClientConfig.CABundle)
-	//assert.Equal(t, "member-operator-webhook", spacebindingrequestWebhook.ClientConfig.Service.Name)
-	//assert.Equal(t, a.Namespace, spacebindingrequestWebhook.ClientConfig.Service.Namespace)
-	//assert.Equal(t, "/validate-spacebindingrequests", *spacebindingrequestWebhook.ClientConfig.Service.Path)
-	//assert.Equal(t, int32(443), *spacebindingrequestWebhook.ClientConfig.Service.Port)
-	//require.Len(t, spacebindingrequestWebhook.Rules, 1)
-	//
-	//spacebindingrequestRule := spacebindingrequestWebhook.Rules[0]
-	//assert.Equal(t, []admv1.OperationType{admv1.Create, admv1.Update}, spacebindingrequestRule.Operations)
-	//assert.Equal(t, []string{"toolchain.dev.openshift.com"}, spacebindingrequestRule.APIGroups)
-	//assert.Equal(t, []string{"v1alpha1"}, spacebindingrequestRule.APIVersions)
-	//assert.Equal(t, []string{"spacebindingrequests"}, spacebindingrequestRule.Resources)
-	//assert.Equal(t, admv1.NamespacedScope, *spacebindingrequestRule.Scope)
+	spacebindingrequestWebhook := actualValWbhConf.Webhooks[2]
+	assert.Equal(t, "users.spacebindingrequests.webhook.sandbox", spacebindingrequestWebhook.Name)
+	assert.Equal(t, []string{"v1"}, spacebindingrequestWebhook.AdmissionReviewVersions)
+	assert.Equal(t, admv1.SideEffectClassNone, *spacebindingrequestWebhook.SideEffects)
+	assert.Equal(t, int32(5), *spacebindingrequestWebhook.TimeoutSeconds)
+	assert.Equal(t, admv1.Fail, *spacebindingrequestWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Equivalent, *spacebindingrequestWebhook.MatchPolicy)
+	assert.Equal(t, codereadyToolchainProviderLabel, spacebindingrequestWebhook.NamespaceSelector.MatchLabels)
+	assert.Equal(t, ca, spacebindingrequestWebhook.ClientConfig.CABundle)
+	assert.Equal(t, "member-operator-webhook", spacebindingrequestWebhook.ClientConfig.Service.Name)
+	assert.Equal(t, a.Namespace, spacebindingrequestWebhook.ClientConfig.Service.Namespace)
+	assert.Equal(t, "/validate-spacebindingrequests", *spacebindingrequestWebhook.ClientConfig.Service.Path)
+	assert.Equal(t, int32(443), *spacebindingrequestWebhook.ClientConfig.Service.Port)
+	require.Len(t, spacebindingrequestWebhook.Rules, 1)
+
+	spacebindingrequestRule := spacebindingrequestWebhook.Rules[0]
+	assert.Equal(t, []admv1.OperationType{admv1.Create, admv1.Update}, spacebindingrequestRule.Operations)
+	assert.Equal(t, []string{"toolchain.dev.openshift.com"}, spacebindingrequestRule.APIGroups)
+	assert.Equal(t, []string{"v1alpha1"}, spacebindingrequestRule.APIVersions)
+	assert.Equal(t, []string{"spacebindingrequests"}, spacebindingrequestRule.Resources)
+	assert.Equal(t, admv1.NamespacedScope, *spacebindingrequestRule.Scope)
 
 }
 

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -2323,7 +2323,7 @@ func (a *MemberAwaitility) verifyValidatingWebhookConfig(t *testing.T, ca []byte
 	assert.Equal(t, []string{"v1"}, spacebindingrequestWebhook.AdmissionReviewVersions)
 	assert.Equal(t, admv1.SideEffectClassNone, *spacebindingrequestWebhook.SideEffects)
 	assert.Equal(t, int32(5), *spacebindingrequestWebhook.TimeoutSeconds)
-	assert.Equal(t, admv1.Fail, *spacebindingrequestWebhook.FailurePolicy)
+	assert.Equal(t, admv1.Ignore, *spacebindingrequestWebhook.FailurePolicy)
 	assert.Equal(t, admv1.Equivalent, *spacebindingrequestWebhook.MatchPolicy)
 	assert.Equal(t, codereadyToolchainProviderLabel, spacebindingrequestWebhook.NamespaceSelector.MatchLabels)
 	assert.Equal(t, ca, spacebindingrequestWebhook.ClientConfig.CABundle)


### PR DESCRIPTION
Dammit^2 🤦‍♂️ 
 
I just realized that I have to do it in two steps, since the deployed webhook from master branch now has `FailurePolicy=Ignore`. 
```
.....
e2e/test/migration/setup/setup_migration_test.go:12
        	Error:      	Not equal: 
        	            	expected: "Fail"
        	            	actual  : "Ignore"
        	            	
```

so:

- first enable the test
- then merge this which changes the policy from `Ignore` to `Fail`: https://github.com/codeready-toolchain/toolchain-e2e/pull/810