### PR TITLE
Add rules for SecretStore and ExternalSecret CRs 

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1688,6 +1688,11 @@ func appstudioAdminUserActionsRole() spaceRoleObjectsCheck {
 					Resources: []string{"projects", "projectdevelopmentstreams", "projectdevelopmentstreamtemplates"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
+				{
+					APIGroups: []string{"external-secrets.io/v1beta1"},
+					Resources: []string{"secretstores", "externalsecrets"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				},
 			},
 		}
 


### PR DESCRIPTION
This change adds a Role and RoleBinding to the tenant use to CRUD on SecretStore and ExternalSecret CRs provided by external-secrets.io

This is meant for testing if this can enable tenants to create SecretStore and ExternalSecret from their own self-hosted or managed secrets backend

Paired PR in `codeready-toolchain/host-operator` - https://github.com/codeready-toolchain/host-operator/pull/1034