### PR TITLE
fix flaky: copy ToolchainCluster secret

### DIFF
--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -54,25 +54,22 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		require.Equal(t, current.Name, secret.Labels[toolchainv1alpha1.ToolchainClusterLabel], "the secret of the ToolchainCluster %s is not labeled", client.ObjectKeyFromObject(&current))
 	})
 
-	t.Run(fmt.Sprintf("create new ToolchainCluster based on '%s' with correct data and expect to be ready", string(await.ClusterName)), func(t *testing.T) {
+	t.Run(fmt.Sprintf("create new ToolchainCluster based on '%s' with correct data and expect to be ready", current.Name), func(t *testing.T) {
 		// given
-		name := "new-ready-" + string(await.ClusterName)
+		secretCopy := copySecret(t, await, current.Namespace, current.Spec.SecretRef.Name, "new-ready-")
+
+		name := "new-ready-" + current.Name
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			apiEndpoint(current.Spec.APIEndpoint),
 			caBundle(current.Spec.CABundle),
-			secretRef(current.Spec.SecretRef.Name),
+			secretRef(secretCopy.Name),
 			owner(current.Labels["ownerClusterName"]),
 			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
-		t.Cleanup(func() {
-			if err := await.Client.Delete(context.TODO(), toolchainCluster); err != nil && !errors.IsNotFound(err) {
-				require.NoError(t, err)
-			}
-		})
 
 		// when
-		err := await.Client.Create(context.TODO(), toolchainCluster)
+		err = await.CreateWithCleanup(t, toolchainCluster)
 		require.NoError(t, err)
 		// wait for toolchaincontroller to reconcile
 		time.Sleep(1 * time.Second)
@@ -100,25 +97,22 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		require.NoError(t, err)
 	})
 
-	t.Run(fmt.Sprintf("create new ToolchainCluster based on '%s' with incorrect data and expect to be offline", string(await.ClusterName)), func(t *testing.T) {
+	t.Run(fmt.Sprintf("create new ToolchainCluster based on '%s' with incorrect data and expect to be offline", current.Name), func(t *testing.T) {
 		// given
-		name := "new-offline-" + string(await.ClusterName)
+		secretCopy := copySecret(t, await, current.Namespace, current.Spec.SecretRef.Name, "new-offline-")
+
+		name := "new-offline-" + current.Name
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			apiEndpoint("https://1.2.3.4:8443"),
 			caBundle(current.Spec.CABundle),
-			secretRef(current.Spec.SecretRef.Name),
+			secretRef(secretCopy.Name),
 			owner(current.Labels["ownerClusterName"]),
 			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
-		t.Cleanup(func() {
-			if err := await.Client.Delete(context.TODO(), toolchainCluster); err != nil && !errors.IsNotFound(err) {
-				require.NoError(t, err)
-			}
-		})
 
 		// when
-		err := await.Client.Create(context.TODO(), toolchainCluster)
+		err := await.CreateWithCleanup(t, toolchainCluster)
 		// wait for toolchaincontroller to reconcile
 		time.Sleep(1 * time.Second)
 
@@ -148,6 +142,24 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		)
 		require.NoError(t, err)
 	})
+}
+
+func copySecret(t *testing.T, await *wait.Awaitility, namespace, name, prefix string) *corev1.Secret {
+	secret := &corev1.Secret{}
+	require.NoError(t, await.Client.Get(context.TODO(), test.NamespacedName(namespace, name), secret))
+
+	secretCopy := &corev1.Secret{}
+	secretCopy.Namespace = secret.Namespace
+	secretCopy.Name = prefix + secret.Name
+	secretCopy.Type = secret.Type
+	secretCopy.Data = map[string][]byte{}
+	for key, value := range secret.Data {
+		secretCopy.Data[key] = value
+	}
+	err := await.CreateWithCleanup(t, secretCopy)
+	require.NoError(t, err)
+
+	return secretCopy
 }
 
 func newToolchainCluster(namespace, name string, options ...clusterOption) *toolchainv1alpha1.ToolchainCluster {

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -145,10 +145,7 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 }
 
 func generateNewName(prefix, baseName string) string {
-	if len(prefix+baseName) >= 63 {
-		return prefix + baseName[len(prefix):]
-	}
-	return prefix + baseName
+	return (prefix + baseName)[:63]
 }
 
 func copySecret(t *testing.T, await *wait.Awaitility, namespace, name, prefix string) *corev1.Secret {

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -58,7 +58,7 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		// given
 		secretCopy := copySecret(t, await, current.Namespace, current.Spec.SecretRef.Name, "new-ready-")
 
-		name := "new-ready-" + current.Name
+		name := generateNewName("new-ready-", current.Name)
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			apiEndpoint(current.Spec.APIEndpoint),
 			caBundle(current.Spec.CABundle),
@@ -101,7 +101,7 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		// given
 		secretCopy := copySecret(t, await, current.Namespace, current.Spec.SecretRef.Name, "new-offline-")
 
-		name := "new-offline-" + current.Name
+		name := generateNewName("new-offline-", current.Name)
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			apiEndpoint("https://1.2.3.4:8443"),
 			caBundle(current.Spec.CABundle),
@@ -142,6 +142,13 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 		)
 		require.NoError(t, err)
 	})
+}
+
+func generateNewName(prefix, baseName string) string {
+	if len(prefix+baseName) >= 63 {
+		return prefix + baseName[len(prefix):]
+	}
+	return prefix + baseName
 }
 
 func copySecret(t *testing.T, await *wait.Awaitility, namespace, name, prefix string) *corev1.Secret {


### PR DESCRIPTION
We need to copy the secret that is referenced by the ToolchainCluster CR. 
What happens now is that the migration code in ToolchainCluster controller updates the secret with the expected label `toolchain.dev.openshift.com/toolchain-cluster` set to the name of the ToolchainCluster CR, but since the same secret is used by two ToolchainClusters then there is a huge number of immediate updates of the same secret in a row when the controller is changing the label from one value to another. This increase of updates can cause instability of the controller/operator that we can see in openshift-ci around the time when this particular test is running.

**EDIT**: Taking a second look at the ToolchainCluster controller, the flow described above is probably not valid. The ToolchainCluster controller doesn't watch the secrets, so the updates of the label to a different value shouldn't trigger new reconcile. But let's try this, copying the secret (and not reusing the existing one) is a good thing anyway.

**EDIT 2**: Ok, it wasn't the cause because I just faced the same error in this PR as well https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/codeready-toolchain_toolchain-e2e/980/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1791354153084129280

**EDIT 3**: As discussed in this thread https://redhat-internal.slack.com/archives/CHK0J6HT6/p1715939245467529 I found a root cause of the problem. The test is adding a prefix to the already existing names of the ToolchainClusters, but in openshift-ci the name is already long, so with the prefix it exceeds the max number of chars (63) we can set at labels. Fix: [c57651a](https://github.com/codeready-toolchain/toolchain-e2e/pull/980/commits/c57651a9ba48f52d6519b3463967aad1929ad32a)