### PR TITLE
test: fix catalog source issue on hypershift 4.14

### DIFF
--- a/make/run-cicd-script.mk
+++ b/make/run-cicd-script.mk
@@ -1,5 +1,5 @@
 
-OWNER_AND_BRANCH_LOCATION=codeready-toolchain/toolchain-cicd/master
+OWNER_AND_BRANCH_LOCATION=mfrancisc/toolchain-cicd/fixcatalogsource
 GH_SCRIPTS_URL=https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}
 USE_LOCAL_SCRIPTS=false
 


### PR DESCRIPTION
This is just testing the new cicd scripts [here](https://github.com/codeready-toolchain/toolchain-cicd/pull/99). 

I'll close this PR once done.