### PR TITLE
Use SpaceProvisionerConfig in capacity manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240227212148-b32711b41532

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87 h1:eQLsrMqfjAzGfuO9t6pVxO4K6cUDKOMxEvl0ujQq/2I=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240227212148-b32711b41532 h1:mfTiDF9af5hmc23AR1DreoCcyLTeAJKhYbFPyd7f/+Q=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240227212148-b32711b41532/go.mod h1:nA1+TOD7zDS6spCBTaIZ63B/KyysR66fJI3DUT86kKE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/make/resources/default-spaceprovisionerconfig.yaml
+++ b/make/resources/default-spaceprovisionerconfig.yaml
@@ -11,6 +11,8 @@ objects:
     spec:
       toolchainCluster: ${TOOLCHAINCLUSTER_NAME}
       enabled: true
+      placementRoles:
+        - cluster-role.toolchain.dev.openshift.com/tenant
 parameters:
   - name: SPACEPROVISIONERCONFIG_NAME
   - name: SPACEPROVISIONERCONFIG_NS

--- a/make/test.mk
+++ b/make/test.mk
@@ -352,7 +352,7 @@ endif
 
 .PHONY: create-spaceprovisionerconfigs-for-members
 create-spaceprovisionerconfigs-for-members:
-	for member_name in `oc get toolchaincluster -l -n ${HOST_NS} --no-headers -o custom-columns=":metadata.name"`; do \
+	for member_name in `oc get toolchaincluster -n ${HOST_NS} --no-headers -o custom-columns=":metadata.name"`; do \
 	  oc process -p TOOLCHAINCLUSTER_NAME=$${member_name} -p SPACEPROVISIONERCONFIG_NAME=$${member_name} -p SPACEPROVISIONERCONFIG_NS=${HOST_NS} -f ${PWD}/make/resources/default-spaceprovisionerconfig.yaml | oc apply -f -; \
 	done
 

--- a/test/e2e/parallel/spaceprovisionerconfig_test.go
+++ b/test/e2e/parallel/spaceprovisionerconfig_test.go
@@ -32,7 +32,7 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		spc := CreateSpaceProvisionerConfig(t, host.Awaitility, ReferencingToolchainCluster(cluster.Name))
+		spc := Create(t, host.Awaitility, ReferencingToolchainCluster(cluster.Name))
 
 		// then
 		_, err = wait.
@@ -43,7 +43,7 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 
 	t.Run("not ready without existing cluster", func(t *testing.T) {
 		// when
-		spc := CreateSpaceProvisionerConfig(t, host.Awaitility, ReferencingToolchainCluster("invalid%@@name"))
+		spc := Create(t, host.Awaitility, ReferencingToolchainCluster("invalid%@@name"))
 
 		// then
 		_, err := wait.
@@ -57,7 +57,7 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 		clusterName := util.NewObjectNamePrefix(t) + string(uuid.NewUUID()[0:20])
 
 		// when
-		spc := CreateSpaceProvisionerConfig(t, host.Awaitility, ReferencingToolchainCluster(clusterName))
+		spc := Create(t, host.Awaitility, ReferencingToolchainCluster(clusterName))
 
 		// then
 		_, err := wait.
@@ -93,7 +93,7 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 		assert.NoError(t, host.CreateWithCleanup(t, cluster))
 
 		// when
-		spc := CreateSpaceProvisionerConfig(t, host.Awaitility, ReferencingToolchainCluster(clusterName))
+		spc := Create(t, host.Awaitility, ReferencingToolchainCluster(clusterName))
 
 		// then
 		_, err := wait.

--- a/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -1,16 +1,20 @@
 package spaceprovisionerconfig
 
 import (
+	"context"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	testSpc "github.com/codeready-toolchain/toolchain-common/pkg/test/spaceprovisionerconfig"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateSpaceProvisionerConfig(t *testing.T, await *wait.Awaitility, opts ...testSpc.CreateOption) *toolchainv1alpha1.SpaceProvisionerConfig {
+func Create(t *testing.T, await *wait.Awaitility, opts ...testSpc.ModifyOption) *toolchainv1alpha1.SpaceProvisionerConfig {
+	t.Helper()
 	namePrefix := util.NewObjectNamePrefix(t)
 
 	spc := testSpc.NewSpaceProvisionerConfig("", await.Namespace, opts...)
@@ -19,4 +23,39 @@ func CreateSpaceProvisionerConfig(t *testing.T, await *wait.Awaitility, opts ...
 	require.NoError(t, err)
 
 	return spc
+}
+
+func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterName string, opts ...testSpc.ModifyOption) {
+	t.Helper()
+	spcs, err := getAllSpcs(t, await)
+	require.NoError(t, err)
+
+	idx := findIndexOfFirstSpaceProvisionerConfigReferencingCluster(spcs, referencedClusterName)
+	require.GreaterOrEqual(t, idx, 0, "could not find SpaceProvisionerConfig referencing the required cluster: %s", referencedClusterName)
+
+	spc := &spcs[idx]
+
+	for _, opt := range opts {
+		opt(spc)
+	}
+
+	assert.NoError(t, await.Client.Update(context.TODO(), spc))
+}
+
+func getAllSpcs(t *testing.T, await *wait.Awaitility) ([]toolchainv1alpha1.SpaceProvisionerConfig, error) {
+	t.Helper()
+	list := &toolchainv1alpha1.SpaceProvisionerConfigList{}
+	if err := await.Client.List(context.TODO(), list, client.InNamespace(await.Namespace)); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func findIndexOfFirstSpaceProvisionerConfigReferencingCluster(spcs []toolchainv1alpha1.SpaceProvisionerConfig, clusterName string) int {
+	for i, spc := range spcs {
+		if spc.Spec.ToolchainCluster == clusterName {
+			return i
+		}
+	}
+	return -1
 }

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -586,6 +586,8 @@ func UntilToolchainClusterHasCondition(expected toolchainv1alpha1.ToolchainClust
 	}
 }
 
+// TODO: the following 2 functions need to start using the placement roles and SPC I assume
+
 // UntilToolchainClusterHasLabels checks if ToolchainCluster has the given labels
 func UntilToolchainClusterHasLabels(expected client.MatchingLabels) ToolchainClusterWaitCriterion {
 	return ToolchainClusterWaitCriterion{


### PR DESCRIPTION
This modifies the existing tests to accommodate for the changes introduced by the change to how capacity thresholds are configured.

No new tests are introduced yet and the changes are not yet even complete. This is just a draft PR to show what the changes in the existing tests are going to look like.

The current problem is the flakiness of the `TestAutomaticClusterAssignment` tests (that have been converted to the new way of configuring thresholds). Interestingly, it seems that the subtests fail at random. The e2e test fail when executed using 

```
make clean-e2e-resources test-e2e-host-local DISABLE_KUBE_CLIENT_TLS_VERIFY=true 
TESTS_RUN_FILTER_REGEXP="TestAutomaticClusterAssignment"`
```

when the test is subsequently modified to point to the same namespaces by programmatically updating the envvars (as suggested in the test output) and ran for the second time using merely

```
go test ./test/e2e/ -run TestAutomaticClusterAssignment
```

the test surprisingly passes. I have not yet been able to determine what the problem is.

Once this is solved, more changes will most probably be required.