### PR TITLE
Remove version from apiGroups

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -1689,7 +1689,7 @@ func appstudioAdminUserActionsRole() spaceRoleObjectsCheck {
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 				{
-					APIGroups: []string{"external-secrets.io/v1beta1"},
+					APIGroups: []string{"external-secrets.io"},
 					Resources: []string{"secretstores", "externalsecrets"},
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},


### PR DESCRIPTION
Intended role was not applied properly due to including version in apiGroups.
Removing the same as part of this PR
https://github.com/codeready-toolchain/host-operator/pull/1038