### PR TITLE
test: SANDBOX-593 create first Space and SpaceBinding and just after add them to the clean up task in CreateSpaceAndSpaceBinding

### DIFF
--- a/testsupport/util/log_timestamp.go
+++ b/testsupport/util/log_timestamp.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func LogWithTimestamp(t *testing.T, message string) {
+	time := time.Now().Format("2006-01-02 15:04:05")
+	t.Logf("[%s] %s", time, message)
+}

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -639,6 +639,14 @@ func (a *Awaitility) CreateWithCleanup(t *testing.T, obj client.Object, opts ...
 	return nil
 }
 
+// Create creates the given object via client.Client.Create()
+func (a *Awaitility) Create(obj client.Object, opts ...client.CreateOption) error {
+	if err := a.Client.Create(context.TODO(), obj, opts...); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Clean triggers cleanup of all resources that were marked to be cleaned before that
 func (a *Awaitility) Clean(t *testing.T) {
 	cleanup.ExecuteAllCleanTasks(t)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2390,10 +2390,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		}
 		// let's see if space was provisioned as expected
 		spaceCreated = &toolchainv1alpha1.Space{}
-		err = a.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: spaceToCreate.Namespace,
-			Name:      spaceToCreate.Name,
-		}, spaceCreated)
+		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				t.Logf("The created Space %s is not present", spaceToCreate.Name)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2422,7 +2422,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		t.Logf("Space %s and SpaceBinding %s created", spaceCreated.Name, spaceBinding.Name)
 
 		// schedules the cleanup of the Space and the SpaceBinding at the end of the current test
-		cleanup.AddCleanTasks(t, a.GetClient(), space)
+		cleanup.AddCleanTasks(t, a.GetClient(), spaceCreated)
 		cleanup.AddCleanTasks(t, a.GetClient(), spaceBinding)
 		return true, nil
 	})

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2377,6 +2377,10 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 				return false, err
 			}
 		}
+
+		// temporary log due to SANDBOX-593
+		t.Logf("Space created: %v", spaceToCreate)
+
 		// create spacebinding request immediately after ...
 		spaceBinding = spacebinding.NewSpaceBinding(mur, spaceToCreate, spaceRole, spacebinding.WithRole(spaceRole))
 		if err := a.CreateWithCleanup(t, spaceBinding); err != nil {
@@ -2386,10 +2390,13 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		}
 		// let's see if space was provisioned as expected
 		spaceCreated = &toolchainv1alpha1.Space{}
-		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
+		err = a.Client.Get(context.TODO(), types.NamespacedName{
+			Namespace: spaceToCreate.Namespace,
+			Name:      spaceToCreate.Name,
+		}, spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				t.Logf("The created Space %s is not present", spaceCreated.Name)
+				t.Logf("The created Space %s is not present", spaceToCreate.Name)
 				return false, nil
 			}
 			return false, err

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2368,7 +2368,7 @@ func EncodeUserIdentifier(subject string) string {
 func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, spaceRole string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBinding, error) {
 	var spaceBinding *toolchainv1alpha1.SpaceBinding
 	var spaceCreated *toolchainv1alpha1.Space
-	t.Logf("Creating Space %s (prefix: %s) and SpaceBinding with role %s for %s", space.Name, space.GenerateName, spaceRole, mur.Name)
+	testutil.LogWithTimestamp(t, fmt.Sprintf("Creating Space %s (prefix: %s) and SpaceBinding with role %s for %s", space.Name, space.GenerateName, spaceRole, mur.Name))
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		// create the space
 		spaceToCreate := space.DeepCopy()
@@ -2379,8 +2379,8 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		}
 
 		// temporary log due to SANDBOX-593
-		t.Logf("Space created with name %s", spaceToCreate.Name)
-		t.Logf("Space created: %v", spaceToCreate)
+		testutil.LogWithTimestamp(t, fmt.Sprintf("Space created with name %s", spaceToCreate.Name))
+		testutil.LogWithTimestamp(t, fmt.Sprintf("Space created: %v", spaceToCreate))
 
 		// create spacebinding request immediately after ...
 		spaceBinding = spacebinding.NewSpaceBinding(mur, spaceToCreate, spaceRole, spacebinding.WithRole(spaceRole))
@@ -2394,7 +2394,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				t.Logf("The created Space %s is not present", spaceToCreate.Name)
+				testutil.LogWithTimestamp(t, fmt.Sprintf("The created Space %s is not present", spaceToCreate.Name))
 				return false, nil
 			}
 			return false, err

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -17,6 +17,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	testutil "github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
@@ -2372,29 +2373,33 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		// create the space
 		spaceToCreate := space.DeepCopy()
-		if err := a.CreateWithCleanup(t, spaceToCreate); err != nil {
+		if err := a.Create(spaceToCreate); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return false, err
 			}
 		}
 
 		// temporary log due to SANDBOX-593
-		testutil.LogWithTimestamp(t, fmt.Sprintf("Space created with name %s", spaceToCreate.Name))
-		testutil.LogWithTimestamp(t, fmt.Sprintf("Space created: %v", spaceToCreate))
+		testutil.LogWithTimestamp(t, fmt.Sprintf("Space created with name %s, %s", spaceToCreate.Name, time.Now()))
 
 		// create spacebinding request immediately after ...
 		spaceBinding = spacebinding.NewSpaceBinding(mur, spaceToCreate, spaceRole, spacebinding.WithRole(spaceRole))
-		if err := a.CreateWithCleanup(t, spaceBinding); err != nil {
+		if err := a.Create(spaceBinding); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return false, err
 			}
 		}
+
+		// schedules the cleanup of the Space and the SpaceBinding at the end of the current test
+		cleanup.AddCleanTasks(t, a.GetClient(), space)
+		cleanup.AddCleanTasks(t, a.GetClient(), spaceBinding)
+
 		// let's see if space was provisioned as expected
 		spaceCreated = &toolchainv1alpha1.Space{}
 		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				testutil.LogWithTimestamp(t, fmt.Sprintf("The created Space %s is not present", spaceToCreate.Name))
+				testutil.LogWithTimestamp(t, fmt.Sprintf("The created Space %s is not present in namespace %s", spaceToCreate.Name, spaceToCreate.Namespace))
 				return false, nil
 			}
 			return false, err
@@ -2410,7 +2415,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			return false, err
 		}
 		if spaceBinding == nil {
-			t.Logf("The created SpaceBinding %s is not present", spaceCreated.Name)
+			t.Logf("The created SpaceBinding %s is not present in namespace %s", spaceBinding.Name, spaceBinding.Namespace)
 			return false, nil
 		}
 		if util.IsBeingDeleted(spaceBinding) {

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2368,7 +2368,7 @@ func EncodeUserIdentifier(subject string) string {
 func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, spaceRole string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBinding, error) {
 	var spaceBinding *toolchainv1alpha1.SpaceBinding
 	var spaceCreated *toolchainv1alpha1.Space
-	t.Logf("Creating Space %s and SpaceBinding with role %s for %s", space.Name, spaceRole, mur.Name)
+	t.Logf("Creating Space %s (prefix: %s) and SpaceBinding with role %s for %s", space.Name, space.GenerateName, spaceRole, mur.Name)
 	err := wait.Poll(a.RetryInterval, a.Timeout, func() (done bool, err error) {
 		// create the space
 		spaceToCreate := space.DeepCopy()
@@ -2379,6 +2379,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		}
 
 		// temporary log due to SANDBOX-593
+		t.Logf("Space created with name %s", spaceToCreate.Name)
 		t.Logf("Space created: %v", spaceToCreate)
 
 		// create spacebinding request immediately after ...

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2390,10 +2390,6 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			}
 		}
 
-		// schedules the cleanup of the Space and the SpaceBinding at the end of the current test
-		cleanup.AddCleanTasks(t, a.GetClient(), space)
-		cleanup.AddCleanTasks(t, a.GetClient(), spaceBinding)
-
 		// let's see if space was provisioned as expected
 		spaceCreated = &toolchainv1alpha1.Space{}
 		err = a.Client.Get(context.TODO(), client.ObjectKeyFromObject(spaceToCreate), spaceCreated)
@@ -2424,6 +2420,10 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			return false, a.WaitUntilSpaceBindingDeleted(spaceBinding.Name)
 		}
 		t.Logf("Space %s and SpaceBinding %s created", spaceCreated.Name, spaceBinding.Name)
+
+		// schedules the cleanup of the Space and the SpaceBinding at the end of the current test
+		cleanup.AddCleanTasks(t, a.GetClient(), space)
+		cleanup.AddCleanTasks(t, a.GetClient(), spaceBinding)
 		return true, nil
 	})
 	return spaceCreated, spaceBinding, err

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2415,7 +2415,7 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 			return false, err
 		}
 		if spaceBinding == nil {
-			t.Logf("The created SpaceBinding %s is not present in namespace %s", spaceBinding.Name, spaceBinding.Namespace)
+			testutil.LogWithTimestamp(t, fmt.Sprintf("The created SpaceBinding %s is not present in namespace %s", spaceBinding.Name, spaceBinding.Namespace))
 			return false, nil
 		}
 		if util.IsBeingDeleted(spaceBinding) {


### PR DESCRIPTION
# Description
Some jobs are failing with timeout when trying to get a space right after its creation.

- I have a theory. The `CreateWithCleanup` function used in `CreateSpaceAndSpaceBinding` is “delaying” the time between creating a Space and the SpaceBinding because it schedules the cleanup every time a resource is created. This "little" time window leads to the space being deleted after the get, because it does not "find" any SpaceBinding.
- In order to improve the logs, when the space is not found, we should get the name from `spaceToCreate` instead of `spaceCreated` (since space was not found, spaceCreated will be empty).

## Issue ticket number and link
[SANDBOX-593](https://issues.redhat.com/browse/SANDBOX-593)