### PR TITLE
Fix setup create user missing email

### DIFF
--- a/setup/users/create_users.go
+++ b/setup/users/create_users.go
@@ -27,14 +27,14 @@ func Create(cl client.Client, username, hostOperatorNamespace, memberOperatorNam
 			Namespace: hostOperatorNamespace,
 			Name:      username,
 			Labels: map[string]string{
-				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: hash.EncodeString(fmt.Sprintf("%s@test.com", username)),
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: hash.EncodeString(fmt.Sprintf("%s@fake.test", username)),
 			},
 		},
 		Spec: toolchainv1alpha1.UserSignupSpec{
 			TargetCluster: memberClusterName,
 			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
 				PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
-					Email: fmt.Sprintf("%s@test.com", username),
+					Email: fmt.Sprintf("%s@fake.test", username),
 					Sub:   username,
 				},
 				PreferredUsername: username,

--- a/setup/users/create_users.go
+++ b/setup/users/create_users.go
@@ -26,9 +26,6 @@ func Create(cl client.Client, username, hostOperatorNamespace, memberOperatorNam
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: hostOperatorNamespace,
 			Name:      username,
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: fmt.Sprintf("%s@test.com", username),
-			},
 			Labels: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: hash.EncodeString(fmt.Sprintf("%s@test.com", username)),
 			},
@@ -37,7 +34,8 @@ func Create(cl client.Client, username, hostOperatorNamespace, memberOperatorNam
 			TargetCluster: memberClusterName,
 			IdentityClaims: toolchainv1alpha1.IdentityClaimsEmbedded{
 				PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
-					Sub: username,
+					Email: fmt.Sprintf("%s@test.com", username),
+					Sub:   username,
 				},
 				PreferredUsername: username,
 			},


### PR DESCRIPTION
UserSignups created by the setup tool were stuck with error:
```
spec:
  identityClaims:
    email: ''
    preferredUsername: setup-0001
    sub: setup-0001
  states:
    - approved
  targetCluster: [redacted])
  userid: ''
  username: ''
status:
  conditions:
    - lastTransitionTime: '2023-12-20T14:46:24Z'
      message: missing email at usersignup
      reason: MissingUserEmail
      status: 'False'
      type: Complete
```