### PR TITLE
parallelize nstemplatetier test

### DIFF
--- a/test/e2e/default_tier_test.go
+++ b/test/e2e/default_tier_test.go
@@ -1,0 +1,41 @@
+package e2e
+
+import (
+	"testing"
+
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+)
+
+func TestSetDefaultTier(t *testing.T) {
+	// given
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member1()
+
+	t.Run("original default tier", func(t *testing.T) {
+		// Create and approve a new user that should be provisioned to the base tier
+		NewSignupRequest(awaitilities).
+			Username("defaulttier").
+			ManuallyApprove().
+			TargetCluster(memberAwait).
+			EnsureMUR().
+			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
+			Execute(t).
+			Resources()
+	})
+
+	t.Run("changed default tier configuration", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
+		// Create and approve a new user that should be provisioned to the advanced tier
+		NewSignupRequest(awaitilities).
+			Username("defaulttierchanged").
+			ManuallyApprove().
+			TargetCluster(memberAwait).
+			EnsureMUR().
+			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
+			Execute(t).
+			Resources()
+	})
+}

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -1,15 +1,15 @@
-package e2e
+package parallel
 
 import (
 	"context"
 	"fmt"
-	"github.com/gofrs/uuid"
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
-	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	testspace "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
@@ -29,14 +29,13 @@ const (
 )
 
 func TestNSTemplateTiers(t *testing.T) {
+	t.Parallel()
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 
-	// Create and approve "testingtiers" signups
-	testingTiersName := "testingtiers"
 	testingtiers, _ := NewSignupRequest(awaitilities).
-		Username(testingTiersName).
+		Username("testnstemplatetiers").
 		ManuallyApprove().
 		TargetCluster(awaitilities.Member1()).
 		EnsureMUR().
@@ -67,9 +66,9 @@ func TestNSTemplateTiers(t *testing.T) {
 			UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
 		require.NoError(t, err)
 
-		t.Run(fmt.Sprintf("promote %s space to %s tier", testingTiersName, tierToCheck), func(t *testing.T) {
+		t.Run(fmt.Sprintf("promote %s space to %s tier", testingtiers.Status.CompliantUsername, tierToCheck), func(t *testing.T) {
 			// when
-			tiers.MoveSpaceToTier(t, hostAwait, testingTiersName, tierToCheck)
+			tiers.MoveSpaceToTier(t, hostAwait, testingtiers.Status.CompliantUsername, tierToCheck)
 
 			// then
 			VerifyResourcesProvisionedForSignup(t, awaitilities, testingtiers, "deactivate30", tierToCheck) // deactivate30 is the default UserTier
@@ -77,39 +76,8 @@ func TestNSTemplateTiers(t *testing.T) {
 	}
 }
 
-func TestSetDefaultTier(t *testing.T) {
-	// given
-	awaitilities := WaitForDeployments(t)
-	hostAwait := awaitilities.Host()
-	memberAwait := awaitilities.Member1()
-
-	t.Run("original default tier", func(t *testing.T) {
-		// Create and approve a new user that should be provisioned to the base tier
-		NewSignupRequest(awaitilities).
-			Username("defaulttier").
-			ManuallyApprove().
-			TargetCluster(memberAwait).
-			EnsureMUR().
-			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources()
-	})
-
-	t.Run("changed default tier configuration", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
-		// Create and approve a new user that should be provisioned to the advanced tier
-		NewSignupRequest(awaitilities).
-			Username("defaulttierchanged").
-			ManuallyApprove().
-			TargetCluster(memberAwait).
-			EnsureMUR().
-			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources()
-	})
-}
-
 func TestUpdateNSTemplateTier(t *testing.T) {
+	t.Parallel()
 	// in this test, we have 2 groups of users, configured with their own tier (both using the "base" tier templates)
 	// then, the first tier is updated with the "advanced" templates, whereas the second one is updated using the "baseextendedidling" templates
 	// finally, all user namespaces are verified.
@@ -178,6 +146,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 }
 
 func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
+	t.Parallel()
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	t.Run("test reset deactivating state when promoting user", func(t *testing.T) {
@@ -289,6 +258,7 @@ func verifyResourceUpdatesForSpaces(t *testing.T, hostAwait *HostAwaitility, tar
 }
 
 func TestTierTemplates(t *testing.T) {
+	t.Parallel()
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()


### PR DESCRIPTION
* extract one test that requires changes of the global config
* move the rest of the nstemplatetier_test.go into parallel test suite and add `t.Parallel()` to the tests it in