### PR TITLE
Stop reusing connections

### DIFF
--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -89,5 +89,6 @@ var HTTPClient = &http.Client{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, // nolint:gosec
 		},
+		DisableKeepAlives: true,
 	},
 }


### PR DESCRIPTION
an attempt to fix:
```
=== NAME  TestE2EFlow
    signup_request.go:334: 
        	Error Trace:	/tmp/toolchain-e2e/testsupport/signup_request.go:334
        	            				/tmp/toolchain-e2e/testsupport/signup_request.go:237
        	            				/tmp/toolchain-e2e/testsupport/user_setup.go:39
        	            				/tmp/toolchain-e2e/test/e2e/parallel/e2e_test.go:67
        	Error:      	Received unexpected error:
        	            	Post "https://registration-service-toolchain-host-20211636.apps.ci-op-sktqz02p-93ede.origin-ci-int-aws.dev.rhcloud.com/api/v1/signup": EOF
        	Test:       	TestE2EFlow
```
it's also closer to what we would see in production - each user would use different connection