### PR TITLE
update READMEs with the required tools

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,16 +36,12 @@ This is by design because OLM does not ensure that both the host-operator and me
 
 If you still don't know what to do with e2e tests in some use-cases, go to <<What To Do>> section where all use-cases are covered.
 
-=== Prerequisites if Running Locally
+=== Running Locally
 
-Install the link:required_tools.adoc[required tools].
+*Prerequisites*:
 
-==== OpenShift 4.2+
-
-* Make sure you have set the `QUAY_NAMESPACE` variable: `export QUAY_NAMESPACE=<quay-username>`
-* Log in to the quay.io using `docker login quay.io`
-* Make sure that the visibility of all repositories `host-operator`, `member-operator` and `registration-service` in quay is set to `public` (https://quay.io/repository/<your-username>/host-operator?tab=settings https://quay.io/repository/<your-username>/member-operator?tab=settings https://quay.io/repository/<your-username>/registration-service?tab=settings)
-* Log in to the target OpenShift 4.2+ cluster with cluster admin privileges using `oc login`
+* Install the link:required_tools.adoc[required tools].
+* Configure link:quay.adoc[your quay account for dev deployment].
 
 ==== Running in a Development Environment
 

--- a/required_tools.adoc
+++ b/required_tools.adoc
@@ -1,10 +1,12 @@
 == Required Pre-installed Tools
 * go 1.20.x (1.20.11 or higher)
 * git
-* operator-sdk 1.25.0
+* operator-sdk 1.25.0 +
+NOTE: Follow the installation instructions https://sdk.operatorframework.io/docs/installation/#install-from-github-release[here]. Make sure that the download URL (specified by the `OPERATOR_SDK_DL_URL` environment variable) is set to the correct version.
 * sed
 * yamllint
 * jq
-* yq (python-yq from https://github.com/kislyuk/yq#installation, other distributions may not work)
-* podman (if you need to use docker, then run the make targets with this variable set: `IMAGE_BUILDER=docker`)
-* opm (https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/ or https://github.com/operator-framework/operator-registry/releases - the version should correspond with the OpenShift version you are running)
+* podman +
+NOTE: If you need to use docker, then run the make targets with this variable set: `IMAGE_BUILDER=docker`.
+* opm v1.26.3 +
+NOTE: To download the Operator Registry tool use either https://github.com/operator-framework/operator-registry/releases or https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/. The version should correspond with the OpenShift version you are running. To confirm that the Operator Registry tool is installed correctly: `$ opm version`


### PR DESCRIPTION
replacement for https://github.com/codeready-toolchain/toolchain-e2e/pull/682 but updating the correct files. 
Also, it removes some obsolete parts and drops unneeded requirement for `yq`.