### PR TITLE
Fix issue for appstudio environment

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -316,7 +316,7 @@ create-member1:
 	@echo "Preparing namespace for member operator: $(MEMBER_NS)..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS}
 	-oc label ns --overwrite=true ${MEMBER_NS} app=member-operator
-	oc apply -f deploy/member-operator/${ENVIRONMENT}/ -n ${MEMBER_NS}
+	oc apply -f deploy/member-operator/${ENVIRONMENT}/ -n ${MEMBER_NS} || true
 
 .PHONY: create-member2
 create-member2:
@@ -324,7 +324,7 @@ ifeq ($(SECOND_MEMBER_MODE),true)
 	@echo "Preparing namespace for second member operator: ${MEMBER_NS_2}..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS_2}
 	-oc label ns --overwrite=true ${MEMBER_NS_2} app=member-operator
-	oc apply -f deploy/member-operator/${ENVIRONMENT}/ -n ${MEMBER_NS_2}
+	oc apply -f deploy/member-operator/${ENVIRONMENT}/ -n ${MEMBER_NS_2} || true
 endif
 
 .PHONY: deploy-host


### PR DESCRIPTION
Should fix the appstudio e2e issues:
```
Installing the Toolchain (Sandbox) operators in dev environment:
Cloning into '/tmp/toolchain-e2e'...
make[1]: Entering directory '/tmp/toolchain-e2e'
which: no yamllint in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/cli:/tmp/bin)
make deploy-e2e MEMBER_NS=toolchain-member-operator SECOND_MEMBER_MODE=false HOST_NS=toolchain-host-operator REGISTRATION_SERVICE_NS=toolchain-host-operator ENVIRONMENT=appstudio-dev E2E_TEST_EXECUTION=false IS_OSD= DEPLOY_LATEST=true
make[2]: Entering directory '/tmp/toolchain-e2e'
which: no yamllint in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/cli:/tmp/bin)
Preparing namespace for host operator toolchain-host-operator...
make create-project PROJECT_NAME=toolchain-host-operator
make[3]: Entering directory '/tmp/toolchain-e2e'
which: no yamllint in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/cli:/tmp/bin)
Already on project "toolchain-host-operator" on server "https://api.rhtap-ocp-4-12-amd64-5pcng.ci.stonesoupengineering.com:6443".
adding network policies in toolchain-host-operator namespace
networkpolicy.networking.k8s.io/allow-all-ingress created
make[3]: Leaving directory '/tmp/toolchain-e2e'
oc label ns --overwrite=true toolchain-host-operator app=host-operator
namespace/toolchain-host-operator labeled
Preparing namespace for member operator: toolchain-member-operator...
make create-project PROJECT_NAME=toolchain-member-operator
make[3]: Entering directory '/tmp/toolchain-e2e'
which: no yamllint in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/cli:/tmp/bin)
Already on project "toolchain-member-operator" on server "https://api.rhtap-ocp-4-12-amd64-5pcng.ci.stonesoupengineering.com:6443".
adding network policies in toolchain-member-operator namespace
networkpolicy.networking.k8s.io/allow-all-ingress created
make[3]: Leaving directory '/tmp/toolchain-e2e'
oc label ns --overwrite=true toolchain-member-operator app=member-operator
namespace/toolchain-member-operator labeled
oc apply -f deploy/member-operator/appstudio-dev/ -n toolchain-member-operator
error: the path "deploy/member-operator/appstudio-dev/" does not exist
make[2]: *** [make/test.mk:319: create-member1] Error 1
make[2]: Leaving directory '/tmp/toolchain-e2e'
make[1]: *** [make/dev.mk:27: deploy-e2e-to-dev-namespaces] Error 2
make[1]: Leaving directory '/tmp/toolchain-e2e'
```

Full logs: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/redhat-appstudio_application-service/411/pull-ci-redhat-appstudio-application-service-main-application-service-e2e/1724165104326414336/build-log.txt