### PR TITLE
Better explanations for failures in wait.For().*

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,3 +121,5 @@ require (
 )
 
 go 1.20
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common 67f3c03c27f54c338731bd5593f6868b0fb99f75

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -677,6 +677,8 @@ func (w *Waiter[T]) FirstThat(predicates ...assertions.Predicate[client.Object])
 	w.t.Logf("waiting for objects of GVK '%s' in namespace '%s' to match criteria", w.gvk, w.await.Namespace)
 
 	var returnedObject T
+	// match status of each predicate per object
+	latestResults := map[client.ObjectKey][]bool{}
 
 	err := wait.Poll(w.await.RetryInterval, w.await.Timeout, func() (done bool, err error) {
 		// because there is no generic way of figuring out the list type for some client.Object type, we need to go
@@ -694,13 +696,58 @@ func (w *Waiter[T]) FirstThat(predicates ...assertions.Predicate[client.Object])
 				return false, fmt.Errorf("failed to cast the object to GVK %v: %w", w.gvk, err)
 			}
 
-			if w.matches(object, predicates) {
+			matches, results := w.matches(object, predicates)
+			latestResults[client.ObjectKeyFromObject(object)] = results
+			if matches {
 				returnedObject = object
 				return true, nil
 			}
 		}
 		return false, nil
 	})
+	if err != nil {
+		sb := strings.Builder{}
+		sb.WriteString("failed to find objects (of GVK '%s') in namespace '%s' matching the criteria")
+		args := []any{w.gvk, w.await.Namespace}
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(w.gvk)
+		if err := w.await.Client.List(context.TODO(), list, client.InNamespace(w.await.Namespace)); err != nil {
+			sb.WriteString(" and also failed to retrieve the object at all with error: %s")
+			args = append(args, err)
+		} else {
+			sb.WriteString("\nlisting the objects found in cluster with the differences from the expected state for each:")
+			for _, o := range list.Items {
+				obj, _ := w.cast(&o)
+				key := client.ObjectKeyFromObject(obj)
+
+				matches := true
+				objectResults := latestResults[key]
+				for _, res := range objectResults {
+					if !res {
+						matches = false
+						break
+					}
+				}
+
+				sb.WriteRune('\n')
+				sb.WriteString("object ")
+				sb.WriteString(key.String())
+				if matches {
+					sb.WriteString("matches all predicates")
+				} else {
+					sb.WriteString("was found to have the following differences:")
+					for i, res := range objectResults {
+						if !res {
+							sb.WriteRune('\n')
+							sb.WriteString(assertions.Explain(predicates[i], obj.DeepCopyObject().(T)))
+						}
+					}
+				}
+			}
+		}
+		w.t.Logf(sb.String(), args...)
+
+	}
 	return returnedObject, err
 }
 
@@ -710,6 +757,7 @@ func (w *Waiter[T]) WithNameThat(name string, predicates ...assertions.Predicate
 	w.t.Logf("waiting for object of GVK '%s' with name '%s' in namespace '%s' to match additional criteria", w.gvk, name, w.await.Namespace)
 
 	var returnedObject T
+	latestResults := []bool{}
 
 	err := wait.Poll(w.await.RetryInterval, w.await.Timeout, func() (done bool, err error) {
 		obj := &unstructured.Unstructured{}
@@ -725,13 +773,37 @@ func (w *Waiter[T]) WithNameThat(name string, predicates ...assertions.Predicate
 			return false, fmt.Errorf("failed to cast the object to GVK %v: %w", w.gvk, err)
 		}
 
-		if w.matches(object, predicates) {
+		matches, results := w.matches(object, predicates)
+		latestResults = results
+		if matches {
 			returnedObject = object
 			return true, nil
 		}
 
 		return false, nil
 	})
+	if err != nil {
+		sb := strings.Builder{}
+		sb.WriteString("couldn't match the object (GVK '%s') called '%s' in namespace '%s' with the criteria")
+		args := []any{w.gvk, name, w.await.Namespace}
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(w.gvk)
+		if err := w.await.Client.Get(context.TODO(), client.ObjectKey{Name: name, Namespace: w.await.Namespace}, obj); err != nil {
+			sb.WriteString(" and also failed to retrieve the object at all with error: %s")
+			args = append(args, err)
+		} else {
+			o, _ := w.cast(obj)
+			sb.WriteString(" but the object exists in the cluster with the following differences:")
+			for i, p := range predicates {
+				if !latestResults[i] {
+					expl := assertions.Explain(p, o.DeepCopyObject().(T))
+					sb.WriteRune('\n')
+					sb.WriteString(expl)
+				}
+			}
+		}
+		w.t.Logf(sb.String(), args...)
+	}
 	return returnedObject, err
 }
 
@@ -755,13 +827,15 @@ func (w *Waiter[T]) cast(obj *unstructured.Unstructured) (T, error) {
 	return typed.(T), nil
 }
 
-func (w *Waiter[T]) matches(obj T, predicates []assertions.Predicate[client.Object]) bool {
-	for _, p := range predicates {
-		if !p.Matches(obj) {
-			return false
-		}
+func (w *Waiter[T]) matches(obj T, predicates []assertions.Predicate[client.Object]) (bool, []bool) {
+	matches := true
+	results := make([]bool, len(predicates))
+	for i, p := range predicates {
+		res := p.Matches(obj)
+		results[i] = res
+		matches = matches && res
 	}
-	return true
+	return matches, results
 }
 
 // For returns an struct using which one can wait for the objects with the same type as the one provided.


### PR DESCRIPTION
Support explanations for why wait.For().FirstThat() and wait.For().WithNameThat have errored in the logs.

This builds on top of https://github.com/codeready-toolchain/toolchain-common/pull/362 which needs to be merged first.

An example log output (for an intentionally locally introduced error) looks like this:
```
=== NAME  TestSpaceProvisionerConfig/ready_with_existing_cluster
    awaitility.go:807: couldn't match the object (GVK 'toolchain.dev.openshift.com/v1alpha1, Kind=SpaceProvisionerConfig') called 'testspaceprovisionerconfigreadywithexisttkn5s' in namespace 'toolchain-host-21180250' with the criteria but the object exists in the cluster with the following differences:
        predicate 'spaceprovisionerconfig.notReady' didn't match the object because of the following differences:
          &v1alpha1.SpaceProvisionerConfig{
                Spec: {ToolchainCluster: "member-cluster-xc4dx.dynamic.redhatworkshops.io"},
                Status: v1alpha1.SpaceProvisionerConfigStatus{
                        Conditions: []v1alpha1.Condition{
                                {
                                        Type:               "Ready",
        -                               Status:             "False",
        +                               Status:             "True",
        -                               LastTransitionTime: v1.Time{Time: s"2024-02-21 18:18:20.626733946 +0100 CET m=+140.356773196"},
        +                               LastTransitionTime: v1.Time{Time: s"2024-02-21 18:16:19 +0100 CET"},
                                        Reason:             "AllChecksPassed",
                                        Message:            "",
                                        LastUpdatedTime:    nil,
                                },
                        },
                },
                TypeMeta:   {Kind: "SpaceProvisionerConfig", APIVersion: "toolchain.dev.openshift.com/v1alpha1"},
                ObjectMeta: {Name: "testspaceprovisionerconfigreadywithexisttkn5s", GenerateName: "testspaceprovisionerconfigreadywithexist", Namespace: "toolchain-host-21180250", UID: "330bbe9d-ebe1-47f0-aaa6-f9810298f4ff", ...},
          }
    spaceprovisionerconfig_test.go:42: 
                Error Trace:    /home/brq/lkrejci/Projects/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/spaceprovisionerconfig_test.go:42
                Error:          Received unexpected error:
                                timed out waiting for the condition
```