### PR TITLE
test: SANDBOX-618 TestUpdateSpaceRequest - wait until the space has the desired number of namespaces

### DIFF
--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -328,7 +328,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 		subSpace, err = hostAwait.WaitForSpace(t, subSpace.Name,
 			UntilSpaceHasTier("base"),
 			UntilSpaceHasConditions(Provisioned()),
-			UntilSpaceHasAnyProvisionedNamespaces())
+			UntilSpaceHasExpectedProvisionedNamespacesNumber(2))
 		require.NoError(t, err)
 
 		_, err = memberAwait.WaitForSpaceRequest(t, spaceRequestNamespacedName,

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1991,6 +1991,19 @@ func UntilSpaceHasAnyProvisionedNamespaces() SpaceWaitCriterion {
 	}
 }
 
+// UntilSpaceHasExpectedProvisionedNamespacesNumber returns a `SpaceWaitCriterion` which checks that the given
+// Space has the expected number of `status.ProvisionedNamespaces` set
+func UntilSpaceHasExpectedProvisionedNamespacesNumber(expected int) SpaceWaitCriterion {
+	return SpaceWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.Space) bool {
+			return len(actual.Status.ProvisionedNamespaces) == expected
+		},
+		Diff: func(actual *toolchainv1alpha1.Space) string {
+			return fmt.Sprintf("expected provisioned namespaces to be %d. Actual Space provisioned namespaces:\n%v", expected, actual)
+		},
+	}
+}
+
 // UntilSpaceHasAnyTargetClusterSet returns a `SpaceWaitCriterion` which checks that the given
 // Space has any `spec.targetCluster` set
 func UntilSpaceHasAnyTargetClusterSet() SpaceWaitCriterion {


### PR DESCRIPTION
# Description

Sometimes, in test `TestUpdateSpaceRequest`, after updating the space request tierName, the number of namespaces on the Space Request does not equal the number of namespaces of the Space. When we get the space, we need to ensure that we wait until the space has 2 namespaces (dev and stage, in this case).

[Job example](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/codeready-toolchain_member-operator/562/pull-ci-codeready-toolchain-member-operator-master-e2e/1787595431182602240#1:build-log.txt%3A11488):

```
diffs:
   invalid number of namespaces found in namespaceAccess. expected 1 but got 2
spacerequest_test.go:339:
      Error Trace:	/tmp/toolchain-e2e/test/e2e/parallel/spacerequest_test.go:33911492
      Error:      	Received unexpected error:timed out waiting for the condition
      Test:       	TestUpdateSpaceRequest/update_space_request_tierName
```


## Issue ticket number and link
[SANDBOX-618](https://issues.redhat.com/browse/SANDBOX-618)