### PR TITLE
Remove kubernetesimagepuller webhook test

### DIFF
--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -2349,29 +2349,7 @@ func (a *MemberAwaitility) verifyValidatingWebhookConfig(t *testing.T, ca []byte
 	assert.Equal(t, []string{"rolebindings"}, rolebindingRule.Resources)
 	assert.Equal(t, admv1.NamespacedScope, *rolebindingRule.Scope)
 
-	k8sImagePullerWebhook := actualValWbhConf.Webhooks[1]
-	assert.Equal(t, "users.kubernetesimagepullers.webhook.sandbox", k8sImagePullerWebhook.Name)
-	assert.Equal(t, []string{"v1"}, k8sImagePullerWebhook.AdmissionReviewVersions)
-	assert.Equal(t, admv1.SideEffectClassNone, *k8sImagePullerWebhook.SideEffects)
-	assert.Equal(t, int32(5), *k8sImagePullerWebhook.TimeoutSeconds)
-	assert.Equal(t, admv1.Fail, *k8sImagePullerWebhook.FailurePolicy)
-	assert.Equal(t, admv1.Equivalent, *k8sImagePullerWebhook.MatchPolicy)
-	assert.Equal(t, codereadyToolchainProviderLabel, k8sImagePullerWebhook.NamespaceSelector.MatchLabels)
-	assert.Equal(t, ca, k8sImagePullerWebhook.ClientConfig.CABundle)
-	assert.Equal(t, "member-operator-webhook", k8sImagePullerWebhook.ClientConfig.Service.Name)
-	assert.Equal(t, a.Namespace, k8sImagePullerWebhook.ClientConfig.Service.Namespace)
-	assert.Equal(t, "/validate-users-kubernetesimagepullers", *k8sImagePullerWebhook.ClientConfig.Service.Path)
-	assert.Equal(t, int32(443), *k8sImagePullerWebhook.ClientConfig.Service.Port)
-	require.Len(t, k8sImagePullerWebhook.Rules, 1)
-
-	k8sImagePullerRule := k8sImagePullerWebhook.Rules[0]
-	assert.Equal(t, []admv1.OperationType{admv1.Create}, k8sImagePullerRule.Operations)
-	assert.Equal(t, []string{"che.eclipse.org"}, k8sImagePullerRule.APIGroups)
-	assert.Equal(t, []string{"v1alpha1"}, k8sImagePullerRule.APIVersions)
-	assert.Equal(t, []string{"kubernetesimagepullers"}, k8sImagePullerRule.Resources)
-	assert.Equal(t, admv1.NamespacedScope, *k8sImagePullerRule.Scope)
-
-	spacebindingrequestWebhook := actualValWbhConf.Webhooks[2]
+	spacebindingrequestWebhook := actualValWbhConf.Webhooks[1]
 	assert.Equal(t, "users.spacebindingrequests.webhook.sandbox", spacebindingrequestWebhook.Name)
 	assert.Equal(t, []string{"v1"}, spacebindingrequestWebhook.AdmissionReviewVersions)
 	assert.Equal(t, admv1.SideEffectClassNone, *spacebindingrequestWebhook.SideEffects)


### PR DESCRIPTION
Removes the kubernetesimagepuller webhook tests in https://github.com/codeready-toolchain/toolchain-e2e/pull/840

Since the Kubernetes Image Puller Operator v1.1.0 provides its own webhook to limit image puller resources, this webhook on the member-operator side is not needed anymore: https://github.com/codeready-toolchain/member-operator/pull/526.