### PR TITLE
test: SANDBOX-624: TestForceMetricsSynchronization: EnsureMUR

### DIFF
--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -650,7 +650,6 @@ func banUser(t *testing.T, hostAwait *wait.HostAwaitility, email string) *toolch
 }
 
 func TestForceMetricsSynchronization(t *testing.T) {
-
 	// given
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
@@ -658,7 +657,7 @@ func TestForceMetricsSynchronization(t *testing.T) {
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.Metrics().ForceSynchronization(false))
 
-	userSignups := CreateMultipleSignups(t, awaitilities, nil, 2)
+	userSignups := CreateMultipleSignupsWithMURs(t, awaitilities, nil, 2)
 
 	// delete the current toolchainstatus/toolchain-status resource and restart the host-operator pod,
 	// so we can start with accurate counters/metrics and not get flaky because of previous tests,

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/gofrs/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -38,7 +37,7 @@ func createMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			TargetCluster(targetCluster)
 
 		if ensuresMur {
-			signupRequest = signupRequest.EnsureMUR().RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...)
+			signupRequest = signupRequest.EnsureMUR().RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...)
 		}
 
 		signups[i], _ = signupRequest.Execute(t).Resources()

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -12,13 +12,13 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	authsupport "github.com/codeready-toolchain/toolchain-common/pkg/test/auth"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/gofrs/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+func createMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, capacity int, ensuresMur bool) []*toolchainv1alpha1.UserSignup {
 	hostAwait := awaitilities.Host()
 	signups := make([]*toolchainv1alpha1.UserSignup, capacity)
 	for i := 0; i < capacity; i++ {
@@ -30,17 +30,29 @@ func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			// skip this one, it already exists
 			continue
 		}
-		// Create an approved UserSignup resource
-		signups[i], _ = NewSignupRequest(awaitilities).
+
+		signupRequest := NewSignupRequest(awaitilities).
 			Username(name).
 			Email(fmt.Sprintf("multiple-signup-testuser-%d@test.com", i)).
 			ManuallyApprove().
-			TargetCluster(targetCluster).
-			EnsureMUR().
-			Execute(t).
-			Resources()
+			TargetCluster(targetCluster)
+
+		if ensuresMur {
+			signupRequest = signupRequest.EnsureMUR().RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...)
+		}
+
+		signups[i], _ = signupRequest.Execute(t).Resources()
+
 	}
 	return signups
+}
+
+func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+	return createMultipleSignups(t, awaitilities, targetCluster, capacity, false)
+}
+
+func CreateMultipleSignupsWithMURs(t *testing.T, awaitilities wait.Awaitilities, targetCluster *wait.MemberAwaitility, capacity int) []*toolchainv1alpha1.UserSignup {
+	return createMultipleSignups(t, awaitilities, targetCluster, capacity, true)
 }
 
 type IdentityOption func(*authsupport.Identity) error

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -36,6 +36,7 @@ func CreateMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			Email(fmt.Sprintf("multiple-signup-testuser-%d@test.com", i)).
 			ManuallyApprove().
 			TargetCluster(targetCluster).
+			EnsureMUR().
 			Execute(t).
 			Resources()
 	}


### PR DESCRIPTION
# Description

[Sporadically](https://search.dptools.openshift.org/?search=waited+for+metric+%27sandbox_master_user_records%5C%7B%5C%5Bdomain+external%5C%5D%5C%7D%27+to+reach+%272%27.&maxAge=336h&context=1&type=build-log&name=.*codeready-toolchain.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job), we are hitting this flaky test:

```
=== RUN   TestForceMetricsSynchronization/tampering_activation-counter_annotations/verify_metrics_did_not_change_after_restarting_pod_without_forcing_recount
    awaitility.go:374: waiting for metric 'sandbox_master_user_records{[domain external]}' to reach '2'
    awaitility.go:382: 
        	Error Trace:	/tmp/toolchain-e2e/testsupport/wait/awaitility.go:382
        	            				/tmp/toolchain-e2e/testsupport/wait/awaitility.go:117
        	            				/tmp/toolchain-e2e/test/metrics/metrics_test.go:702
        	Error:      	Received unexpected error:
        	            	timed out waiting for the condition
        	Test:       	TestForceMetricsSynchronization/tampering_activation-counter_annotations/verify_metrics_did_not_change_after_restarting_pod_without_forcing_recount
        	Messages:   	waited for metric 'sandbox_master_user_records{[domain external]}' to reach '2'. Current value: 1
=== NAME  TestForceMetricsSynchronization
    clean.go:113: deleting UserSignup: multiple-signup-testuser-1 ...
    clean.go:113: deleting UserSignup: multiple-signup-testuser-0 ...
    clean.go:131: waiting until UserSignup: multiple-signup-testuser-0 is completely deleted
    clean.go:131: waiting until UserSignup: multiple-signup-testuser-1 is completely deleted
    clean.go:204: the UserSignup multiple-signup-testuser-1 doesn't have CompliantUsername set
    clean.go:238: the UserSignup multiple-signup-testuser-1 doesn't have CompliantUsername set
    clean.go:184: the related MasterUserRecord: multiple-signup-test is deleted as well
```

As we can see on the logs, "the UserSignup multiple-signup-testuser-1 doesn't have CompliantUsername set", so at this time, it does not have the MUR, and that's why it failed.

When the test `TestForceMetricsSynchronization` fails, when it tries to get the metric `sandbox_master_user_records`,  the second UserSignup does not yet have the CompliantUsername set probably because it does not have enough time to generate it between the time that the UserSignup is created and the time the test access the metrics.

Since we are not ensuring MUR in the function `CreateMultipleSignup`, we are not ensuring that the UserSignup has already generated the CompliantUsername (CompliantUsername is needed for the MUR) before continuing the test flow.

For now, this is just a theory that I hope it will solve it :D 

## Issue ticket number and link
[SANDBOX-624](https://issues.redhat.com/browse/SANDBOX-624)