### PR TITLE
feat: add usernames endpoint in reg-service

### DIFF
--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -239,7 +239,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 
 		// when
 		// Create UserSignup with verification required
-		InvokeEndpoint(t, "POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
+		NewHTTPRequest(t).InvokeEndpoint("POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
 
 		// Wait for the UserSignup to be created and in verification required status
 		userSignup, err = hostAwait.WaitForUserSignup(t, identity0.Username,
@@ -260,7 +260,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 		t.Run("no change to metric when verification initiated", func(t *testing.T) {
 			// when
 			// Initiate the verification process
-			InvokeEndpoint(t, "PUT", route+"/api/v1/signup/verification", token0,
+			NewHTTPRequest(t).InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token0,
 				`{ "country_code":"+61", "phone_number":"408999999" }`, http.StatusNoContent)
 
 			// then
@@ -271,7 +271,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 			verificationCode := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
 			require.NotEmpty(t, verificationCode)
 			// Attempt to verify with an incorrect verification code
-			InvokeEndpoint(t, "GET", route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
+			NewHTTPRequest(t).InvokeEndpoint("GET", route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
 			hostAwait.WaitForMetricDelta(t, wait.UserSignupVerificationRequiredMetric, 1) // no change after verification initiated
 		})
 
@@ -293,7 +293,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 
 		t.Run("metric incremented when user reactivated", func(t *testing.T) {
 			// when reactivating the user
-			InvokeEndpoint(t, "POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
+			NewHTTPRequest(t).InvokeEndpoint("POST", route+"/api/v1/signup", token0, "", http.StatusAccepted)
 			userSignup, err = hostAwait.WaitForUserSignup(t, identity0.Username,
 				wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.VerificationRequired(), wait.ApprovedDeactivated())...),
 				wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueNotReady))

--- a/testsupport/regsvc.go
+++ b/testsupport/regsvc.go
@@ -10,38 +10,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type HTTPRequest struct {
+	body []byte
+	t    *testing.T
+}
+
+func NewHTTPRequest(t *testing.T) *HTTPRequest {
+	return &HTTPRequest{
+		t: t,
+	}
+}
+
 // InvokeEndpoint invokes given http URL and returns the json body response
-func InvokeEndpoint(t *testing.T, method, path, authToken, requestBody string, requiredStatus int) map[string]interface{} {
+func (h HTTPRequest) InvokeEndpoint(method, path, authToken, requestBody string, requiredStatus int) *HTTPRequest {
 	var reqBody io.Reader
-	t.Logf("invoking http request: %s %s", method, path)
+	h.t.Logf("invoking http request: %s %s", method, path)
 	if requestBody != "" {
-		t.Logf("request body: %s", requestBody)
+		h.t.Logf("request body: %s", requestBody)
 		reqBody = strings.NewReader(requestBody)
 	}
 	req, err := http.NewRequest(method, path, reqBody)
-	require.NoError(t, err)
+	require.NoError(h.t, err)
 	req.Header.Set("Authorization", "Bearer "+authToken)
 	req.Header.Set("content-type", "application/json")
 	resp, err := httpClient.Do(req) // nolint:bodyclose // see `defer.Close(...)`
-	t.Logf("response status code: %d", resp.StatusCode)
-	require.NoError(t, err)
-	defer Close(t, resp)
+	h.t.Logf("response status code: %d", resp.StatusCode)
+	require.NoError(h.t, err)
+	defer Close(h.t, resp)
 
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.NotNil(t, body)
-	require.Equal(t, requiredStatus, resp.StatusCode, "unexpected response status with body: %s", body)
+	h.body, err = io.ReadAll(resp.Body)
+	require.NoError(h.t, err)
+	require.NotNil(h.t, h.body)
+	require.Equal(h.t, requiredStatus, resp.StatusCode, "unexpected response status with body: %s", h.body)
+	return &h
+}
 
+// UnmarshalMap unmarshal the response body into a map type
+func (h HTTPRequest) UnmarshalMap() map[string]interface{} {
 	mp := make(map[string]interface{})
-	if len(body) > 0 {
-		err = json.Unmarshal(body, &mp)
-		require.NoError(t, err)
+	if len(h.body) > 0 {
+		err := json.Unmarshal(h.body, &mp)
+		require.NoError(h.t, err)
 	}
 	return mp
 }
 
-// ParseResponse parses a given http response body
-func ParseResponse(t *testing.T, responseBody map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
+// UnmarshalSlice unmarshal the response body into a slice of maps
+func (h HTTPRequest) UnmarshalSlice() []map[string]interface{} {
+	var response []map[string]interface{}
+	if len(h.body) > 0 {
+		err := json.Unmarshal(h.body, &response)
+		require.NoError(h.t, err)
+	}
+	return response
+}
+
+// ParseSignupResponse parses a given http response body according to the Signup type
+func ParseSignupResponse(t *testing.T, responseBody map[string]interface{}) (map[string]interface{}, map[string]interface{}) {
 	// Check that the response looks fine
 	status, ok := responseBody["status"].(map[string]interface{})
 	require.True(t, ok)


### PR DESCRIPTION
Add e2e tests for the new registration service endpoint `GET /usernames/:username`.

Paired with: https://github.com/codeready-toolchain/registration-service/pull/361

Jira: https://issues.redhat.com/browse/ASC-413