### PR TITLE
Increase appstudiolarge tier quotas

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -427,10 +427,9 @@ type appstudioTierChecks struct {
 	tierName string
 }
 
-func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObjectsCheck {
-	checks := []namespaceObjectsCheck{
+func commonAppstudioTierChecks() []namespaceObjectsCheck {
+	return []namespaceObjectsCheck{
 		resourceQuotaComputeDeploy("20", "32Gi", "1750m", "32Gi"),
-		resourceQuotaComputeBuild("120", "128Gi", "12", "64Gi"),
 		resourceQuotaStorage("50Gi", "200Gi", "50Gi", "90"),
 		limitRange("2", "2Gi", "10m", "256Mi"),
 		numberOfLimitRanges(1),
@@ -449,7 +448,13 @@ func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObje
 		pipelineRunnerRoleBinding(),
 		caBundleConfigMap(),
 	}
+}
 
+func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObjectsCheck {
+	checks := []namespaceObjectsCheck{
+		resourceQuotaComputeBuild("120", "128Gi", "12", "64Gi"),
+	}
+	checks = append(checks, commonAppstudioTierChecks()...)
 	checks = append(checks, append(commonNetworkPolicyChecks(), networkPolicyAllowFromCRW(), numberOfNetworkPolicies(6))...)
 	return checks
 }
@@ -516,7 +521,7 @@ func (a *appstudioTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 		clusterResourceQuotaJobs(),
 		clusterResourceQuotaServices(),
 		clusterResourceQuotaBuildConfig(),
-		clusterResourceQuotaSecrets(),
+		clusterResourceQuotaSecretCount("300"),
 		clusterResourceQuotaConfigMap(),
 		numberOfClusterResourceQuotas(8),
 		idlers(0, ""),
@@ -527,6 +532,15 @@ type appstudiolargeTierChecks struct {
 	appstudioTierChecks
 }
 
+func (a *appstudiolargeTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObjectsCheck {
+	checks := []namespaceObjectsCheck{
+		resourceQuotaComputeBuild("480", "512Gi", "48", "128Gi"),
+	}
+	checks = append(checks, commonAppstudioTierChecks()...)
+	checks = append(checks, append(commonNetworkPolicyChecks(), networkPolicyAllowFromCRW(), numberOfNetworkPolicies(6))...)
+	return checks
+}
+
 func (a *appstudiolargeTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return clusterObjectsChecks(
 		clusterResourceQuotaDeploymentCount("600", "100", ""),
@@ -535,7 +549,7 @@ func (a *appstudiolargeTierChecks) GetClusterObjectChecks() []clusterObjectsChec
 		clusterResourceQuotaJobs(),
 		clusterResourceQuotaServiceCount("100"),
 		clusterResourceQuotaBuildConfig(),
-		clusterResourceQuotaSecretCount("300"),
+		clusterResourceQuotaSecretCount("900"),
 		clusterResourceQuotaConfigMapCount("300"),
 		numberOfClusterResourceQuotas(8),
 		idlers(0, ""),


### PR DESCRIPTION
Change the default appstudio tier to parametrize all the compute-build values(cpu request/limit) and increase the large tier compute-build quotas. The numbers are quite high but one typical build-container task/pod have a limits of 20GiB and 18 cpus.

Also increase the secret quota for both tiers

Paired with https://github.com/codeready-toolchain/host-operator/pull/1014

[KFLUXINFRA-508](https://issues.redhat.com//browse/KFLUXINFRA-508)