### PR TITLE
fix: flaky provisioned namespaces assertion with out of date nstemplateset 

### DIFF
--- a/testsupport/space/space.go
+++ b/testsupport/space/space.go
@@ -154,7 +154,7 @@ func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaiti
 	require.NoError(t, err)
 
 	// verify NSTemplateSet with namespace & cluster scoped resources
-	tiers.VerifyNSTemplateSet(t, hostAwait, targetCluster, nsTmplSet, checks)
+	nsTmplSet = tiers.VerifyNSTemplateSet(t, hostAwait, targetCluster, nsTmplSet, checks)
 
 	// Wait for space to have list of provisioned namespaces in Space status.
 	// the expected namespaces for `nsTmplSet.Status.ProvisionedNamespaces` are checked as part of VerifyNSTemplateSet function above.

--- a/testsupport/tiers/nstemplateset.go
+++ b/testsupport/tiers/nstemplateset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet, checks TierChecks) {
+func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwait *wait.MemberAwaitility, nsTmplSet *toolchainv1alpha1.NSTemplateSet, checks TierChecks) *toolchainv1alpha1.NSTemplateSet {
 	t.Logf("verifying NSTemplateSet '%s' and its resources", nsTmplSet.Name)
 	expectedTemplateRefs := checks.GetExpectedTemplateRefs(t, hostAwait)
 
@@ -75,8 +75,9 @@ func VerifyNSTemplateSet(t *testing.T, hostAwait *wait.HostAwaitility, memberAwa
 	// Once all concurrent checks are done, and the expected list of namespaces for the NSTemplateSet is generated,
 	// let's verify NSTemplateSet.Status.ProvisionedNamespaces is populated as expected.
 	expectedProvisionedNamespaces := getExpectedProvisionedNamespaces(actualNamespaces)
-	_, err = memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name, wait.UntilNSTemplateSetHasProvisionedNamespaces(expectedProvisionedNamespaces))
+	nsTmplSet, err = memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name, wait.UntilNSTemplateSetHasProvisionedNamespaces(expectedProvisionedNamespaces))
 	require.NoError(t, err)
+	return nsTmplSet
 }
 
 // getExpectedProvisionedNamespaces returns a list of provisioned namespaces from the given slice containing namespaces of the template tier.


### PR DESCRIPTION
Attempt to fix:
```
  -expected
        +actual
          []v1alpha1.SpaceNamespace{
          	{
        - 		Name: "do-not-override-sa-dev",
        + 		Name: "do-not-override-sa-env",
          		Type: "default",
          	},
        - 	{Name: "do-not-override-sa-stage"},
          }
        
        
    space.go:163: 
        	Error Trace:	/tmp/toolchain-e2e/testsupport/space/space.go:163
        	            				/tmp/toolchain-e2e/testsupport/space/space.go:116
        	            				/tmp/toolchain-e2e/test/e2e/parallel/serviceaccount_test.go:38
```

Seems like the nstemplateset was moved to the new tier , but the namespaces are those from the old one.

build log: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_host-operator/922/pull-ci-codeready-toolchain-host-operator-master-e2e/1726574234618040320/build-log.txt