### PR TITLE
Updating the E2e Test "TestIdlerAndPriorityClass"

### DIFF
--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -71,11 +71,11 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName(t, "test-idler-stage-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(wait.Sent()))
-	require.True(t, errors.IsNotFound(err))
 
 	// Check if notification has been deleted before creating another pod
 	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-dev-idled")
+	require.NoError(t, err)
+	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-stage-idled")
 	require.NoError(t, err)
 
 	// Create another pod and make sure it's deleted.
@@ -247,7 +247,7 @@ func podSpec() corev1.PodSpec {
 		TerminationGracePeriodSeconds: &zero,
 		Containers: []corev1.Container{{
 			Name:    "sleep",
-			Image:   "busybox",
+			Image:   "quay.io/prometheus/busybox:latest",
 			Command: []string{"sleep", "36000"}, // 10 hours
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -14,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,11 +70,11 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-stage-idled")
-	require.True(t, errors.IsNotFound(err))
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-stage-idled")
+	require.NoError(t, err)
 
 	// Check if notification has been deleted before creating another pod
-	err = hostAwait.WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-dev-idled")
+	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-dev-idled")
 	require.NoError(t, err)
 
 	// Create another pod and make sure it's deleted.
@@ -88,8 +87,8 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
 	err = memberAwait.WaitUntilPodDeleted(t, pod.Namespace, pod.Name)
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-dev-idled")
-	require.True(t, errors.IsNotFound(err))
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-dev-idled")
+	require.NoError(t, err)
 
 	// There should not be any pods left in the namespace
 	err = memberAwait.WaitUntilPodsDeleted(t, idler.Name, wait.WithPodLabel("idler", "idler"))

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -14,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,8 +70,8 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToNotBeCreated(t, "test-idler-stage-idled")
-	require.True(t, errors.IsNotFound(err))
+	err = hostAwait.WaitForNotificationToNotBeCreated(t, "test-idler-stage-idled")
+	require.NoError(t, err)
 
 	// Check if notification has been deleted before creating another pod
 	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-dev-idled")
@@ -88,8 +87,8 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
 	err = memberAwait.WaitUntilPodDeleted(t, pod.Namespace, pod.Name)
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToNotBeCreated(t, "test-idler-dev-idled")
-	require.True(t, errors.IsNotFound(err))
+	err = hostAwait.WaitForNotificationToNotBeCreated(t, "test-idler-dev-idled")
+	require.NoError(t, err)
 
 	// There should not be any pods left in the namespace
 	err = memberAwait.WaitUntilPodsDeleted(t, idler.Name, wait.WithPodLabel("idler", "idler"))

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,7 +72,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
 	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-stage-idled")
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	// Check if notification has been deleted before creating another pod
 	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-dev-idled")
@@ -88,7 +89,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	err = memberAwait.WaitUntilPodDeleted(t, pod.Namespace, pod.Name)
 	require.NoError(t, err)
 	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-dev-idled")
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	// There should not be any pods left in the namespace
 	err = memberAwait.WaitUntilPodsDeleted(t, idler.Name, wait.WithPodLabel("idler", "idler"))

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -71,11 +71,11 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-stage-idled")
+	require.True(t, errors.IsNotFound(err))
 
 	// Check if notification has been deleted before creating another pod
-	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-dev-idled")
-	require.NoError(t, err)
-	err = hostAwait.WaitUntilNotificationWithNameDeleted(t, "test-idler-stage-idled")
+	err = hostAwait.WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-dev-idled")
 	require.NoError(t, err)
 
 	// Create another pod and make sure it's deleted.
@@ -88,7 +88,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
 	err = memberAwait.WaitUntilPodDeleted(t, pod.Namespace, pod.Name)
 	require.NoError(t, err)
-	_, err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationWithName(t, "test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(wait.Sent()))
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitUntilNotificationWithNameDeletedOrNotCreated(t, "test-idler-dev-idled")
 	require.True(t, errors.IsNotFound(err))
 
 	// There should not be any pods left in the namespace

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -71,7 +71,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForPods(t, "workloads-noise", len(externalNsPodsNoise), wait.PodRunning(), wait.WithPodLabel("idler", "idler"), wait.WithOriginalPriorityClass())
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-stage-idled")
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToNotBeCreated(t, "test-idler-stage-idled")
 	require.True(t, errors.IsNotFound(err))
 
 	// Check if notification has been deleted before creating another pod
@@ -88,7 +88,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	time.Sleep(time.Duration(2*idler.Spec.TimeoutSeconds) * time.Second)
 	err = memberAwait.WaitUntilPodDeleted(t, pod.Namespace, pod.Name)
 	require.NoError(t, err)
-	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToBeNotCreated(t, "test-idler-dev-idled")
+	err = hostAwait.WithRetryOptions(wait.TimeoutOption(10*time.Second)).WaitForNotificationToNotBeCreated(t, "test-idler-dev-idled")
 	require.True(t, errors.IsNotFound(err))
 
 	// There should not be any pods left in the namespace

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1199,16 +1199,14 @@ func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationN
 // WaitForNotificationToBeNotCreated waits and checks that notification is NOT created.
 func (a *HostAwaitility) WaitForNotificationToBeNotCreated(t *testing.T, notificationName string) error {
 	t.Logf("waiting to check notification with name '%s' is NOT created", notificationName)
-	return wait.Poll(a.RetryInterval, 10*time.Second, func() (done bool, err error) {
+	err := wait.Poll(a.RetryInterval, 10*time.Second, func() (done bool, err error) {
 		notification := &toolchainv1alpha1.Notification{}
 		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, notification); err != nil {
-			if errors.IsNotFound(err) {
-				return true, nil
-			}
 			return false, err
 		}
-		return false, nil
+		return true, err
 	})
+	return err
 }
 
 // WaitUntilNotificationsDeleted waits until the Notification for the given user is deleted (ie, not found)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -19,9 +19,9 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	testutil "github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
-
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
+	goerr "github.com/pkg/errors"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -1216,7 +1216,7 @@ func (a *HostAwaitility) WaitForNotificationToNotBeCreated(t *testing.T, notific
 	if err == nil {
 		return fmt.Errorf("notification '%s' was found, but it was expected to not be created/present: \n %v", notificationName, notification)
 	}
-	if err == wait.ErrWaitTimeout {
+	if goerr.Is(err, wait.ErrWaitTimeout) {
 		return nil
 	}
 	return err

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1175,9 +1175,10 @@ func (a *HostAwaitility) WaitForNotifications(t *testing.T, username, notificati
 // WaitForNotificationWithName waits until there is an expected Notifications available with the provided name and with the notification type and which match the conditions (if provided).
 func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationName, notificationType string, criteria ...NotificationWaitCriterion) (toolchainv1alpha1.Notification, error) {
 	t.Logf("waiting for notification with name '%s'", notificationName)
-	var notification toolchainv1alpha1.Notification
+	notification := &toolchainv1alpha1.Notification{}
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, &notification); err != nil {
+		notification = &toolchainv1alpha1.Notification{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, notification); err != nil {
 			return false, err
 		}
 		if typeFound, found := notification.GetLabels()[toolchainv1alpha1.NotificationTypeLabelKey]; !found {
@@ -1186,13 +1187,13 @@ func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationN
 			return false, fmt.Errorf("notification found with name does not have the expected type")
 		}
 
-		return matchNotificationWaitCriterion([]toolchainv1alpha1.Notification{notification}, criteria...), nil
+		return matchNotificationWaitCriterion([]toolchainv1alpha1.Notification{*notification}, criteria...), nil
 	})
 	// no match found, print the diffs
 	if err != nil {
-		a.printNotificationWaitCriterionDiffs(t, []toolchainv1alpha1.Notification{notification}, criteria...)
+		a.printNotificationWaitCriterionDiffs(t, []toolchainv1alpha1.Notification{*notification}, criteria...)
 	}
-	return notification, err
+	return *notification, err
 }
 
 // WaitUntilNotificationsDeleted waits until the Notification for the given user is deleted (ie, not found)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1196,6 +1196,21 @@ func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationN
 	return *notification, err
 }
 
+// WaitForNotificationToBeNotCreated waits and checks that notification is NOT created.
+func (a *HostAwaitility) WaitForNotificationToBeNotCreated(t *testing.T, notificationName string) error {
+	t.Logf("waiting to check notification with name '%s' is NOT created", notificationName)
+	return wait.Poll(a.RetryInterval, 10*time.Second, func() (done bool, err error) {
+		notification := &toolchainv1alpha1.Notification{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: notificationName, Namespace: a.Namespace}, notification); err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	})
+}
+
 // WaitUntilNotificationsDeleted waits until the Notification for the given user is deleted (ie, not found)
 func (a *HostAwaitility) WaitUntilNotificationsDeleted(t *testing.T, username, notificationType string) error {
 	t.Logf("waiting until notifications have been deleted for user '%s'", username)
@@ -1210,9 +1225,8 @@ func (a *HostAwaitility) WaitUntilNotificationsDeleted(t *testing.T, username, n
 	})
 }
 
-// WaitUntilNotificationWithNameDeletedOrNotCreated  1. waits until the Notification with the given name is deleted (ie, not found) or
-// 2. waits and checks if the notification with the name is not created
-func (a *HostAwaitility) WaitUntilNotificationWithNameDeletedOrNotCreated(t *testing.T, notificationName string) error {
+// WaitUntilNotificationWithNameDeleted waits until the Notification with the given name is deleted (ie, not found)
+func (a *HostAwaitility) WaitUntilNotificationWithNameDeleted(t *testing.T, notificationName string) error {
 	t.Logf("waiting for notification with name '%s' to get deleted", notificationName)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		notification := &toolchainv1alpha1.Notification{}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1197,7 +1197,7 @@ func (a *HostAwaitility) WaitForNotificationWithName(t *testing.T, notificationN
 }
 
 // WaitForNotificationToBeNotCreated waits and checks that notification is NOT created.
-func (a *HostAwaitility) WaitForNotificationToBeNotCreated(t *testing.T, notificationName string) error {
+func (a *HostAwaitility) WaitForNotificationToNotBeCreated(t *testing.T, notificationName string) error {
 	t.Logf("waiting to check notification with name '%s' is NOT created", notificationName)
 	err := wait.Poll(a.RetryInterval, 10*time.Second, func() (done bool, err error) {
 		notification := &toolchainv1alpha1.Notification{}

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1210,8 +1210,9 @@ func (a *HostAwaitility) WaitUntilNotificationsDeleted(t *testing.T, username, n
 	})
 }
 
-// WaitUntilNotificationWithNameDeleted waits until the Notification with the given name is deleted (ie, not found)
-func (a *HostAwaitility) WaitUntilNotificationWithNameDeleted(t *testing.T, notificationName string) error {
+// WaitUntilNotificationWithNameDeletedOrNotCreated  1. waits until the Notification with the given name is deleted (ie, not found) or
+// 2. waits and checks if the notification with the name is not created
+func (a *HostAwaitility) WaitUntilNotificationWithNameDeletedOrNotCreated(t *testing.T, notificationName string) error {
 	t.Logf("waiting for notification with name '%s' to get deleted", notificationName)
 	return wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		notification := &toolchainv1alpha1.Notification{}


### PR DESCRIPTION
Updating the test "TestIdlerAndPriorityClass" to fix some edge case failures.

- To fix limit error for docker "busybox" image pull 
- Make logger a less confusing
- Update the 'notification' variable to not use previous values while testing.