### PR TITLE
fix: drop type label selector from ToolchainCluster list

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -337,7 +337,7 @@ create-host-resources: create-spaceprovisionerconfigs-for-members
 	# since e2e environment has 2 member operators running in the same cluster
 	# for details on how the TOOLCHAINCLUSTER_NAME is composed see https://github.com/codeready-toolchain/toolchain-cicd/blob/master/scripts/add-cluster.sh
 	if [[ ${SECOND_MEMBER_MODE} == true ]]; then \
-		TOOLCHAIN_CLUSTER_NAME=`oc get toolchaincluster -l type=member -n ${HOST_NS} --no-headers -o custom-columns=":metadata.name" | grep "2$$"`; \
+		TOOLCHAIN_CLUSTER_NAME=`oc get toolchaincluster -n ${HOST_NS} --no-headers -o custom-columns=":metadata.name" | grep "2$$"`; \
 		echo "TOOLCHAIN_CLUSTER_NAME $${TOOLCHAIN_CLUSTER_NAME}"; \
 		echo "ENVIRONMENT ${ENVIRONMENT}"; \
 		PATCH_FILE=/tmp/patch-toolchainconfig_${DATE_SUFFIX}.json; \

--- a/make/test.mk
+++ b/make/test.mk
@@ -338,6 +338,10 @@ create-host-resources: create-spaceprovisionerconfigs-for-members
 	# for details on how the TOOLCHAINCLUSTER_NAME is composed see https://github.com/codeready-toolchain/toolchain-cicd/blob/master/scripts/add-cluster.sh
 	if [[ ${SECOND_MEMBER_MODE} == true ]]; then \
 		TOOLCHAIN_CLUSTER_NAME=`oc get toolchaincluster -n ${HOST_NS} --no-headers -o custom-columns=":metadata.name" | grep "2$$"`; \
+		if [[ -z $${TOOLCHAIN_CLUSTER_NAME} ]]; then \
+			echo "ERROR: no ToolchainCluster for member 2 found"; \
+			exit 1; \
+		fi; \
 		echo "TOOLCHAIN_CLUSTER_NAME $${TOOLCHAIN_CLUSTER_NAME}"; \
 		echo "ENVIRONMENT ${ENVIRONMENT}"; \
 		PATCH_FILE=/tmp/patch-toolchainconfig_${DATE_SUFFIX}.json; \


### PR DESCRIPTION
it causes failures in e2e tests https://storage.googleapis.com/test-platform-results/pr-logs/pull/codeready-toolchain_registration-service/416/pull-ci-codeready-toolchain-registration-service-master-e2e/1770125318879711232/build-log.txt