### PR TITLE
add migration assertions for space requests

### DIFF
--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -101,7 +101,7 @@ func (r *SetupMigrationRunner) createAndWaitForSpace(t *testing.T, name, tierNam
 func (r *SetupMigrationRunner) prepareProvisionedSubspace(t *testing.T) {
 	hostAwait := r.Awaitilities.Host()
 	memberAwait := r.Awaitilities.Member2()
-	r.createAndWaitForSpace(t, ProvisionedParentSpace, "base", memberAwait)
+	r.createAndWaitForSpace(t, ProvisionedParentSpace, "appstudio-env", memberAwait)
 	memberCluster, found, err := hostAwait.GetToolchainCluster(t, cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(t, err)
 	require.True(t, found)
@@ -114,7 +114,7 @@ func (r *SetupMigrationRunner) prepareProvisionedSubspace(t *testing.T) {
 		ProvisionedParentSpace,
 		tsspace.WithName(ProvisionedSpaceRequest),
 		tsspace.WithSpecTargetClusterRoles(srClusterRoles),
-		tsspace.WithSpecTierName("base"))
+		tsspace.WithSpecTierName("appstudio-env"))
 
 	subSpace, err := hostAwait.WaitForSubSpace(t,
 		spaceRequest.GetName(),

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -124,7 +124,7 @@ func (r *SetupMigrationRunner) prepareProvisionedSubspace(t *testing.T) {
 		wait.UntilSpaceHasAnyProvisionedNamespaces())
 	require.NoError(t, err)
 
-	spaceRequest, err = memberAwait.WaitForSpaceRequest(t,
+	_, err = memberAwait.WaitForSpaceRequest(t,
 		types.NamespacedName{
 			Namespace: spaceRequest.Namespace,
 			Name:      spaceRequest.Name,

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -138,7 +138,7 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 		subSpaceNamespace,
 		parentSpace.GetName(),
 		wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-		wait.UntilSpaceHasTier("base"),
+		wait.UntilSpaceHasTier("appstudio-env"),
 		wait.UntilSpaceHasAnyProvisionedNamespaces())
 	require.NoError(t, err)
 
@@ -154,10 +154,10 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	require.NoError(t, err)
 	VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
 
-	cleanup.AddCleanTasks(t, awaitilities.Host().Client, subSpace)
-	cleanup.AddCleanTasks(t, awaitilities.Member2().Client, spaceRequest)
-	cleanup.AddCleanTasks(t, awaitilities.Host().Client, parentSpace)
-	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
+	cleanup.AddCleanTasks(t, hostAwait.Client, subSpace)
+	cleanup.AddCleanTasks(t, memberAwait.Client, spaceRequest)
+	cleanup.AddCleanTasks(t, hostAwait.Client, parentSpace)
+	cleanup.AddCleanTasks(t, hostAwait.Client, userSignupForSpace)
 }
 
 func verifyProvisionedSignup(t *testing.T, awaitilities wait.Awaitilities, signup *toolchainv1alpha1.UserSignup) {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -147,9 +147,9 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 			Namespace: subSpaceNamespace,
 			Name:      migration.ProvisionedSpaceRequest,
 		},
-		wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
 		wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
 		wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
+		wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
 	)
 	require.NoError(t, err)
 	VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -131,10 +131,11 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	memberCluster, found, err := hostAwait.GetToolchainCluster(t, cluster.Member, memberAwait.Namespace, nil)
 	require.NoError(t, err)
 	require.True(t, found)
+	subSpaceNamespace := GetDefaultNamespace(parentSpace.Status.ProvisionedNamespaces)
 
 	subSpace, err := awaitilities.Host().WaitForSubSpace(t,
 		migration.ProvisionedSpaceRequest,
-		memberAwait.Namespace,
+		subSpaceNamespace,
 		parentSpace.GetName(),
 		wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
 		wait.UntilSpaceHasTier("base"),
@@ -143,7 +144,7 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 
 	spaceRequest, err := memberAwait.WaitForSpaceRequest(t,
 		types.NamespacedName{
-			Namespace: memberAwait.Namespace,
+			Namespace: subSpaceNamespace,
 			Name:      migration.ProvisionedSpaceRequest,
 		},
 		wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
@@ -154,7 +155,7 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
 
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, subSpace)
-	cleanup.AddCleanTasks(t, awaitilities.Member1().Client, spaceRequest)
+	cleanup.AddCleanTasks(t, awaitilities.Member2().Client, spaceRequest)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, parentSpace)
 	cleanup.AddCleanTasks(t, awaitilities.Host().Client, userSignupForSpace)
 }

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -154,8 +154,6 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 	require.NoError(t, err)
 	VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
 
-	cleanup.AddCleanTasks(t, hostAwait.Client, subSpace)
-	cleanup.AddCleanTasks(t, memberAwait.Client, spaceRequest)
 	cleanup.AddCleanTasks(t, hostAwait.Client, parentSpace)
 	cleanup.AddCleanTasks(t, hostAwait.Client, userSignupForSpace)
 }

--- a/testsupport/space/spacerequest.go
+++ b/testsupport/space/spacerequest.go
@@ -66,25 +66,6 @@ func CreateSpaceRequest(t *testing.T, awaitilities wait.Awaitilities, memberName
 	return spaceRequest, parentSpace
 }
 
-func CreateSpaceRequestForParentSpace(t *testing.T, awaitilities wait.Awaitilities, memberName, parent string, opts ...SpaceRequestOption) *toolchainv1alpha1.SpaceRequest {
-	memberAwait, err := awaitilities.Member(memberName)
-	require.NoError(t, err)
-
-	// wait for the namespace to be provisioned since we will be creating the spacerequest into it.
-	parentSpace, err := awaitilities.Host().WaitForSpace(t, parent, wait.UntilSpaceHasAnyProvisionedNamespaces())
-	require.NoError(t, err)
-
-	// create the space request in the "default" namespace provisioned by the parentSpace
-	namespace := GetDefaultNamespace(parentSpace.Status.ProvisionedNamespaces)
-	spaceRequest := NewSpaceRequest(t, append(opts, WithNamespace(namespace))...)
-	require.NotEmpty(t, spaceRequest)
-
-	// don't cleanup the new spacerequest, since we need it for migration testing
-	err = memberAwait.Create(t, spaceRequest)
-	require.NoError(t, err)
-	return spaceRequest
-}
-
 // NewSpaceRequest initializes a new SpaceRequest object with the given options.
 // By default sets appstudio tier and tenant roles for the cluster to use
 func NewSpaceRequest(t *testing.T, opts ...SpaceRequestOption) *toolchainv1alpha1.SpaceRequest {

--- a/testsupport/space/spacerequest.go
+++ b/testsupport/space/spacerequest.go
@@ -43,6 +43,7 @@ func WithNamespace(namespace string) SpaceRequestOption {
 
 func WithName(name string) SpaceRequestOption {
 	return func(s *toolchainv1alpha1.SpaceRequest) {
+		s.ObjectMeta.GenerateName = ""
 		s.ObjectMeta.Name = name
 	}
 }
@@ -75,10 +76,10 @@ func CreateSpaceRequestForParentSpace(t *testing.T, awaitilities wait.Awaitiliti
 
 	// create the space request in the "default" namespace provisioned by the parentSpace
 	namespace := GetDefaultNamespace(parentSpace.Status.ProvisionedNamespaces)
-	t.Logf("creating space request in namespace %s", namespace)
 	spaceRequest := NewSpaceRequest(t, append(opts, WithNamespace(namespace))...)
 	require.NotEmpty(t, spaceRequest)
 
+	// don't cleanup the new spacerequest, since we need it for migration testing
 	err = memberAwait.Create(t, spaceRequest)
 	require.NoError(t, err)
 	return spaceRequest


### PR DESCRIPTION
Make sure that existing spaces don't fall over during migrations.

See also: https://github.com/codeready-toolchain/host-operator/pull/891