### PR TITLE
extract test verifying skipped creation of user and identity

### DIFF
--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -23,7 +23,7 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 
-	// member cluster configured to skip user creation to mimic stonesoup configuration where user & identity resources are not created
+	// member cluster configured to skip user creation to mimic appstudio configuration where user & identity resources are not created
 	memberConfigurationWithSkipUserCreation := testconfig.ModifyMemberOperatorConfigObj(memberAwait.GetMemberOperatorConfig(t), testconfig.SkipUserCreation(true))
 	// configure default space tier to appstudio and apply the member configuration
 	hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"), testconfig.Members().Default(memberConfigurationWithSkipUserCreation.Spec))

--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -1,0 +1,105 @@
+package e2e
+
+import (
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	identitypkg "github.com/codeready-toolchain/toolchain-common/pkg/identity"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/gofrs/uuid"
+	userv1 "github.com/openshift/api/user/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
+	// given
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
+	memberAwait := awaitilities.Member1()
+
+	// member cluster configured to skip user creation to mimic stonesoup configuration where user & identity resources are not created
+	memberConfigurationWithSkipUserCreation := testconfig.ModifyMemberOperatorConfigObj(memberAwait.GetMemberOperatorConfig(t), testconfig.SkipUserCreation(true))
+	// configure default space tier to appstudio and apply the member configuration
+	hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"), testconfig.Members().Default(memberConfigurationWithSkipUserCreation.Spec))
+
+	username := "nouseridentity"
+	identityID := uuid.Must(uuid.NewV4())
+
+	// create pre-existing user and identity
+	preexistingUser := &userv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: username,
+		},
+		Identities: []string{
+			identitypkg.NewIdentityNamingStandard(identityID.String(), "rhd").IdentityName(),
+		},
+	}
+	require.NoError(t, memberAwait.CreateWithCleanup(t, preexistingUser))
+
+	preexistingIdentity := &userv1.Identity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: identitypkg.NewIdentityNamingStandard(identityID.String(), "rhd").IdentityName(),
+		},
+		ProviderName:     "rhd",
+		ProviderUserName: username,
+		User: corev1.ObjectReference{
+			Name: preexistingUser.Name,
+			UID:  preexistingUser.UID,
+		},
+	}
+	require.NoError(t, memberAwait.CreateWithCleanup(t, preexistingIdentity))
+
+	// Create and approve signup
+	signup, _ := NewSignupRequest(awaitilities).
+		Username(username).
+		IdentityID(identityID).
+		ManuallyApprove().
+		TargetCluster(memberAwait).
+		EnsureMUR().
+		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
+		Execute(t).Resources()
+
+	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
+
+	// preexisting user & identity are still there and not modified
+	// Verify provisioned User
+	user, err := memberAwait.WaitForUser(t, preexistingUser.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, preexistingUser.UID, user.UID)
+	assert.NotEqual(t, toolchainv1alpha1.ProviderLabelValue, user.Labels[toolchainv1alpha1.ProviderLabelKey])
+
+	// Verify provisioned Identity
+	identity, err := memberAwait.WaitForIdentity(t, preexistingIdentity.Name)
+	assert.NoError(t, err)
+	assert.Equal(t, preexistingIdentity.UID, identity.UID)
+	assert.NotEqual(t, toolchainv1alpha1.ProviderLabelValue, identity.Labels[toolchainv1alpha1.ProviderLabelKey])
+
+	t.Run("user and identity stay there when user is deactivated", func(t *testing.T) {
+		// when
+		userSignup, err := hostAwait.UpdateUserSignup(t, signup.Name,
+			func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(us, true)
+			})
+		require.NoError(t, err)
+
+		// Wait until the UserSignup is deactivated
+		_, err = hostAwait.WaitForUserSignup(t, userSignup.Name,
+			wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.ManuallyDeactivated())...))
+		require.NoError(t, err)
+
+		// then
+		// Verify provisioned User
+		_, err = memberAwait.WaitForUser(t, preexistingUser.Name)
+		assert.NoError(t, err)
+
+		// Verify provisioned Identity
+		_, err = memberAwait.WaitForIdentity(t, preexistingIdentity.Name)
+		assert.NoError(t, err)
+	})
+}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -18,21 +18,19 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	identitypkg "github.com/codeready-toolchain/toolchain-common/pkg/identity"
 	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
-	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	testspace "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	appstudiov1 "github.com/codeready-toolchain/toolchain-e2e/testsupport/appstudio/api/v1alpha1"
 	testsupportspace "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/spacebinding"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/websocket"
-	userv1 "github.com/openshift/api/user/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -143,8 +141,6 @@ func TestProxyFlow(t *testing.T) {
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
 
-	setStoneSoupConfig(t, hostAwait, memberAwait)
-
 	t.Logf("Proxy URL: %s", hostAwait.APIProxyURL)
 
 	waitForWatcher := runWatcher(t, awaitilities)
@@ -174,9 +170,6 @@ func TestProxyFlow(t *testing.T) {
 	for _, user := range users {
 		createAppStudioUser(t, awaitilities, user)
 	}
-
-	// if there is an identity & user resources already present, but don't contain "owner" label, then they shouldn't be deleted
-	preexistingUser, preexistingIdentity := createPreexistingUserAndIdentity(t, *users[0])
 
 	for index, user := range users {
 		t.Run(user.username, func(t *testing.T) {
@@ -567,14 +560,6 @@ func TestProxyFlow(t *testing.T) {
 
 	})
 
-	// preexisting user & identity are still there
-	// Verify provisioned User
-	_, err := memberAwait.WaitForUser(t, preexistingUser.Name)
-	assert.NoError(t, err)
-
-	// Verify provisioned Identity
-	_, err = memberAwait.WaitForIdentity(t, preexistingIdentity.Name)
-	assert.NoError(t, err)
 }
 
 // this test will:
@@ -652,8 +637,6 @@ func TestSpaceLister(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-
-	setStoneSoupConfig(t, hostAwait, memberAwait)
 
 	t.Logf("Proxy URL: %s", hostAwait.APIProxyURL)
 
@@ -951,36 +934,11 @@ func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *pro
 		Execute(t)
 	user.signup, _ = req.Resources()
 	user.token = req.GetToken()
+	tiers.MoveSpaceToTier(t, awaitilities.Host(), user.signup.Status.CompliantUsername, "appstudio")
 	VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "deactivate30", "appstudio")
 	user.compliantUsername = user.signup.Status.CompliantUsername
 	_, err := awaitilities.Host().WaitForMasterUserRecord(t, user.compliantUsername, wait.UntilMasterUserRecordHasCondition(wait.Provisioned()))
 	require.NoError(t, err)
-}
-
-func createPreexistingUserAndIdentity(t *testing.T, user proxyUser) (*userv1.User, *userv1.Identity) {
-	preexistingUser := &userv1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: user.username,
-		},
-		Identities: []string{
-			identitypkg.NewIdentityNamingStandard(user.identityID.String(), "rhd").IdentityName(),
-		},
-	}
-	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(t, preexistingUser))
-
-	preexistingIdentity := &userv1.Identity{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: identitypkg.NewIdentityNamingStandard(user.identityID.String(), "rhd").IdentityName(),
-		},
-		ProviderName:     "rhd",
-		ProviderUserName: user.username,
-		User: corev1.ObjectReference{
-			Name: preexistingUser.Name,
-			UID:  preexistingUser.UID,
-		},
-	}
-	require.NoError(t, user.expectedMemberCluster.CreateWithCleanup(t, preexistingIdentity))
-	return preexistingUser, preexistingIdentity
 }
 
 func newWsWatcher(t *testing.T, user proxyUser, namespace, proxyURL string) *wsWatcher {
@@ -1145,14 +1103,6 @@ func newApplication(applicationName, namespace string) *appstudiov1.Application 
 			DisplayName: fmt.Sprintf("Proxy test for user %s", namespace),
 		},
 	}
-}
-
-// setStoneSoupConfig applies toolchain configuration for stone soup scenarios
-func setStoneSoupConfig(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility) {
-	// member cluster configured to skip user creation to mimic stonesoup configuration where user & identity resources are not created
-	memberConfigurationWithSkipUserCreation := testconfig.ModifyMemberOperatorConfigObj(memberAwait.GetMemberOperatorConfig(t), testconfig.SkipUserCreation(true))
-	// configure default space tier to appstudio
-	hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("appstudio"), testconfig.Members().Default(memberConfigurationWithSkipUserCreation.Spec))
 }
 
 func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha1.Workspace, actualWorkspaces ...toolchainv1alpha1.Workspace) {


### PR DESCRIPTION
prepare proxy_test for moving to the parallel test suite by:
* extracting the logic that verifies skipped creation of user and identity
* removing changes of the ToolchainConfig
* moving the Space CR into the appstudio tier in the proxy test