### PR TITLE
SANDBOX-555: clean up packages being imported more than once

### DIFF
--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -83,7 +82,7 @@ func EnsureOperatorsInstalled(ctx context.Context, cl client.Client, s *runtime.
 		}
 
 		// find the subscription resource
-		var subscriptionResource runtimeclient.Object
+		var subscriptionResource client.Object
 		foundSub := false
 		for _, obj := range objsToProcess {
 			if obj.GetObjectKind().GroupVersionKind().Kind == "Subscription" {

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -15,7 +15,6 @@ import (
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,7 +67,7 @@ func TestNSTemplateTiers(t *testing.T) {
 		// check that the tier exists, and all its namespace other cluster-scoped resource revisions
 		// are different from `000000a` which is the value specified in the initial manifest (used for base tier)
 		_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierToCheck,
-			UntilNSTemplateTierSpec(HasNoTemplateRefWithSuffix("-000000a")))
+			wait.UntilNSTemplateTierSpec(wait.HasNoTemplateRefWithSuffix("-000000a")))
 		require.NoError(t, err)
 
 		t.Run(fmt.Sprintf("promote %s space to %s tier", testingtiers.Status.CompliantUsername, tierToCheck), func(t *testing.T) {
@@ -95,8 +94,8 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	// we will have a lot of usersignups who are affected by the tier updates, so
 	// we need to increase the timeouts on assertions/awaitilities to allow for all resources to be updated
-	hostAwait = hostAwait.WithRetryOptions(TimeoutOption(hostAwait.Timeout + time.Second*time.Duration(3*count*2)))       // 3 batches of `count` accounts, with 2s of interval between each update
-	memberAwait = memberAwait.WithRetryOptions(TimeoutOption(memberAwait.Timeout + time.Second*time.Duration(3*count*2))) // 3 batches of `count` accounts, with 2s of interval between each update
+	hostAwait = hostAwait.WithRetryOptions(wait.TimeoutOption(hostAwait.Timeout + time.Second*time.Duration(3*count*2)))       // 3 batches of `count` accounts, with 2s of interval between each update
+	memberAwait = memberAwait.WithRetryOptions(wait.TimeoutOption(memberAwait.Timeout + time.Second*time.Duration(3*count*2))) // 3 batches of `count` accounts, with 2s of interval between each update
 
 	baseTier, err := hostAwait.WaitForNSTemplateTier(t, "base")
 	require.NoError(t, err)
@@ -186,7 +185,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 // setupSpaces takes care of:
 // 1. creating a new tier with the provided tierName and using the TemplateRefs of the provided tier.
 // 2. creating `count` number of spaces
-func setupSpaces(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNSTemplateTier, nameFmt string, targetCluster *MemberAwaitility, count int) []string {
+func setupSpaces(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.CustomNSTemplateTier, nameFmt string, targetCluster *wait.MemberAwaitility, count int) []string {
 	var spaces []string
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf(nameFmt, i)
@@ -201,7 +200,7 @@ func setupSpaces(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNSTe
 // 2. creating 10 users (signups, MURs, etc.)
 // 3. promoting the users to the new tier
 // returns the tier, users and their "syncIndexes"
-func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNSTemplateTier, nameFmt string, targetCluster *MemberAwaitility, count int) []*toolchainv1alpha1.UserSignup {
+func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.CustomNSTemplateTier, nameFmt string, targetCluster *wait.MemberAwaitility, count int) []*toolchainv1alpha1.UserSignup {
 	// first, let's create the a new NSTemplateTier (to avoid messing with other tiers)
 	hostAwait := awaitilities.Host()
 
@@ -229,22 +228,22 @@ func setupAccounts(t *testing.T, awaitilities Awaitilities, tier *tiers.CustomNS
 	return userSignups
 }
 
-func verifyStatus(t *testing.T, hostAwait *HostAwaitility, tierName string, expectedCount int) {
-	_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierName, UntilNSTemplateTierStatusUpdates(expectedCount))
+func verifyStatus(t *testing.T, hostAwait *wait.HostAwaitility, tierName string, expectedCount int) {
+	_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierName, wait.UntilNSTemplateTierStatusUpdates(expectedCount))
 	require.NoError(t, err)
 }
 
-func verifyResourceUpdatesForUserSignups(t *testing.T, hostAwait *HostAwaitility, memberAwaitility *MemberAwaitility, userSignups []*toolchainv1alpha1.UserSignup, tier *tiers.CustomNSTemplateTier) {
+func verifyResourceUpdatesForUserSignups(t *testing.T, hostAwait *wait.HostAwaitility, memberAwaitility *wait.MemberAwaitility, userSignups []*toolchainv1alpha1.UserSignup, tier *tiers.CustomNSTemplateTier) {
 	// if there's an annotation that describes on which other tier this one is based (for e2e tests only)
 	for _, usersignup := range userSignups {
 		userAccount, err := memberAwaitility.WaitForUserAccount(t, usersignup.Status.CompliantUsername,
-			UntilUserAccountHasConditions(wait.Provisioned()),
-			UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Spec.IdentityClaims.PropagatedClaims)),
-			UntilUserAccountMatchesMur(hostAwait))
+			wait.UntilUserAccountHasConditions(wait.Provisioned()),
+			wait.UntilUserAccountHasSpec(ExpectedUserAccount(usersignup.Spec.IdentityClaims.PropagatedClaims)),
+			wait.UntilUserAccountMatchesMur(hostAwait))
 		require.NoError(t, err)
 		require.NotNil(t, userAccount)
 
-		nsTemplateSet, err := memberAwaitility.WaitForNSTmplSet(t, usersignup.Status.CompliantUsername, UntilNSTemplateSetHasTier(tier.Name))
+		nsTemplateSet, err := memberAwaitility.WaitForNSTmplSet(t, usersignup.Status.CompliantUsername, wait.UntilNSTemplateSetHasTier(tier.Name))
 		if err != nil {
 			t.Logf("getting NSTemplateSet '%s' failed with: %s", usersignup.Status.CompliantUsername, err)
 		}
@@ -255,7 +254,7 @@ func verifyResourceUpdatesForUserSignups(t *testing.T, hostAwait *HostAwaitility
 	}
 }
 
-func verifyResourceUpdatesForSpaces(t *testing.T, hostAwait *HostAwaitility, targetCluster *MemberAwaitility, spaces []string, tier *tiers.CustomNSTemplateTier) {
+func verifyResourceUpdatesForSpaces(t *testing.T, hostAwait *wait.HostAwaitility, targetCluster *wait.MemberAwaitility, spaces []string, tier *tiers.CustomNSTemplateTier) {
 	// verify individual space updates
 	for _, spaceName := range spaces {
 		VerifyResourcesProvisionedForSpaceWithCustomTier(t, hostAwait, targetCluster, spaceName, tier)

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -15,7 +15,6 @@ import (
 	testspace "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
-	"github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	tsspace "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
@@ -122,7 +121,7 @@ func (r *SetupMigrationRunner) prepareProvisionedSubspace(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func createSpaceRequestForParentSpace(t *testing.T, awaitilities wait.Awaitilities, memberName, parent string, opts ...space.SpaceRequestOption) *toolchainv1alpha1.SpaceRequest {
+func createSpaceRequestForParentSpace(t *testing.T, awaitilities wait.Awaitilities, memberName, parent string, opts ...tsspace.SpaceRequestOption) *toolchainv1alpha1.SpaceRequest {
 	memberAwait, err := awaitilities.Member(memberName)
 	require.NoError(t, err)
 
@@ -131,8 +130,8 @@ func createSpaceRequestForParentSpace(t *testing.T, awaitilities wait.Awaitiliti
 	require.NoError(t, err)
 
 	// create the space request in the "default" namespace provisioned by the parentSpace
-	namespace := space.GetDefaultNamespace(parentSpace.Status.ProvisionedNamespaces)
-	spaceRequest := space.NewSpaceRequest(t, append(opts, space.WithNamespace(namespace))...)
+	namespace := tsspace.GetDefaultNamespace(parentSpace.Status.ProvisionedNamespaces)
+	spaceRequest := tsspace.NewSpaceRequest(t, append(opts, tsspace.WithNamespace(namespace))...)
 	require.NotEmpty(t, spaceRequest)
 
 	// don't cleanup the new spacerequest, since we need it for migration testing


### PR DESCRIPTION
# Description

While taking a look at `nstemplatetier_test.go`, I noticed that the wait package was being imported more than once. So, I ran `staticcheck ./...` locally to check if it occurs in other files. This PR cleans up the packages being imported more than once. In the future, maybe we can wonder if it makes sense to add this check to golangci lint config.

## Issue ticket number and link
[SANDBOX-555](https://issues.redhat.com/browse/SANDBOX-555)