### PR TITLE
test: SANDBOX-629: drop Resources and also return space and token in Execute

### DIFF
--- a/test/e2e/default_tier_test.go
+++ b/test/e2e/default_tier_test.go
@@ -22,8 +22,7 @@ func TestSetDefaultTier(t *testing.T) {
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
@@ -35,7 +34,6 @@ func TestSetDefaultTier(t *testing.T) {
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 	})
 }

--- a/test/e2e/default_tier_test.go
+++ b/test/e2e/default_tier_test.go
@@ -23,7 +23,7 @@ func TestSetDefaultTier(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
@@ -36,6 +36,6 @@ func TestSetDefaultTier(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 	})
 }

--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -56,7 +56,7 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 	require.NoError(t, memberAwait.CreateWithCleanup(t, preexistingIdentity))
 
 	// Create and approve signup
-	signup, _, _, _ := NewSignupRequest(awaitilities).
+	u := NewSignupRequest(awaitilities).
 		Username(username).
 		IdentityID(identityID).
 		ManuallyApprove().
@@ -64,6 +64,7 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	signup := u.UserSignup
 
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
 

--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -56,14 +56,14 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 	require.NoError(t, memberAwait.CreateWithCleanup(t, preexistingIdentity))
 
 	// Create and approve signup
-	signup, _, _ := NewSignupRequest(awaitilities).
+	signup, _, _, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		IdentityID(identityID).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
 

--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -56,14 +56,14 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 	require.NoError(t, memberAwait.CreateWithCleanup(t, preexistingIdentity))
 
 	// Create and approve signup
-	signup, _ := NewSignupRequest(awaitilities).
+	signup, _, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		IdentityID(identityID).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	VerifyResourcesProvisionedForSignup(t, awaitilities, signup, "deactivate30", "appstudio")
 

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -67,42 +67,42 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup, _, _ := NewSignupRequest(awaitilities).
+	johnSignup, _, _, _ := NewSignupRequest(awaitilities).
 		Username(johnsmithName).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	extrajohnName := "extrajohn"
-	johnExtraSignup, _, _ := NewSignupRequest(awaitilities).
+	johnExtraSignup, _, _, _ := NewSignupRequest(awaitilities).
 		Username(extrajohnName).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	targetedJohnName := "targetedjohn"
-	targetedJohnSignup, _, _ := NewSignupRequest(awaitilities).
+	targetedJohnSignup, _, _, _ := NewSignupRequest(awaitilities).
 		Username(targetedJohnName).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait2).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	originalSubJohnName := "originalsubjohn"
 	originalSubJohnClaim := "originalsub:john"
-	originalSubJohnSignup, _, _ := NewSignupRequest(awaitilities).
+	originalSubJohnSignup, _, originalSubJohnSpace, _ := NewSignupRequest(awaitilities).
 		Username(originalSubJohnName).
 		OriginalSub(originalSubJohnClaim).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	// Confirm the originalSub property has been set during signup
 	require.Equal(t, originalSubJohnClaim, originalSubJohnSignup.Spec.IdentityClaims.OriginalSub)
@@ -236,14 +236,14 @@ func TestE2EFlow(t *testing.T) {
 		userNamespace := "laracroft-dev"
 		cmName := "test-useraccount-delete-1"
 
-		laraSignUp, _, _ := NewSignupRequest(awaitilities).
+		laraSignUp, _, _, _ := NewSignupRequest(awaitilities).
 			Username(laraUserName).
 			Email("laracroft@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		require.Equal(t, "laracroft", laraSignUp.Status.CompliantUsername)
 
@@ -329,14 +329,14 @@ func TestE2EFlow(t *testing.T) {
 	})
 
 	t.Run("delete namespaced scoped resources of users and expect recreation", func(t *testing.T) {
-		userSignup, _, _ := NewSignupRequest(awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(awaitilities).
 			Username("wonderwoman").
 			Email("wonderwoman@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 		devNs := corev1.Namespace{}
 		err := memberAwait.Client.Get(context.TODO(), types.NamespacedName{Name: "wonderwoman-dev"}, &devNs)
 		require.NoError(t, err)
@@ -444,7 +444,7 @@ func TestE2EFlow(t *testing.T) {
 		// owner label to locate them
 
 		// First, find the MUR
-		mur, err := hostAwait.WaitForMasterUserRecord(t, originalSubJohnSignup.Status.CompliantUsername)
+		mur, err := hostAwait.WaitForMasterUserRecord(t, originalSubJohnSpace.Name)
 		require.NoError(t, err)
 
 		memberAwait := GetMurTargetMember(t, awaitilities, mur)

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -67,42 +67,42 @@ func TestE2EFlow(t *testing.T) {
 
 	// Create and approve "johnsmith" and "extrajohn" signups
 	johnsmithName := "johnsmith"
-	johnSignup, _ := NewSignupRequest(awaitilities).
+	johnSignup, _, _ := NewSignupRequest(awaitilities).
 		Username(johnsmithName).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	extrajohnName := "extrajohn"
-	johnExtraSignup, _ := NewSignupRequest(awaitilities).
+	johnExtraSignup, _, _ := NewSignupRequest(awaitilities).
 		Username(extrajohnName).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	targetedJohnName := "targetedjohn"
-	targetedJohnSignup, _ := NewSignupRequest(awaitilities).
+	targetedJohnSignup, _, _ := NewSignupRequest(awaitilities).
 		Username(targetedJohnName).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait2).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	originalSubJohnName := "originalsubjohn"
 	originalSubJohnClaim := "originalsub:john"
-	originalSubJohnSignup, _ := NewSignupRequest(awaitilities).
+	originalSubJohnSignup, _, _ := NewSignupRequest(awaitilities).
 		Username(originalSubJohnName).
 		OriginalSub(originalSubJohnClaim).
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	// Confirm the originalSub property has been set during signup
 	require.Equal(t, originalSubJohnClaim, originalSubJohnSignup.Spec.IdentityClaims.OriginalSub)
@@ -236,14 +236,14 @@ func TestE2EFlow(t *testing.T) {
 		userNamespace := "laracroft-dev"
 		cmName := "test-useraccount-delete-1"
 
-		laraSignUp, _ := NewSignupRequest(awaitilities).
+		laraSignUp, _, _ := NewSignupRequest(awaitilities).
 			Username(laraUserName).
 			Email("laracroft@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		require.Equal(t, "laracroft", laraSignUp.Status.CompliantUsername)
 
@@ -329,14 +329,14 @@ func TestE2EFlow(t *testing.T) {
 	})
 
 	t.Run("delete namespaced scoped resources of users and expect recreation", func(t *testing.T) {
-		userSignup, _ := NewSignupRequest(awaitilities).
+		userSignup, _, _ := NewSignupRequest(awaitilities).
 			Username("wonderwoman").
 			Email("wonderwoman@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 		devNs := corev1.Namespace{}
 		err := memberAwait.Client.Get(context.TODO(), types.NamespacedName{Name: "wonderwoman-dev"}, &devNs)
 		require.NoError(t, err)

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -33,13 +33,15 @@ func TestNSTemplateTiers(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 
-	testingtiers, _, space, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username("testnstemplatetiers").
 		ManuallyApprove().
 		TargetCluster(awaitilities.Member1()).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	testingtiers := user.UserSignup
+	space := user.Space
 
 	// all tiers to check - keep the base as the last one, it will verify downgrade back to the default tier at the end of the test
 	tiersToCheck := []string{"advanced", "baseextendedidling", "baselarge", "test", "appstudio", "appstudiolarge", "appstudio-env", "base1ns", "base1nsnoidling", "base1ns6didler", "base"}
@@ -153,7 +155,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	t.Run("test reset deactivating state when promoting user", func(t *testing.T) {
-		userSignup, _, _, _ := NewSignupRequest(awaitilities).
+		user := NewSignupRequest(awaitilities).
 			Username("promoteuser").
 			Email("promoteuser@redhat.com").
 			ManuallyApprove().
@@ -161,7 +163,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
-
+		userSignup := user.UserSignup
 		// Set the deactivating state on the UserSignup
 		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
@@ -206,7 +208,7 @@ func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.Cus
 	// and wait until they are all provisioned by calling EnsureMUR()
 	userSignups := make([]*toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
-		userSignups[i], _, _, _ = NewSignupRequest(awaitilities).
+		user := NewSignupRequest(awaitilities).
 			Username(fmt.Sprintf(nameFmt, i)).
 			ManuallyApprove().
 			WaitForMUR().
@@ -214,6 +216,7 @@ func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.Cus
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			TargetCluster(targetCluster).
 			Execute(t)
+		userSignups[i] = user.UserSignup
 	}
 
 	// let's promote to users the new tier

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -163,9 +163,8 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
-		userSignup := user.UserSignup
 		// Set the deactivating state on the UserSignup
-		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, user.UserSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivating(us, true)
 			})

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -33,14 +33,14 @@ func TestNSTemplateTiers(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 
-	testingtiers, _ := NewSignupRequest(awaitilities).
+	testingtiers, _, _ := NewSignupRequest(awaitilities).
 		Username("testnstemplatetiers").
 		ManuallyApprove().
 		TargetCluster(awaitilities.Member1()).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t).
-		Resources()
+		Resources(t)
 
 	// all tiers to check - keep the base as the last one, it will verify downgrade back to the default tier at the end of the test
 	tiersToCheck := []string{"advanced", "baseextendedidling", "baselarge", "test", "appstudio", "appstudiolarge", "appstudio-env", "base1ns", "base1nsnoidling", "base1ns6didler", "base"}
@@ -154,7 +154,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 	awaitilities := WaitForDeployments(t)
 	hostAwait := awaitilities.Host()
 	t.Run("test reset deactivating state when promoting user", func(t *testing.T) {
-		userSignup, _ := NewSignupRequest(awaitilities).
+		userSignup, _, _ := NewSignupRequest(awaitilities).
 			Username("promoteuser").
 			Email("promoteuser@redhat.com").
 			ManuallyApprove().
@@ -162,7 +162,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 
 		// Set the deactivating state on the UserSignup
 		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
@@ -208,7 +208,7 @@ func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.Cus
 	// and wait until they are all provisioned by calling EnsureMUR()
 	userSignups := make([]*toolchainv1alpha1.UserSignup, count)
 	for i := 0; i < count; i++ {
-		userSignups[i], _ = NewSignupRequest(awaitilities).
+		userSignups[i], _, _ = NewSignupRequest(awaitilities).
 			Username(fmt.Sprintf(nameFmt, i)).
 			ManuallyApprove().
 			WaitForMUR().
@@ -216,7 +216,7 @@ func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.Cus
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			TargetCluster(targetCluster).
 			Execute(t).
-			Resources()
+			Resources(t)
 	}
 
 	// let's promote to users the new tier

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -977,7 +977,7 @@ func tenantNsName(username string) string {
 
 func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *proxyUser) {
 	// Create and approve signup
-	signup, _, space, token := NewSignupRequest(awaitilities).
+	u := NewSignupRequest(awaitilities).
 		Username(user.username).
 		IdentityID(user.identityID).
 		ManuallyApprove().
@@ -985,9 +985,9 @@ func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *pro
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-	user.signup = signup
-	user.token = token
-	tiers.MoveSpaceToTier(t, awaitilities.Host(), space.Name, "appstudio")
+	user.signup = u.UserSignup
+	user.token = u.Token
+	tiers.MoveSpaceToTier(t, awaitilities.Host(), u.Space.Name, "appstudio")
 	VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "deactivate30", "appstudio")
 	user.compliantUsername = user.signup.Status.CompliantUsername
 	_, err := awaitilities.Host().WaitForMasterUserRecord(t, user.compliantUsername, wait.UntilMasterUserRecordHasCondition(wait.Provisioned()))

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -985,7 +985,7 @@ func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *pro
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-	user.signup, _ = req.Resources()
+	user.signup, _, _ = req.Resources(t)
 	user.token = req.GetToken()
 	tiers.MoveSpaceToTier(t, awaitilities.Host(), user.signup.Status.CompliantUsername, "appstudio")
 	VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "deactivate30", "appstudio")

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -977,7 +977,7 @@ func tenantNsName(username string) string {
 
 func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *proxyUser) {
 	// Create and approve signup
-	req := NewSignupRequest(awaitilities).
+	signup, _, space, token := NewSignupRequest(awaitilities).
 		Username(user.username).
 		IdentityID(user.identityID).
 		ManuallyApprove().
@@ -985,9 +985,9 @@ func createAppStudioUser(t *testing.T, awaitilities wait.Awaitilities, user *pro
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-	user.signup, _, _ = req.Resources(t)
-	user.token = req.GetToken()
-	tiers.MoveSpaceToTier(t, awaitilities.Host(), user.signup.Status.CompliantUsername, "appstudio")
+	user.signup = signup
+	user.token = token
+	tiers.MoveSpaceToTier(t, awaitilities.Host(), space.Name, "appstudio")
 	VerifyResourcesProvisionedForSignup(t, awaitilities, user.signup, "deactivate30", "appstudio")
 	user.compliantUsername = user.signup.Status.CompliantUsername
 	_, err := awaitilities.Host().WaitForMasterUserRecord(t, user.compliantUsername, wait.UntilMasterUserRecordHasCondition(wait.Provisioned()))

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -781,7 +781,7 @@ func TestUsernames(t *testing.T) {
 	t.Run("get usernames 200 response", func(t *testing.T) {
 		// given
 		// we have a user in the system
-		_, mur := NewSignupRequest(awaitilities).
+		_, mur, _ := NewSignupRequest(awaitilities).
 			Username("testgetusernames").
 			Email("testgetusernames@redhat.com").
 			ManuallyApprove().
@@ -790,7 +790,7 @@ func TestUsernames(t *testing.T) {
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			NoSpace().
 			Execute(t).
-			Resources()
+			Resources(t)
 
 		// when
 		// we call the get usernames endpoint to get the user

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -781,7 +781,7 @@ func TestUsernames(t *testing.T) {
 	t.Run("get usernames 200 response", func(t *testing.T) {
 		// given
 		// we have a user in the system
-		_, mur, _ := NewSignupRequest(awaitilities).
+		_, mur, _, _ := NewSignupRequest(awaitilities).
 			Username("testgetusernames").
 			Email("testgetusernames@redhat.com").
 			ManuallyApprove().
@@ -789,8 +789,7 @@ func TestUsernames(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			NoSpace().
-			Execute(t).
-			Resources(t)
+			Execute(t)
 
 		// when
 		// we call the get usernames endpoint to get the user

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -790,11 +790,10 @@ func TestUsernames(t *testing.T) {
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			NoSpace().
 			Execute(t)
-		mur := user.MUR
 		// when
 		// we call the get usernames endpoint to get the user
 		response := NewHTTPRequest(t).
-			InvokeEndpoint("GET", route+"/api/v1/usernames/"+mur.GetName(), token, "", http.StatusOK).
+			InvokeEndpoint("GET", route+"/api/v1/usernames/"+user.MUR.GetName(), token, "", http.StatusOK).
 			UnmarshalSlice()
 
 		// then

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -781,7 +781,7 @@ func TestUsernames(t *testing.T) {
 	t.Run("get usernames 200 response", func(t *testing.T) {
 		// given
 		// we have a user in the system
-		_, mur, _, _ := NewSignupRequest(awaitilities).
+		user := NewSignupRequest(awaitilities).
 			Username("testgetusernames").
 			Email("testgetusernames@redhat.com").
 			ManuallyApprove().
@@ -790,7 +790,7 @@ func TestUsernames(t *testing.T) {
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			NoSpace().
 			Execute(t)
-
+		mur := user.MUR
 		// when
 		// we call the get usernames endpoint to get the user
 		response := NewHTTPRequest(t).

--- a/test/e2e/parallel/retarget_test.go
+++ b/test/e2e/parallel/retarget_test.go
@@ -26,12 +26,9 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	userSignup := user.UserSignup
-	mur := user.MUR
-	space := user.Space
 
 	// when
-	space, err := hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
+	space, err := hostAwait.UpdateSpace(t, user.Space.Name, func(s *toolchainv1alpha1.Space) {
 		s.Spec.TargetCluster = member2Await.ClusterName
 	})
 	require.NoError(t, err)
@@ -45,7 +42,7 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 	_, err = member2Await.WaitForNSTmplSet(t, space.Name)
 	require.NoError(t, err)
 	VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name, UntilSpaceHasStatusTargetCluster(member2Await.ClusterName))
-	VerifyUserRelatedResources(t, awaitilities, userSignup, mur.Spec.TierName, ExpectUserAccountIn(member2Await))
+	VerifyUserRelatedResources(t, awaitilities, user.UserSignup, user.MUR.Spec.TierName, ExpectUserAccountIn(member2Await))
 }
 
 func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T) {
@@ -62,7 +59,6 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith1 := userToShareWith1.UserSignup
 	murToShareWith1 := userToShareWith1.MUR
 
 	userToShareWith2 := NewSignupRequest(awaitilities).
@@ -71,7 +67,6 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith2 := userToShareWith2.UserSignup
 	murToShareWith2 := userToShareWith2.MUR
 
 	user := NewSignupRequest(awaitilities).
@@ -80,7 +75,6 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	userSignup := user.UserSignup
 	ownerMur := user.MUR
 	spaceToMove := user.Space
 
@@ -111,13 +105,13 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 			SpaceRole(tier.Spec.SpaceRoles["admin"].TemplateRef, ownerMur.Name, murToShareWith1.Name, murToShareWith2.Name)))
 	require.NoError(t, err)
 	VerifyResourcesProvisionedForSpace(t, awaitilities, spaceToMove.Name, UntilSpaceHasStatusTargetCluster(member2Await.ClusterName))
-	VerifyUserRelatedResources(t, awaitilities, userSignup, ownerMur.Spec.TierName, ExpectUserAccountIn(member2Await))
+	VerifyUserRelatedResources(t, awaitilities, user.UserSignup, ownerMur.Spec.TierName, ExpectUserAccountIn(member2Await))
 
 	// the move doesn't have any effect on the other signups and MURs
-	VerifyUserRelatedResources(t, awaitilities, signupToShareWith1, murToShareWith1.Spec.TierName, ExpectUserAccountIn(member1Await))
+	VerifyUserRelatedResources(t, awaitilities, userToShareWith1.UserSignup, murToShareWith1.Spec.TierName, ExpectUserAccountIn(member1Await))
 	VerifyResourcesProvisionedForSpace(t, awaitilities, murToShareWith1.Name, UntilSpaceHasStatusTargetCluster(member1Await.ClusterName))
 
-	VerifyUserRelatedResources(t, awaitilities, signupToShareWith2, murToShareWith2.Spec.TierName, ExpectUserAccountIn(member2Await))
+	VerifyUserRelatedResources(t, awaitilities, userToShareWith2.UserSignup, murToShareWith2.Spec.TierName, ExpectUserAccountIn(member2Await))
 	VerifyResourcesProvisionedForSpace(t, awaitilities, murToShareWith2.Name, UntilSpaceHasStatusTargetCluster(member2Await.ClusterName))
 }
 
@@ -139,7 +133,6 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith1 := userToShareWith1.UserSignup
 	murToShareWith1 := userToShareWith1.MUR
 
 	userToShareWith2 := NewSignupRequest(awaitilities).
@@ -148,7 +141,6 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith2 := userToShareWith2.UserSignup
 	murToShareWith2 := userToShareWith2.MUR
 
 	user := NewSignupRequest(awaitilities).
@@ -157,7 +149,6 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	userSignup := user.UserSignup
 	ownerMur := user.MUR
 	spaceToMove := user.Space
 
@@ -194,13 +185,13 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 			SpaceRole(tier.Spec.SpaceRoles["admin"].TemplateRef, ownerMur.Name)))
 	require.NoError(t, err)
 	VerifyResourcesProvisionedForSpace(t, awaitilities, spaceToMove.Name, UntilSpaceHasStatusTargetCluster(member2Await.ClusterName))
-	VerifyUserRelatedResources(t, awaitilities, userSignup, ownerMur.Spec.TierName, ExpectUserAccountIn(member2Await))
+	VerifyUserRelatedResources(t, awaitilities, user.UserSignup, ownerMur.Spec.TierName, ExpectUserAccountIn(member2Await))
 
 	// the move doesn't have any effect on the other signups and MURs
-	VerifyUserRelatedResources(t, awaitilities, signupToShareWith1, murToShareWith1.Spec.TierName, ExpectUserAccountIn(member1Await))
+	VerifyUserRelatedResources(t, awaitilities, userToShareWith1.UserSignup, murToShareWith1.Spec.TierName, ExpectUserAccountIn(member1Await))
 	VerifyResourcesProvisionedForSpace(t, awaitilities, murToShareWith1.Name, UntilSpaceHasStatusTargetCluster(member1Await.ClusterName))
 
-	VerifyUserRelatedResources(t, awaitilities, signupToShareWith2, murToShareWith2.Spec.TierName, ExpectUserAccountIn(member2Await))
+	VerifyUserRelatedResources(t, awaitilities, userToShareWith2.UserSignup, murToShareWith2.Spec.TierName, ExpectUserAccountIn(member2Await))
 	VerifyResourcesProvisionedForSpace(t, awaitilities, murToShareWith2.Name, UntilSpaceHasStatusTargetCluster(member2Await.ClusterName))
 
 	// no SBRs are present

--- a/test/e2e/parallel/retarget_test.go
+++ b/test/e2e/parallel/retarget_test.go
@@ -20,12 +20,12 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	userSignup, mur, space := NewSignupRequest(awaitilities).
+	userSignup, mur, space, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	// when
 	space, err := hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
@@ -53,25 +53,25 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1, _ := NewSignupRequest(awaitilities).
+	signupToShareWith1, murToShareWith1, _, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
-	signupToShareWith2, murToShareWith2, _ := NewSignupRequest(awaitilities).
+		Execute(t)
+	signupToShareWith2, murToShareWith2, _, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
-	userSignup, ownerMur, spaceToMove := NewSignupRequest(awaitilities).
+	userSignup, ownerMur, spaceToMove, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith1, spaceToMove, "admin")
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith2, spaceToMove, "admin")
@@ -122,25 +122,25 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1, _ := NewSignupRequest(awaitilities).
+	signupToShareWith1, murToShareWith1, _, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
-	signupToShareWith2, murToShareWith2, _ := NewSignupRequest(awaitilities).
+		Execute(t)
+	signupToShareWith2, murToShareWith2, _, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
-	userSignup, ownerMur, spaceToMove := NewSignupRequest(awaitilities).
+	userSignup, ownerMur, spaceToMove, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	spacebinding.CreateSpaceBindingRequest(t, awaitilities, member1Await.ClusterName,
 		spacebinding.WithSpecSpaceRole("admin"),

--- a/test/e2e/parallel/retarget_test.go
+++ b/test/e2e/parallel/retarget_test.go
@@ -20,20 +20,15 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	userSignup, mur := NewSignupRequest(awaitilities).
+	userSignup, mur, space := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
-
-	space, err := hostAwait.WaitForSpace(t, userSignup.Status.CompliantUsername,
-		UntilSpaceHasStatusTargetCluster(member1Await.ClusterName),
-		UntilSpaceHasAnyTierNameSet())
-	require.NoError(t, err)
+		Execute(t).Resources(t)
 
 	// when
-	space, err = hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
+	space, err := hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
 		s.Spec.TargetCluster = member2Await.ClusterName
 	})
 	require.NoError(t, err)
@@ -58,30 +53,25 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1 := NewSignupRequest(awaitilities).
+	signupToShareWith1, murToShareWith1, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
-	signupToShareWith2, murToShareWith2 := NewSignupRequest(awaitilities).
+		Execute(t).Resources(t)
+	signupToShareWith2, murToShareWith2, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
-	userSignup, ownerMur := NewSignupRequest(awaitilities).
+	userSignup, ownerMur, spaceToMove := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
-
-	spaceToMove, err := hostAwait.WaitForSpace(t, userSignup.Status.CompliantUsername,
-		UntilSpaceHasStatusTargetCluster(member1Await.ClusterName),
-		UntilSpaceHasAnyTierNameSet())
-	require.NoError(t, err)
+		Execute(t).Resources(t)
 
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith1, spaceToMove, "admin")
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith2, spaceToMove, "admin")
@@ -132,30 +122,25 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1 := NewSignupRequest(awaitilities).
+	signupToShareWith1, murToShareWith1, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
-	signupToShareWith2, murToShareWith2 := NewSignupRequest(awaitilities).
+		Execute(t).Resources(t)
+	signupToShareWith2, murToShareWith2, _ := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
-	userSignup, ownerMur := NewSignupRequest(awaitilities).
+	userSignup, ownerMur, spaceToMove := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-		Execute(t).Resources()
-
-	spaceToMove, err := hostAwait.WaitForSpace(t, userSignup.Status.CompliantUsername,
-		UntilSpaceHasStatusTargetCluster(member1Await.ClusterName),
-		UntilSpaceHasAnyTierNameSet())
-	require.NoError(t, err)
+		Execute(t).Resources(t)
 
 	spacebinding.CreateSpaceBindingRequest(t, awaitilities, member1Await.ClusterName,
 		spacebinding.WithSpecSpaceRole("admin"),

--- a/test/e2e/parallel/retarget_test.go
+++ b/test/e2e/parallel/retarget_test.go
@@ -20,12 +20,15 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	userSignup, mur, space, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
+	userSignup := user.UserSignup
+	mur := user.MUR
+	space := user.Space
 
 	// when
 	space, err := hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
@@ -53,25 +56,33 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1, _, _ := NewSignupRequest(awaitilities).
+	userToShareWith1 := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith2, murToShareWith2, _, _ := NewSignupRequest(awaitilities).
+	signupToShareWith1 := userToShareWith1.UserSignup
+	murToShareWith1 := userToShareWith1.MUR
+
+	userToShareWith2 := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
+	signupToShareWith2 := userToShareWith2.UserSignup
+	murToShareWith2 := userToShareWith2.MUR
 
-	userSignup, ownerMur, spaceToMove, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
+	userSignup := user.UserSignup
+	ownerMur := user.MUR
+	spaceToMove := user.Space
 
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith1, spaceToMove, "admin")
 	spacebinding.CreateSpaceBinding(t, hostAwait, murToShareWith2, spaceToMove, "admin")
@@ -122,25 +133,33 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 	member1Await := awaitilities.Member1()
 	member2Await := awaitilities.Member2()
 
-	signupToShareWith1, murToShareWith1, _, _ := NewSignupRequest(awaitilities).
+	userToShareWith1 := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
-	signupToShareWith2, murToShareWith2, _, _ := NewSignupRequest(awaitilities).
+	signupToShareWith1 := userToShareWith1.UserSignup
+	murToShareWith1 := userToShareWith1.MUR
+
+	userToShareWith2 := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member2Await).
 		WaitForMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
+	signupToShareWith2 := userToShareWith2.UserSignup
+	murToShareWith2 := userToShareWith2.MUR
 
-	userSignup, ownerMur, spaceToMove, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(member1Await).
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		Execute(t)
+	userSignup := user.UserSignup
+	ownerMur := user.MUR
+	spaceToMove := user.Space
 
 	spacebinding.CreateSpaceBindingRequest(t, awaitilities, member1Await.ClusterName,
 		spacebinding.WithSpecSpaceRole("admin"),

--- a/test/e2e/parallel/serviceaccount_test.go
+++ b/test/e2e/parallel/serviceaccount_test.go
@@ -24,14 +24,13 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 	member := awaitilities.Member1()
 
 	// let's provision user
-	_, mur, _ := NewSignupRequest(awaitilities).
+	_, mur, _, _ := NewSignupRequest(awaitilities).
 		Username("do-not-override-sa").
 		ManuallyApprove().
 		TargetCluster(member).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).
-		Resources(t)
+		Execute(t)
 
 	// and move the user to appstudio tier
 	tiers.MoveSpaceToTier(t, awaitilities.Host(), mur.Name, "appstudio-env")

--- a/test/e2e/parallel/serviceaccount_test.go
+++ b/test/e2e/parallel/serviceaccount_test.go
@@ -31,8 +31,8 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-
 	mur := user.MUR
+
 	// and move the user to appstudio tier
 	tiers.MoveSpaceToTier(t, awaitilities.Host(), mur.Name, "appstudio-env")
 	VerifyResourcesProvisionedForSpace(t, awaitilities, mur.Name)

--- a/test/e2e/parallel/serviceaccount_test.go
+++ b/test/e2e/parallel/serviceaccount_test.go
@@ -24,7 +24,7 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 	member := awaitilities.Member1()
 
 	// let's provision user
-	_, mur, _, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username("do-not-override-sa").
 		ManuallyApprove().
 		TargetCluster(member).
@@ -32,6 +32,7 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
 
+	mur := user.MUR
 	// and move the user to appstudio tier
 	tiers.MoveSpaceToTier(t, awaitilities.Host(), mur.Name, "appstudio-env")
 	VerifyResourcesProvisionedForSpace(t, awaitilities, mur.Name)

--- a/test/e2e/parallel/serviceaccount_test.go
+++ b/test/e2e/parallel/serviceaccount_test.go
@@ -24,14 +24,14 @@ func TestDoNotOverrideServiceAccount(t *testing.T) {
 	member := awaitilities.Member1()
 
 	// let's provision user
-	_, mur := NewSignupRequest(awaitilities).
+	_, mur, _ := NewSignupRequest(awaitilities).
 		Username("do-not-override-sa").
 		ManuallyApprove().
 		TargetCluster(member).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t).
-		Resources()
+		Resources(t)
 
 	// and move the user to appstudio tier
 	tiers.MoveSpaceToTier(t, awaitilities.Host(), mur.Name, "appstudio-env")

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -166,14 +166,14 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 }
 
 func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awaitilities, memberAwait *wait.MemberAwaitility, space *toolchainv1alpha1.Space, hostAwait *wait.HostAwaitility, username, spaceRole string) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBindingRequest, *toolchainv1alpha1.SpaceBinding) {
-	userSignup2, mur2, _ := NewSignupRequest(awaitilities).
+	userSignup2, mur2, _, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		NoSpace().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 	//... that gets access to the space but using SpaceBindingRequests
 	spaceBindingRequest := testsupportsb.CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		testsupportsb.WithSpecSpaceRole(spaceRole),
@@ -200,13 +200,13 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	space, owner, _ := CreateSpace(t, awaitilities, testspace.WithTierName("appstudio"), testspace.WithSpecTargetCluster(targetMember.ClusterName), testspace.WithName(spaceName))
 	// at this point, just make sure the space exists so we can bind it to our user
-	userSignup, mur, _ := NewSignupRequest(awaitilities).
+	userSignup, mur, _, _ := NewSignupRequest(awaitilities).
 		Username(murName).
 		ManuallyApprove().
 		TargetCluster(targetMember).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 	spaceBinding := testsupportsb.CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
 	appstudioTier, err := awaitilities.Host().WaitForNSTemplateTier(t, "appstudio")
 	require.NoError(t, err)

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -166,14 +166,14 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 }
 
 func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awaitilities, memberAwait *wait.MemberAwaitility, space *toolchainv1alpha1.Space, hostAwait *wait.HostAwaitility, username, spaceRole string) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBindingRequest, *toolchainv1alpha1.SpaceBinding) {
-	userSignup2, mur2 := NewSignupRequest(awaitilities).
+	userSignup2, mur2, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		NoSpace().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 	//... that gets access to the space but using SpaceBindingRequests
 	spaceBindingRequest := testsupportsb.CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		testsupportsb.WithSpecSpaceRole(spaceRole),
@@ -200,13 +200,13 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	space, owner, _ := CreateSpace(t, awaitilities, testspace.WithTierName("appstudio"), testspace.WithSpecTargetCluster(targetMember.ClusterName), testspace.WithName(spaceName))
 	// at this point, just make sure the space exists so we can bind it to our user
-	userSignup, mur := NewSignupRequest(awaitilities).
+	userSignup, mur, _ := NewSignupRequest(awaitilities).
 		Username(murName).
 		ManuallyApprove().
 		TargetCluster(targetMember).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 	spaceBinding := testsupportsb.CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
 	appstudioTier, err := awaitilities.Host().WaitForNSTemplateTier(t, "appstudio")
 	require.NoError(t, err)

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -166,7 +166,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 }
 
 func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awaitilities, memberAwait *wait.MemberAwaitility, space *toolchainv1alpha1.Space, hostAwait *wait.HostAwaitility, username, spaceRole string) (*toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBindingRequest, *toolchainv1alpha1.SpaceBinding) {
-	userSignup2, mur2, _, _ := NewSignupRequest(awaitilities).
+	user2 := NewSignupRequest(awaitilities).
 		Username(username).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
@@ -174,6 +174,8 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 		NoSpace().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	userSignup2 := user2.UserSignup
+	mur2 := user2.MUR
 	//... that gets access to the space but using SpaceBindingRequests
 	spaceBindingRequest := testsupportsb.CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		testsupportsb.WithSpecSpaceRole(spaceRole),
@@ -200,13 +202,15 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	space, owner, _ := CreateSpace(t, awaitilities, testspace.WithTierName("appstudio"), testspace.WithSpecTargetCluster(targetMember.ClusterName), testspace.WithName(spaceName))
 	// at this point, just make sure the space exists so we can bind it to our user
-	userSignup, mur, _, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username(murName).
 		ManuallyApprove().
 		TargetCluster(targetMember).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	userSignup := user.UserSignup
+	mur := user.MUR
 	spaceBinding := testsupportsb.CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
 	appstudioTier, err := awaitilities.Host().WaitForNSTemplateTier(t, "appstudio")
 	require.NoError(t, err)

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -174,12 +174,10 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 		NoSpace().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-	userSignup2 := user2.UserSignup
-	mur2 := user2.MUR
 	//... that gets access to the space but using SpaceBindingRequests
 	spaceBindingRequest := testsupportsb.CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		testsupportsb.WithSpecSpaceRole(spaceRole),
-		testsupportsb.WithSpecMasterUserRecord(mur2.GetName()),
+		testsupportsb.WithSpecMasterUserRecord(user2.MUR.GetName()),
 		testsupportsb.WithNamespace(GetDefaultNamespace(space.Status.ProvisionedNamespaces)),
 	)
 	// check for the spaceBinding creation
@@ -196,7 +194,7 @@ func setupForSpaceBindingCleanupWithSBRTest(t *testing.T, awaitilities wait.Awai
 		wait.UntilSpaceBindingRequestHasConditions(wait.Provisioned()),
 	)
 	require.NoError(t, err)
-	return userSignup2, spaceBindingRequest, spaceBinding
+	return user2.UserSignup, spaceBindingRequest, spaceBinding
 }
 
 func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilities, targetMember *wait.MemberAwaitility, murName, spaceName string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
@@ -209,9 +207,7 @@ func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilitie
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
-	userSignup := user.UserSignup
-	mur := user.MUR
-	spaceBinding := testsupportsb.CreateSpaceBinding(t, awaitilities.Host(), mur, space, "admin")
+	spaceBinding := testsupportsb.CreateSpaceBinding(t, awaitilities.Host(), user.MUR, space, "admin")
 	appstudioTier, err := awaitilities.Host().WaitForNSTemplateTier(t, "appstudio")
 	require.NoError(t, err)
 	// make sure that the NSTemplateSet associated with the Space was updated after the space binding was created (new entry in the `spec.SpaceRoles`)
@@ -222,5 +218,5 @@ func setupForSpaceBindingCleanupTest(t *testing.T, awaitilities wait.Awaitilitie
 	require.NoError(t, err)
 	// in particular, verify that there are role and rolebindings for all the users (the "default" one and the one referred as an argument of this func) in the space
 	VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name, wait.UntilSpaceHasStatusTargetCluster(targetMember.ClusterName), wait.UntilSpaceHasAnyProvisionedNamespaces())
-	return space, userSignup, spaceBinding
+	return space, user.UserSignup, spaceBinding
 }

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -122,7 +122,7 @@ func TestSpaceRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// given a user (with her own space, but we'll ignore it in this test)
-	_, ownerMUR, _ := NewSignupRequest(awaitilities).
+	_, ownerMUR, _, _ := NewSignupRequest(awaitilities).
 		Username("spaceowner").
 		Email("spaceowner@redhat.com").
 		ManuallyApprove().
@@ -130,8 +130,7 @@ func TestSpaceRoles(t *testing.T) {
 		EnsureMUR().
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		NoSpace().
-		Execute(t).
-		Resources(t)
+		Execute(t)
 
 	// when a space owned by the user above is created (and user is an admin of this space)
 	s, ownerBinding := CreateSpaceWithBinding(t, awaitilities, ownerMUR,
@@ -159,7 +158,7 @@ func TestSpaceRoles(t *testing.T) {
 
 	t.Run("and with guest admin binding", func(t *testing.T) {
 		// given a `spaceguest` user (with her own space, but we'll ignore it in this test)
-		_, guestMUR, _ := NewSignupRequest(awaitilities).
+		_, guestMUR, _, _ := NewSignupRequest(awaitilities).
 			Username("spaceguest").
 			Email("spaceguest@redhat.com").
 			ManuallyApprove().
@@ -167,8 +166,7 @@ func TestSpaceRoles(t *testing.T) {
 			WaitForMUR().
 			NoSpace().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 
 		// when the `spaceguest` user is bound to the space as an admin
 		guestBinding := testsupportsb.CreateSpaceBinding(t, hostAwait, guestMUR, s, "admin")

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -122,7 +122,7 @@ func TestSpaceRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// given a user (with her own space, but we'll ignore it in this test)
-	_, ownerMUR, _, _ := NewSignupRequest(awaitilities).
+	ownerUser := NewSignupRequest(awaitilities).
 		Username("spaceowner").
 		Email("spaceowner@redhat.com").
 		ManuallyApprove().
@@ -131,6 +131,7 @@ func TestSpaceRoles(t *testing.T) {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		NoSpace().
 		Execute(t)
+	ownerMUR := ownerUser.MUR
 
 	// when a space owned by the user above is created (and user is an admin of this space)
 	s, ownerBinding := CreateSpaceWithBinding(t, awaitilities, ownerMUR,
@@ -158,7 +159,7 @@ func TestSpaceRoles(t *testing.T) {
 
 	t.Run("and with guest admin binding", func(t *testing.T) {
 		// given a `spaceguest` user (with her own space, but we'll ignore it in this test)
-		_, guestMUR, _, _ := NewSignupRequest(awaitilities).
+		guestUser := NewSignupRequest(awaitilities).
 			Username("spaceguest").
 			Email("spaceguest@redhat.com").
 			ManuallyApprove().
@@ -167,6 +168,7 @@ func TestSpaceRoles(t *testing.T) {
 			NoSpace().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute(t)
+		guestMUR := guestUser.MUR
 
 		// when the `spaceguest` user is bound to the space as an admin
 		guestBinding := testsupportsb.CreateSpaceBinding(t, hostAwait, guestMUR, s, "admin")

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -168,10 +168,9 @@ func TestSpaceRoles(t *testing.T) {
 			NoSpace().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute(t)
-		guestMUR := guestUser.MUR
 
 		// when the `spaceguest` user is bound to the space as an admin
-		guestBinding := testsupportsb.CreateSpaceBinding(t, hostAwait, guestMUR, s, "admin")
+		guestBinding := testsupportsb.CreateSpaceBinding(t, hostAwait, guestUser.MUR, s, "admin")
 
 		// then
 		nsTmplSet, err = memberAwait.WaitForNSTmplSet(t, nsTmplSet.Name,

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -122,7 +122,7 @@ func TestSpaceRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	// given a user (with her own space, but we'll ignore it in this test)
-	_, ownerMUR := NewSignupRequest(awaitilities).
+	_, ownerMUR, _ := NewSignupRequest(awaitilities).
 		Username("spaceowner").
 		Email("spaceowner@redhat.com").
 		ManuallyApprove().
@@ -131,7 +131,7 @@ func TestSpaceRoles(t *testing.T) {
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		NoSpace().
 		Execute(t).
-		Resources()
+		Resources(t)
 
 	// when a space owned by the user above is created (and user is an admin of this space)
 	s, ownerBinding := CreateSpaceWithBinding(t, awaitilities, ownerMUR,
@@ -159,7 +159,7 @@ func TestSpaceRoles(t *testing.T) {
 
 	t.Run("and with guest admin binding", func(t *testing.T) {
 		// given a `spaceguest` user (with her own space, but we'll ignore it in this test)
-		_, guestMUR := NewSignupRequest(awaitilities).
+		_, guestMUR, _ := NewSignupRequest(awaitilities).
 			Username("spaceguest").
 			Email("spaceguest@redhat.com").
 			ManuallyApprove().
@@ -168,7 +168,7 @@ func TestSpaceRoles(t *testing.T) {
 			NoSpace().
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 
 		// when the `spaceguest` user is bound to the space as an admin
 		guestBinding := testsupportsb.CreateSpaceBinding(t, hostAwait, guestMUR, s, "admin")

--- a/test/e2e/parallel/spacebindingrequest_test.go
+++ b/test/e2e/parallel/spacebindingrequest_test.go
@@ -113,11 +113,10 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 				NoSpace().
 				WaitForMUR().Execute(t)
-			mur := user.MUR
 			// create the spacebinding request
 			spaceBindingRequest := CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 				WithSpecSpaceRole("invalid"), // set invalid spacerole
-				WithSpecMasterUserRecord(mur.GetName()),
+				WithSpecMasterUserRecord(user.MUR.GetName()),
 				WithNamespace(testsupportspace.GetDefaultNamespace(space.Status.ProvisionedNamespaces)),
 			)
 
@@ -196,12 +195,11 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			NoSpace().
 			WaitForMUR().Execute(t)
-		newmur := newUser.MUR
 		// and we try to update the MUR in the SBR
 		// with lower timeout since it will fail as expected
 		_, err := memberAwait.WithRetryOptions(TimeoutOption(time.Second*2)).UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
 			func(s *toolchainv1alpha1.SpaceBindingRequest) {
-				s.Spec.MasterUserRecord = newmur.GetName() // set to the new MUR
+				s.Spec.MasterUserRecord = newUser.MUR.GetName() // set to the new MUR
 			},
 		)
 		require.Error(t, err) // an error from the validating webhook is expected when trying to update the MUR field

--- a/test/e2e/parallel/spacebindingrequest_test.go
+++ b/test/e2e/parallel/spacebindingrequest_test.go
@@ -107,12 +107,12 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 			space, err := hostAwait.WaitForSpace(t, space.Name, UntilSpaceHasAnyProvisionedNamespaces())
 			require.NoError(t, err)
 			// let's create a new MUR that will have access to the space
-			_, mur, _ := NewSignupRequest(awaitilities).
+			_, mur, _, _ := NewSignupRequest(awaitilities).
 				ManuallyApprove().
 				TargetCluster(memberAwait).
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 				NoSpace().
-				WaitForMUR().Execute(t).Resources(t)
+				WaitForMUR().Execute(t)
 			// create the spacebinding request
 			spaceBindingRequest := CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 				WithSpecSpaceRole("invalid"), // set invalid spacerole
@@ -187,14 +187,14 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 		space, spaceBindingRequest, _ := NewSpaceBindingRequest(t, awaitilities, memberAwait, hostAwait, "admin")
 		// let's create another MUR that will be used for the update request
 		username := uuid.Must(uuid.NewV4()).String()
-		_, newmur, _ := NewSignupRequest(awaitilities).
+		_, newmur, _, _ := NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@acme.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			NoSpace().
-			WaitForMUR().Execute(t).Resources(t)
+			WaitForMUR().Execute(t)
 		// and we try to update the MUR in the SBR
 		// with lower timeout since it will fail as expected
 		_, err := memberAwait.WithRetryOptions(TimeoutOption(time.Second*2)).UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
@@ -229,14 +229,14 @@ func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait
 	require.NoError(t, err)
 	// let's create a new MUR that will have access to the space
 	username := uuid.Must(uuid.NewV4()).String()
-	_, secondUserMUR, _ := NewSignupRequest(awaitilities).
+	_, secondUserMUR, _, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		NoSpace().
-		WaitForMUR().Execute(t).Resources(t)
+		WaitForMUR().Execute(t)
 	// create the spacebinding request
 	spaceBindingRequest := CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		WithSpecSpaceRole(spaceRole),

--- a/test/e2e/parallel/spacebindingrequest_test.go
+++ b/test/e2e/parallel/spacebindingrequest_test.go
@@ -106,14 +106,14 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 			require.NoError(t, err)
 			// let's create a new MUR that will have access to the space
 			username := uuid.Must(uuid.NewV4()).String()
-			_, mur := NewSignupRequest(awaitilities).
+			_, mur, _ := NewSignupRequest(awaitilities).
 				Username(username).
 				Email(username + "@acme.com").
 				ManuallyApprove().
 				TargetCluster(memberAwait).
 				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 				NoSpace().
-				WaitForMUR().Execute(t).Resources()
+				WaitForMUR().Execute(t).Resources(t)
 			// create the spacebinding request
 			spaceBindingRequest := CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 				WithSpecSpaceRole("invalid"), // set invalid spacerole
@@ -198,14 +198,14 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 		space, spaceBindingRequest, _ := NewSpaceBindingRequest(t, awaitilities, memberAwait, hostAwait, "admin")
 		// let's create another MUR that will be used for the update request
 		username := uuid.Must(uuid.NewV4()).String()
-		_, newmur := NewSignupRequest(awaitilities).
+		_, newmur, _ := NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@acme.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 			NoSpace().
-			WaitForMUR().Execute(t).Resources()
+			WaitForMUR().Execute(t).Resources(t)
 		// and we try to update the MUR in the SBR
 		// with lower timeout since it will fail as expected
 		_, err := memberAwait.WithRetryOptions(TimeoutOption(time.Second*2)).UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
@@ -240,14 +240,14 @@ func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait
 	require.NoError(t, err)
 	// let's create a new MUR that will have access to the space
 	username := uuid.Must(uuid.NewV4()).String()
-	_, secondUserMUR := NewSignupRequest(awaitilities).
+	_, secondUserMUR, _ := NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
 		NoSpace().
-		WaitForMUR().Execute(t).Resources()
+		WaitForMUR().Execute(t).Resources(t)
 	// create the spacebinding request
 	spaceBindingRequest := CreateSpaceBindingRequest(t, awaitilities, memberAwait.ClusterName,
 		WithSpecSpaceRole(spaceRole),

--- a/test/e2e/parallel/usersignup_test.go
+++ b/test/e2e/parallel/usersignup_test.go
@@ -32,13 +32,15 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 	conflictingSpace, _, _ := CreateSpace(t, awaitilities, testcommonspace.WithName("conflicting"))
 
 	// when
-	userSignup, _, space, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username(conflictingSpace.Name).
 		TargetCluster(memberAwait).
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	userSignup := user.UserSignup
+	space := user.Space
 
 	// then
 	expectedCompliantUsername := userSignup.Status.CompliantUsername
@@ -200,7 +202,7 @@ func TestTransformUsername(t *testing.T) {
 }
 
 func assertComplaintUsernameForNewSignup(t *testing.T, awaitilities wait.Awaitilities, testCase TestCase) {
-	userSignup, _, _, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username(testCase.username).
 		Email(testCase.email).
 		ManuallyApprove().
@@ -208,5 +210,5 @@ func assertComplaintUsernameForNewSignup(t *testing.T, awaitilities wait.Awaitil
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
 
-	require.Equal(t, testCase.expectedCompliantUsername, userSignup.Status.CompliantUsername)
+	require.Equal(t, testCase.expectedCompliantUsername, user.UserSignup.Status.CompliantUsername)
 }

--- a/test/e2e/parallel/usersignup_test.go
+++ b/test/e2e/parallel/usersignup_test.go
@@ -40,7 +40,6 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
 	userSignup := user.UserSignup
-	space := user.Space
 
 	// then
 	expectedCompliantUsername := userSignup.Status.CompliantUsername
@@ -49,7 +48,7 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 	t.Run("when signup is deactivated, Space is stuck in terminating state, and when it reactivates then it should generate a new name", func(t *testing.T) {
 		// given
 		// let's get a namespace of the space
-		namespaceName := space.Status.ProvisionedNamespaces[0].Name
+		namespaceName := user.Space.Status.ProvisionedNamespaces[0].Name
 		// and add a dummy finalizer there so it will get stuck
 		_, err := memberAwait.UpdateNamespace(t, namespaceName, func(ns *v1.Namespace) {
 			util.AddFinalizer(ns, "test/finalizer.toolchain.e2e.tests")

--- a/test/e2e/parallel/usersignup_test.go
+++ b/test/e2e/parallel/usersignup_test.go
@@ -32,13 +32,13 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 	conflictingSpace, _, _ := CreateSpace(t, awaitilities, testcommonspace.WithName("conflicting"))
 
 	// when
-	userSignup, _, space := NewSignupRequest(awaitilities).
+	userSignup, _, space, _ := NewSignupRequest(awaitilities).
 		Username(conflictingSpace.Name).
 		TargetCluster(memberAwait).
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	// then
 	expectedCompliantUsername := userSignup.Status.CompliantUsername
@@ -200,13 +200,13 @@ func TestTransformUsername(t *testing.T) {
 }
 
 func assertComplaintUsernameForNewSignup(t *testing.T, awaitilities wait.Awaitilities, testCase TestCase) {
-	userSignup, _, _ := NewSignupRequest(awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(awaitilities).
 		Username(testCase.username).
 		Email(testCase.email).
 		ManuallyApprove().
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	require.Equal(t, testCase.expectedCompliantUsername, userSignup.Status.CompliantUsername)
 }

--- a/test/e2e/parallel/web_console_plugin_test.go
+++ b/test/e2e/parallel/web_console_plugin_test.go
@@ -35,7 +35,7 @@ func TestWebConsoleDeployedSuccessfully(t *testing.T) {
 		waitForWebConsolePluginDeployment(t, memberAwait, image)
 		waitForWebConsolePluginService(t, memberAwait)
 
-		_, _, _, token := NewSignupRequest(await).
+		user := NewSignupRequest(await).
 			Username(fmt.Sprintf("consoletest%d", i)).
 			Email("consoletest@redhat.com").
 			TargetCluster(memberAwait).
@@ -43,6 +43,7 @@ func TestWebConsoleDeployedSuccessfully(t *testing.T) {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		token := user.Token
 
 		// Since we can't easily access the web console API resources directly (due to complex security requirements) we
 		// will instead create a route in the member cluster with which to access the console plugin

--- a/test/e2e/parallel/web_console_plugin_test.go
+++ b/test/e2e/parallel/web_console_plugin_test.go
@@ -35,7 +35,7 @@ func TestWebConsoleDeployedSuccessfully(t *testing.T) {
 		waitForWebConsolePluginDeployment(t, memberAwait, image)
 		waitForWebConsolePluginService(t, memberAwait)
 
-		signupRequest := NewSignupRequest(await).
+		_, _, _, token := NewSignupRequest(await).
 			Username(fmt.Sprintf("consoletest%d", i)).
 			Email("consoletest@redhat.com").
 			TargetCluster(memberAwait).
@@ -112,7 +112,7 @@ func TestWebConsoleDeployedSuccessfully(t *testing.T) {
 		// some problem with the service.
 		req, err := http.NewRequest("GET", healthCheckURL, nil)
 		require.NoError(t, err)
-		req.Header.Set("Authorization", signupRequest.GetToken())
+		req.Header.Set("Authorization", token)
 
 		healthCheckResponse, err = httpClient.Do(req) //nolint
 		require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestWebConsoleDeployedSuccessfully(t *testing.T) {
 
 		req, err = http.NewRequest("GET", manifestURL, nil)
 		require.NoError(t, err)
-		req.Header.Set("Authorization", signupRequest.GetToken())
+		req.Header.Set("Authorization", token)
 
 		manifestResponse, err := httpClient.Do(req)
 		require.NoError(t, err)

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -25,7 +25,7 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait1 := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	_, mur := NewSignupRequest(awaitilities).
+	_, mur, _ := NewSignupRequest(awaitilities).
 		Username("for-member1").
 		Email("for-member1@redhat.com").
 		TargetCluster(memberAwait1).
@@ -33,7 +33,7 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		EnsureMUR().
 		Execute(t).
-		Resources()
+		Resources(t)
 	NewSignupRequest(awaitilities).
 		Username("for-member2").
 		Email("for-member2@redhat.com").

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -25,7 +25,7 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait1 := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	_, mur, _, _ := NewSignupRequest(awaitilities).
+	user := NewSignupRequest(awaitilities).
 		Username("for-member1").
 		Email("for-member1@redhat.com").
 		TargetCluster(memberAwait1).
@@ -33,6 +33,7 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		EnsureMUR().
 		Execute(t)
+	mur := user.MUR
 	NewSignupRequest(awaitilities).
 		Username("for-member2").
 		Email("for-member2@redhat.com").

--- a/test/e2e/space_autocompletion_test.go
+++ b/test/e2e/space_autocompletion_test.go
@@ -25,15 +25,14 @@ func TestAutomaticClusterAssignment(t *testing.T) {
 	hostAwait := awaitilities.Host()
 	memberAwait1 := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
-	_, mur, _ := NewSignupRequest(awaitilities).
+	_, mur, _, _ := NewSignupRequest(awaitilities).
 		Username("for-member1").
 		Email("for-member1@redhat.com").
 		TargetCluster(memberAwait1).
 		ManuallyApprove().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		EnsureMUR().
-		Execute(t).
-		Resources(t)
+		Execute(t)
 	NewSignupRequest(awaitilities).
 		Username("for-member2").
 		Email("for-member2@redhat.com").

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -110,7 +110,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
 		// User on member cluster 1
-		userSignupMember1, _, _, _ := NewSignupRequest(s.Awaitilities).
+		userMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate").
 			Email("usertodeactivate@redhat.com").
 			ManuallyApprove().
@@ -118,9 +118,10 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignupMember1 := userMember1.UserSignup
 
 		// User on member cluster 2
-		userSignupMember2, _, _, _ := NewSignupRequest(s.Awaitilities).
+		userMember2 := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate2").
 			Email("usertodeactivate2@example.com").
 			ManuallyApprove().
@@ -128,6 +129,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait2).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignupMember2 := userMember2.UserSignup
 
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember1)
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember2)
@@ -140,7 +142,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
 		// User on member cluster 1
-		userNoEmail, _, _, _ := NewSignupRequest(s.Awaitilities).
+		uNoEmail := NewSignupRequest(s.Awaitilities).
 			Username("usernoemail").
 			Email("usernoemail@redhat.com").
 			ManuallyApprove().
@@ -148,6 +150,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userNoEmail := uNoEmail.UserSignup
 
 		// Delete the user's email and set them to deactivated
 		userSignup, err := hostAwait.UpdateUserSignup(t, userNoEmail.Name,
@@ -164,7 +167,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
-		_, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("usernodeactivate").
 			Email("usernodeactivate@redhat.com").
 			ManuallyApprove().
@@ -172,6 +175,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		murMember1 := user.MUR
 
 		// Get the tier that has deactivation disabled
 		deactivationDisabledTier, err := hostAwait.WaitForUserTier(t, "nodeactivation")
@@ -207,7 +211,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
-		userSignupMember1, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
+		userMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usertoautodeactivate").
 			Email("usertoautodeactivate@redhat.com").
 			ManuallyApprove().
@@ -215,11 +219,13 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignupMember1 := userMember1.UserSignup
+		murMember1 := userMember1.MUR
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
 
-		deactivationExcludedUserSignupMember1, excludedMurMember1, _, _ := NewSignupRequest(s.Awaitilities).
+		deactivationExcludedUserMember1 := NewSignupRequest(s.Awaitilities).
 			Username("userdeactivationexcluded").
 			Email("userdeactivationexcluded@excluded.com").
 			ManuallyApprove().
@@ -227,6 +233,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		deactivationExcludedUserSignupMember1 := deactivationExcludedUserMember1.UserSignup
+		excludedMurMember1 := deactivationExcludedUserMember1.MUR
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
@@ -290,7 +298,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		config := hostAwait.GetToolchainConfig(t)
 		require.Equal(t, 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
-		userSignupMember1, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
+		userMember1 := NewSignupRequest(s.Awaitilities).
 			Username("usertostartdeactivating").
 			Email("usertostartdeactivating@redhat.com").
 			ManuallyApprove().
@@ -298,6 +306,8 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignupMember1 := userMember1.UserSignup
+		murMember1 := userMember1.MUR
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
@@ -338,12 +348,15 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.Equal(t, 3, *hostConfig.Deactivation.DeactivatingNotificationDays)
 
 		// Create a new UserSignup
-		userSignup, mur, space, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("fulldeactivationlifecycle").
 			Email("fulldeactivationlifecycle@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(t)
+		userSignup := user.UserSignup
+		mur := user.MUR
+		space := user.Space
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, mur)
@@ -468,7 +481,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and wait for it to be provisioned
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("usertoreactivate").
 			Email("usertoreactivate@redhat.com").
 			ManuallyApprove().
@@ -476,6 +489,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignup := user.UserSignup
 
 		// Wait for the UserSignup to have the desired state
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
@@ -531,13 +545,14 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("banprovisioned").
 			Email("banprovisioned@test.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignup := user.UserSignup
 
 		// Create the BannedUser
 		CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -632,7 +647,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
-		userSignup, mur, space, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("banandunban").
 			Email("banandunban@test.com").
 			EnsureMUR().
@@ -640,6 +655,9 @@ func (s *userManagementTestSuite) TestUserBanning() {
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
+		userSignup := user.UserSignup
+		mur := user.MUR
+		space := user.Space
 
 		// Create the BannedUser
 		bannedUser := CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -687,13 +705,15 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup
-	userSignup, mur, _, _ := NewSignupRequest(s.Awaitilities).
+	u := NewSignupRequest(s.Awaitilities).
 		Username("janedoe").
 		EnsureMUR().
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(s.T())
+	userSignup := u.UserSignup
+	mur := u.MUR
 
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 
@@ -755,7 +775,7 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 			// when
 			t.Run(fmt.Sprintf("cluster %s: user activated->deactivated->reactivated", initialTargetCluster.ClusterName), func(t *testing.T) {
 				// given
-				userSignup, _, space, _ := NewSignupRequest(s.Awaitilities).
+				user := NewSignupRequest(s.Awaitilities).
 					Username(fmt.Sprintf("returninguser%d", i)).
 					Email(fmt.Sprintf("returninguser%d@redhat.com", i)).
 					EnsureMUR().
@@ -763,7 +783,8 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 					TargetCluster(initialTargetCluster). // use TargetCluster initially to force user to provision to the expected cluster
 					RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 					Execute(t)
-
+				userSignup := user.UserSignup
+				space := user.Space
 				// when
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)
 				// If TargetCluster is set it will override the last cluster annotation so remove TargetCluster

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -110,24 +110,24 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
 		// User on member cluster 1
-		userSignupMember1, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate").
 			Email("usertodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// User on member cluster 2
-		userSignupMember2, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember2, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate2").
 			Email("usertodeactivate2@example.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait2).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember1)
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember2)
@@ -140,14 +140,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
 		// User on member cluster 1
-		userNoEmail, _ := NewSignupRequest(s.Awaitilities).
+		userNoEmail, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usernoemail").
 			Email("usernoemail@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// Delete the user's email and set them to deactivated
 		userSignup, err := hostAwait.UpdateUserSignup(t, userNoEmail.Name,
@@ -164,14 +164,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
-		_, murMember1 := NewSignupRequest(s.Awaitilities).
+		_, murMember1, _ := NewSignupRequest(s.Awaitilities).
 			Username("usernodeactivate").
 			Email("usernodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// Get the tier that has deactivation disabled
 		deactivationDisabledTier, err := hostAwait.WaitForUserTier(t, "nodeactivation")
@@ -207,26 +207,26 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
-		userSignupMember1, murMember1 := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, murMember1, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertoautodeactivate").
 			Email("usertoautodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
 
-		deactivationExcludedUserSignupMember1, excludedMurMember1 := NewSignupRequest(s.Awaitilities).
+		deactivationExcludedUserSignupMember1, excludedMurMember1, _ := NewSignupRequest(s.Awaitilities).
 			Username("userdeactivationexcluded").
 			Email("userdeactivationexcluded@excluded.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
@@ -290,14 +290,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		config := hostAwait.GetToolchainConfig(t)
 		require.Equal(t, 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
-		userSignupMember1, murMember1 := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, murMember1, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertostartdeactivating").
 			Email("usertostartdeactivating@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
@@ -338,12 +338,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.Equal(t, 3, *hostConfig.Deactivation.DeactivatingNotificationDays)
 
 		// Create a new UserSignup
-		userSignup, mur := NewSignupRequest(s.Awaitilities).
+		userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
 			Username("fulldeactivationlifecycle").
 			Email("fulldeactivationlifecycle@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, mur)
@@ -468,14 +468,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and wait for it to be provisioned
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertoreactivate").
 			Email("usertoreactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// Wait for the UserSignup to have the desired state
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
@@ -531,13 +531,13 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("banprovisioned").
 			Email("banprovisioned@test.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// Create the BannedUser
 		CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -632,14 +632,14 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
-		userSignup, mur := NewSignupRequest(s.Awaitilities).
+		userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
 			Username("banandunban").
 			Email("banandunban@test.com").
 			EnsureMUR().
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources()
+			Execute(t).Resources(t)
 
 		// Create the BannedUser
 		bannedUser := CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -687,13 +687,13 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup
-	userSignup, mur := NewSignupRequest(s.Awaitilities).
+	userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
 		Username("janedoe").
 		EnsureMUR().
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 
@@ -755,14 +755,14 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 			// when
 			t.Run(fmt.Sprintf("cluster %s: user activated->deactivated->reactivated", initialTargetCluster.ClusterName), func(t *testing.T) {
 				// given
-				userSignup, _ := NewSignupRequest(s.Awaitilities).
+				userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 					Username(fmt.Sprintf("returninguser%d", i)).
 					Email(fmt.Sprintf("returninguser%d@redhat.com", i)).
 					EnsureMUR().
 					ManuallyApprove().
 					TargetCluster(initialTargetCluster). // use TargetCluster initially to force user to provision to the expected cluster
 					RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-					Execute(t).Resources()
+					Execute(t).Resources(t)
 
 				// when
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -110,24 +110,24 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify user deactivation on each member cluster", func(t *testing.T) {
 		// User on member cluster 1
-		userSignupMember1, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate").
 			Email("usertodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// User on member cluster 2
-		userSignupMember2, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember2, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertodeactivate2").
 			Email("usertodeactivate2@example.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait2).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember1)
 		DeactivateAndCheckUser(t, s.Awaitilities, userSignupMember2)
@@ -140,14 +140,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 	s.T().Run("verify notification fails on user deactivation with no usersignup email", func(t *testing.T) {
 		// User on member cluster 1
-		userNoEmail, _, _ := NewSignupRequest(s.Awaitilities).
+		userNoEmail, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usernoemail").
 			Email("usernoemail@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// Delete the user's email and set them to deactivated
 		userSignup, err := hostAwait.UpdateUserSignup(t, userNoEmail.Name,
@@ -164,14 +164,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation disabled", func(t *testing.T) {
-		_, murMember1, _ := NewSignupRequest(s.Awaitilities).
+		_, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usernodeactivate").
 			Email("usernodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// Get the tier that has deactivation disabled
 		deactivationDisabledTier, err := hostAwait.WaitForUserTier(t, "nodeactivation")
@@ -207,26 +207,26 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 	})
 
 	s.T().Run("tests for tiers with automatic deactivation enabled", func(t *testing.T) {
-		userSignupMember1, murMember1, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertoautodeactivate").
 			Email("usertoautodeactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
 
-		deactivationExcludedUserSignupMember1, excludedMurMember1, _ := NewSignupRequest(s.Awaitilities).
+		deactivationExcludedUserSignupMember1, excludedMurMember1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("userdeactivationexcluded").
 			Email("userdeactivationexcluded@excluded.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
@@ -290,14 +290,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		config := hostAwait.GetToolchainConfig(t)
 		require.Equal(t, 3, *config.Spec.Host.Deactivation.DeactivatingNotificationDays)
 
-		userSignupMember1, murMember1, _ := NewSignupRequest(s.Awaitilities).
+		userSignupMember1, murMember1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertostartdeactivating").
 			Email("usertostartdeactivating@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
@@ -338,12 +338,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.Equal(t, 3, *hostConfig.Deactivation.DeactivatingNotificationDays)
 
 		// Create a new UserSignup
-		userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, mur, space, _ := NewSignupRequest(s.Awaitilities).
 			Username("fulldeactivationlifecycle").
 			Email("fulldeactivationlifecycle@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// TODO remove once UserTier migration is completed
 		s.promoteToDefaultUserTier(hostAwait.Client, mur)
@@ -359,7 +359,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			baseUserTier, err := hostAwait.WaitForUserTier(t, "deactivate30")
 			require.NoError(t, err)
 
-			mur, err := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername,
+			mur, err := hostAwait.WaitForMasterUserRecord(t, space.Name,
 				wait.UntilMasterUserRecordHasConditions(wait.Provisioned(), wait.ProvisionedNotificationCRCreated()))
 			require.NoError(t, err)
 
@@ -468,14 +468,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and wait for it to be provisioned
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("usertoreactivate").
 			Email("usertoreactivate@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// Wait for the UserSignup to have the desired state
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
@@ -531,13 +531,13 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup and approve it manually
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("banprovisioned").
 			Email("banprovisioned@test.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// Create the BannedUser
 		CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -632,14 +632,14 @@ func (s *userManagementTestSuite) TestUserBanning() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// Create a new UserSignup
-		userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, mur, space, _ := NewSignupRequest(s.Awaitilities).
 			Username("banandunban").
 			Email("banandunban@test.com").
 			EnsureMUR().
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).Resources(t)
+			Execute(t)
 
 		// Create the BannedUser
 		bannedUser := CreateBannedUser(t, s.Host(), userSignup.Spec.IdentityClaims.Email)
@@ -657,7 +657,7 @@ func (s *userManagementTestSuite) TestUserBanning() {
 			wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.Banned())...),
 			wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueBanned))
 		require.NoError(t, err)
-		require.NoError(t, hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, userSignup.Status.CompliantUsername))
+		require.NoError(t, hostAwait.WaitUntilSpaceAndSpaceBindingsDeleted(t, space.Name))
 
 		t.Run("unban the banned user", func(t *testing.T) {
 			// Unban the user
@@ -687,13 +687,13 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(false))
 
 	// Create UserSignup
-	userSignup, mur, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, mur, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("janedoe").
 		EnsureMUR().
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
 
@@ -755,14 +755,14 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 			// when
 			t.Run(fmt.Sprintf("cluster %s: user activated->deactivated->reactivated", initialTargetCluster.ClusterName), func(t *testing.T) {
 				// given
-				userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+				userSignup, _, space, _ := NewSignupRequest(s.Awaitilities).
 					Username(fmt.Sprintf("returninguser%d", i)).
 					Email(fmt.Sprintf("returninguser%d@redhat.com", i)).
 					EnsureMUR().
 					ManuallyApprove().
 					TargetCluster(initialTargetCluster). // use TargetCluster initially to force user to provision to the expected cluster
 					RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-					Execute(t).Resources(t)
+					Execute(t)
 
 				// when
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)
@@ -773,8 +773,8 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 					})
 				require.NoError(t, err)
 
-				userSignup = ReactivateAndCheckUser(t, s.Awaitilities, userSignup)
-				mur2, err := hostAwait.WaitForMasterUserRecord(t, userSignup.Status.CompliantUsername,
+				ReactivateAndCheckUser(t, s.Awaitilities, userSignup)
+				mur2, err := hostAwait.WaitForMasterUserRecord(t, space.Name,
 					wait.UntilMasterUserRecordHasConditions(wait.Provisioned(), wait.ProvisionedNotificationCRCreated()))
 
 				// then

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -199,7 +199,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		})
 
 		t.Run("add user with bad email format and expect the user will not be approved nor provisioned", func(t *testing.T) {
-			msg := "unable to determine automatic approval: invalid email address: waitingList4@somedomain.org@anotherdomain.com"
+			msg := "unable to determine automatic approval: invalid email address: waitinglist4@somedomain.org@anotherdomain.com"
 			// when
 			waitingListUser4 := NewSignupRequest(s.Awaitilities).
 				Username("waitinglist4").

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -51,12 +51,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	memberAwait2 := s.Member2()
 
 	// when & then
-	_, mur1, space1 := NewSignupRequest(s.Awaitilities).
+	_, mur1, space1, _ := NewSignupRequest(s.Awaitilities).
 		Username("automatic1").
 		Email("automatic1@redhat.com").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	s.T().Run("set low max number of spaces and expect that space won't be approved nor provisioned but added on waiting list", func(t *testing.T) {
 		// given
@@ -65,12 +65,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		spaceprovisionerconfig.UpdateForCluster(t, hostAwait.Awaitility, memberAwait2.ClusterName, testSpc.MaxNumberOfSpaces(1))
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// create additional user to reach max space limits on both members
-		_, mur2, space2 := NewSignupRequest(s.Awaitilities).
+		_, mur2, space2, _ := NewSignupRequest(s.Awaitilities).
 			Username("automatic2").
 			Email("automatic2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// TestProvisionToOtherClusterWhenOneIsFull
 		// checks that users will be provisioned to the other member when one is full.
@@ -79,19 +79,19 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
 
 		// when
-		waitingList1, _, _ := NewSignupRequest(s.Awaitilities).
+		waitingList1, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist1").
 			Email("waitinglist1@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
-		waitlinglist2, _, _ := NewSignupRequest(s.Awaitilities).
+		waitlinglist2, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist2").
 			Email("waitinglist2@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, waitingList1)
@@ -136,11 +136,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 
 		// when
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("automatic3").
 			Email("automatic3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(t).Resources(s.T())
+			Execute(t)
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -167,11 +167,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasAutoApprovalDomains(domains), wait.UntilToolchainConfigHasVerificationEnabled(false))
 
 		// and
-		waitingList3, _, _ := NewSignupRequest(s.Awaitilities).
+		waitingList3, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist3").
 			Email("waitinglist3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, waitingList3)
@@ -193,11 +193,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		t.Run("add user with bad email format and expect the user will not be approved nor provisioned", func(t *testing.T) {
 			msg := "unable to determine automatic approval: invalid email address: waitinglist4@somedomain.org@anotherdomain.com"
 			// when
-			waitingList4, _, _ := NewSignupRequest(s.Awaitilities).
+			waitingList4, _, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("waitinglist4").
 				Email("waitinglist4@somedomain.org@anotherdomain.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApprovalWithMsg(msg), wait.PendingApprovalNoClusterWithMsg(msg))...).
-				Execute(s.T()).Resources(s.T())
+				Execute(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, waitingList4)
@@ -216,19 +216,19 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// when
-		_, mur1, space1 := NewSignupRequest(s.Awaitilities).
+		_, mur1, space1, _ := NewSignupRequest(s.Awaitilities).
 			Username("multimember-1").
 			Email("multi1@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
-		_, mur2, space2 := NewSignupRequest(s.Awaitilities).
+		_, mur2, space2, _ := NewSignupRequest(s.Awaitilities).
 			Username("multimember-2").
 			Email("multi2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// then
 		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
@@ -236,11 +236,11 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 		t.Run("after both members are full then new signups won't be approved nor provisioned", func(t *testing.T) {
 			// when
-			userSignupPending, _, _ := NewSignupRequest(s.Awaitilities).
+			userSignupPending, _, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("multimember-3").
 				Email("multi3@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-				Execute(s.T()).Resources(s.T())
+				Execute(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, userSignupPending)
@@ -255,14 +255,14 @@ func (s *userSignupIntegrationTest) TestUserIDAndAccountIDClaimsPropagated() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user").
 		Email("test-user@redhat.com").
 		UserID("123456789").
 		AccountID("987654321").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -277,7 +277,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 	id := uuid.New()
 
 	// when
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-identityclaims").
 		Email("test-user-identityclaims@redhat.com").
 		IdentityID(id).
@@ -285,7 +285,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 		AccountID("111999").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -334,13 +334,13 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-originalsub").
 		Email("test-user-with-originalsub@redhat.com").
 		OriginalSub("abc:fff000111-bbbccc").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -358,14 +358,14 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 	// 2. user ID and account ID are set by test
 	// 3. no original sub claim is set
 	// This scenario is expected with the regular RHD SSO client
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-resources-updated").
 		Email("test-user-resources-updated@redhat.com").
 		UserID("43215432").
 		AccountID("ppqnnn00099").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -401,7 +401,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	identityID := uuid.New()
 
 	// when
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-userid-and-originalsub").
 		Email("test-user-with-userid-and-originalsub@redhat.com").
 		IdentityID(identityID).
@@ -410,7 +410,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 		OriginalSub("def:98734987234").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources(s.T())
+		Execute(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -434,23 +434,23 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
-			userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+			userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual1").
 				Email("manual1@redhat.com").
 				ManuallyApprove().
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-				Execute(s.T()).Resources(s.T())
+				Execute(s.T())
 
 			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
-			userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+			userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual2").
 				Email("manual2@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
-				Execute(s.T()).Resources(s.T())
+				Execute(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, userSignup)
@@ -487,15 +487,15 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			Email("manualwithcapacity2@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// when
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity3").
 			Email("manualwithcapacity3@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -522,12 +522,12 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity4").
 			Email("manualwithcapacity4@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -554,14 +554,14 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when & then
-		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("withtargetcluster").
 			Email("withtargetcluster@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait1).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(s.T()).Resources(s.T())
+			Execute(s.T())
 
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
@@ -640,14 +640,13 @@ func (s *userSignupIntegrationTest) TestSkipSpaceCreation() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("nospace").
 		Email("nospace@redhat.com").
 		NoSpace().
 		WaitForMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).
-		Resources(s.T())
+		Execute(s.T())
 
 	// then
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -175,8 +175,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 
 		// and
 		waitingListUser3 := NewSignupRequest(s.Awaitilities).
-			Username("waitingList3").
-			Email("waitingList3@redhat.com").
+			Username("waitinglist3").
+			Email("waitinglist3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
 			Execute(s.T())
 		waitingList3 := waitingListUser3.UserSignup
@@ -202,8 +202,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 			msg := "unable to determine automatic approval: invalid email address: waitingList4@somedomain.org@anotherdomain.com"
 			// when
 			waitingListUser4 := NewSignupRequest(s.Awaitilities).
-				Username("waitingList4").
-				Email("waitingList4@somedomain.org@anotherdomain.com").
+				Username("waitinglist4").
+				Email("waitinglist4@somedomain.org@anotherdomain.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApprovalWithMsg(msg), wait.PendingApprovalNoClusterWithMsg(msg))...).
 				Execute(s.T())
 			waitingList4 := waitingListUser4.UserSignup

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -57,8 +57,6 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
-	mur1 := user1.MUR
-	space1 := user1.Space
 
 	s.T().Run("set low max number of spaces and expect that space won't be approved nor provisioned but added on waiting list", func(t *testing.T) {
 		// given
@@ -73,14 +71,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
-		mur2 := user2.MUR
-		space2 := user2.Space
 
 		// TestProvisionToOtherClusterWhenOneIsFull
 		// checks that users will be provisioned to the other member when one is full.
 		// if one cluster if full, then a new space will be placed in the another cluster.
-		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
-		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
+		require.NotEqual(t, user1.MUR.Status.UserAccounts[0].Cluster.Name, user2.MUR.Status.UserAccounts[0].Cluster.Name)
+		require.NotEqual(t, user1.Space.Spec.TargetCluster, user2.Space.Spec.TargetCluster)
 
 		// when
 		waitingListUser1 := NewSignupRequest(s.Awaitilities).
@@ -231,8 +227,6 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
-		mur1 := user1.MUR
-		space1 := user1.Space
 
 		user2 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-2").
@@ -240,12 +234,10 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
-		mur2 := user2.MUR
-		space2 := user2.Space
 
 		// then
-		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
-		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
+		require.NotEqual(t, user1.MUR.Status.UserAccounts[0].Cluster.Name, user2.MUR.Status.UserAccounts[0].Cluster.Name)
+		require.NotEqual(t, user1.Space.Spec.TargetCluster, user2.Space.Spec.TargetCluster)
 
 		t.Run("after both members are full then new signups won't be approved nor provisioned", func(t *testing.T) {
 			// when
@@ -254,10 +246,9 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 				Email("multi3@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 				Execute(s.T())
-			userSignupPending := userPending.UserSignup
 
 			// then
-			s.userIsNotProvisioned(t, userSignupPending)
+			s.userIsNotProvisioned(t, userPending.UserSignup)
 		})
 	})
 }
@@ -356,10 +347,9 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
-	userSignup := user.UserSignup
 
 	// then
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, user.UserSignup, "deactivate30", "base")
 }
 
 func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaimsModified() {
@@ -428,10 +418,9 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
-	userSignup := user.UserSignup
 
 	// then
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, user.UserSignup, "deactivate30", "base")
 }
 
 func (s *userSignupIntegrationTest) userIsNotProvisioned(t *testing.T, userSignup *toolchainv1alpha1.UserSignup) {
@@ -459,9 +448,8 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 				Execute(s.T())
-			userSignup := user.UserSignup
 
-			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
+			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, user.UserSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
@@ -470,10 +458,9 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 				Email("manual2@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
 				Execute(s.T())
-			userSignup := user.UserSignup
 
 			// then
-			s.userIsNotProvisioned(t, userSignup)
+			s.userIsNotProvisioned(t, user.UserSignup)
 		})
 	})
 }
@@ -584,9 +571,8 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			TargetCluster(memberAwait1).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(s.T())
-		userSignup := user.UserSignup
 
-		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
+		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, user.UserSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
 }
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -51,12 +51,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	memberAwait2 := s.Member2()
 
 	// when & then
-	_, mur1 := NewSignupRequest(s.Awaitilities).
+	_, mur1, space1 := NewSignupRequest(s.Awaitilities).
 		Username("automatic1").
 		Email("automatic1@redhat.com").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	s.T().Run("set low max number of spaces and expect that space won't be approved nor provisioned but added on waiting list", func(t *testing.T) {
 		// given
@@ -65,37 +65,33 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		spaceprovisionerconfig.UpdateForCluster(t, hostAwait.Awaitility, memberAwait2.ClusterName, testSpc.MaxNumberOfSpaces(1))
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// create additional user to reach max space limits on both members
-		_, mur2 := NewSignupRequest(s.Awaitilities).
+		_, mur2, space2 := NewSignupRequest(s.Awaitilities).
 			Username("automatic2").
 			Email("automatic2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// TestProvisionToOtherClusterWhenOneIsFull
 		// checks that users will be provisioned to the other member when one is full.
 		// if one cluster if full, then a new space will be placed in the another cluster.
 		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
-		space1, err := hostAwait.WaitForSpace(t, mur1.Name, wait.UntilSpaceHasAnyTargetClusterSet())
-		require.NoError(t, err)
-		space2, err := hostAwait.WaitForSpace(t, mur2.Name, wait.UntilSpaceHasAnyTargetClusterSet())
-		require.NoError(t, err)
 		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
 
 		// when
-		waitingList1, _ := NewSignupRequest(s.Awaitilities).
+		waitingList1, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist1").
 			Email("waitinglist1@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
-		waitlinglist2, _ := NewSignupRequest(s.Awaitilities).
+		waitlinglist2, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist2").
 			Email("waitinglist2@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, waitingList1)
@@ -140,11 +136,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 
 		// when
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("automatic3").
 			Email("automatic3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-			Execute(t).Resources()
+			Execute(t).Resources(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -171,11 +167,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasAutoApprovalDomains(domains), wait.UntilToolchainConfigHasVerificationEnabled(false))
 
 		// and
-		waitingList3, _ := NewSignupRequest(s.Awaitilities).
+		waitingList3, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist3").
 			Email("waitinglist3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, waitingList3)
@@ -197,11 +193,11 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		t.Run("add user with bad email format and expect the user will not be approved nor provisioned", func(t *testing.T) {
 			msg := "unable to determine automatic approval: invalid email address: waitinglist4@somedomain.org@anotherdomain.com"
 			// when
-			waitingList4, _ := NewSignupRequest(s.Awaitilities).
+			waitingList4, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("waitinglist4").
 				Email("waitinglist4@somedomain.org@anotherdomain.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApprovalWithMsg(msg), wait.PendingApprovalNoClusterWithMsg(msg))...).
-				Execute(s.T()).Resources()
+				Execute(s.T()).Resources(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, waitingList4)
@@ -220,35 +216,31 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// when
-		_, mur1 := NewSignupRequest(s.Awaitilities).
+		_, mur1, space1 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-1").
 			Email("multi1@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
-		_, mur2 := NewSignupRequest(s.Awaitilities).
+		_, mur2, space2 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-2").
 			Email("multi2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// then
 		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
-		space1, err := hostAwait.WaitForSpace(t, mur1.Name, wait.UntilSpaceHasAnyTargetClusterSet())
-		require.NoError(t, err)
-		space2, err := hostAwait.WaitForSpace(t, mur2.Name, wait.UntilSpaceHasAnyTargetClusterSet())
-		require.NoError(t, err)
 		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
 
 		t.Run("after both members are full then new signups won't be approved nor provisioned", func(t *testing.T) {
 			// when
-			userSignupPending, _ := NewSignupRequest(s.Awaitilities).
+			userSignupPending, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("multimember-3").
 				Email("multi3@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
-				Execute(s.T()).Resources()
+				Execute(s.T()).Resources(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, userSignupPending)
@@ -263,14 +255,14 @@ func (s *userSignupIntegrationTest) TestUserIDAndAccountIDClaimsPropagated() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user").
 		Email("test-user@redhat.com").
 		UserID("123456789").
 		AccountID("987654321").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -285,7 +277,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 	id := uuid.New()
 
 	// when
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-identityclaims").
 		Email("test-user-identityclaims@redhat.com").
 		IdentityID(id).
@@ -293,7 +285,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 		AccountID("111999").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -342,13 +334,13 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-originalsub").
 		Email("test-user-with-originalsub@redhat.com").
 		OriginalSub("abc:fff000111-bbbccc").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -366,14 +358,14 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 	// 2. user ID and account ID are set by test
 	// 3. no original sub claim is set
 	// This scenario is expected with the regular RHD SSO client
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-resources-updated").
 		Email("test-user-resources-updated@redhat.com").
 		UserID("43215432").
 		AccountID("ppqnnn00099").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -409,7 +401,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	identityID := uuid.New()
 
 	// when
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-userid-and-originalsub").
 		Email("test-user-with-userid-and-originalsub@redhat.com").
 		IdentityID(identityID).
@@ -418,7 +410,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 		OriginalSub("def:98734987234").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-		Execute(s.T()).Resources()
+		Execute(s.T()).Resources(s.T())
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -442,23 +434,23 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
-			userSignup, _ := NewSignupRequest(s.Awaitilities).
+			userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual1").
 				Email("manual1@redhat.com").
 				ManuallyApprove().
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-				Execute(s.T()).Resources()
+				Execute(s.T()).Resources(s.T())
 
 			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
-			userSignup, _ := NewSignupRequest(s.Awaitilities).
+			userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 				Username("manual2").
 				Email("manual2@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
-				Execute(s.T()).Resources()
+				Execute(s.T()).Resources(s.T())
 
 			// then
 			s.userIsNotProvisioned(t, userSignup)
@@ -495,15 +487,15 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			Email("manualwithcapacity2@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// when
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity3").
 			Email("manualwithcapacity3@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -530,12 +522,12 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity4").
 			Email("manualwithcapacity4@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -562,14 +554,14 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when & then
-		userSignup, _ := NewSignupRequest(s.Awaitilities).
+		userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 			Username("withtargetcluster").
 			Email("withtargetcluster@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait1).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(s.T()).Resources()
+			Execute(s.T()).Resources(s.T())
 
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
@@ -648,14 +640,14 @@ func (s *userSignupIntegrationTest) TestSkipSpaceCreation() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _ := NewSignupRequest(s.Awaitilities).
+	userSignup, _, _ := NewSignupRequest(s.Awaitilities).
 		Username("nospace").
 		Email("nospace@redhat.com").
 		NoSpace().
 		WaitForMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T()).
-		Resources()
+		Resources(s.T())
 
 	// then
 

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -84,8 +84,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 
 		// when
 		waitingListUser1 := NewSignupRequest(s.Awaitilities).
-			Username("waitingList1").
-			Email("waitingList1@redhat.com").
+			Username("waitinglist1").
+			Email("waitinglist1@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 			Execute(s.T())
 		waitingList1 := waitingListUser1.UserSignup
@@ -93,8 +93,8 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
 		waitingListUser2 := NewSignupRequest(s.Awaitilities).
-			Username("waitingList2").
-			Email("waitingList2@redhat.com").
+			Username("waitinglist2").
+			Email("waitinglist2@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 			Execute(s.T())
 		waitingList2 := waitingListUser2.UserSignup

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -51,12 +51,14 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 	memberAwait2 := s.Member2()
 
 	// when & then
-	_, mur1, space1, _ := NewSignupRequest(s.Awaitilities).
+	user1 := NewSignupRequest(s.Awaitilities).
 		Username("automatic1").
 		Email("automatic1@redhat.com").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
+	mur1 := user1.MUR
+	space1 := user1.Space
 
 	s.T().Run("set low max number of spaces and expect that space won't be approved nor provisioned but added on waiting list", func(t *testing.T) {
 		// given
@@ -65,12 +67,14 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		spaceprovisionerconfig.UpdateForCluster(t, hostAwait.Awaitility, memberAwait2.ClusterName, testSpc.MaxNumberOfSpaces(1))
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// create additional user to reach max space limits on both members
-		_, mur2, space2, _ := NewSignupRequest(s.Awaitilities).
+		user2 := NewSignupRequest(s.Awaitilities).
 			Username("automatic2").
 			Email("automatic2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
+		mur2 := user2.MUR
+		space2 := user2.Space
 
 		// TestProvisionToOtherClusterWhenOneIsFull
 		// checks that users will be provisioned to the other member when one is full.
@@ -79,23 +83,25 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		require.NotEqual(t, space1.Spec.TargetCluster, space2.Spec.TargetCluster)
 
 		// when
-		waitingList1, _, _, _ := NewSignupRequest(s.Awaitilities).
-			Username("waitinglist1").
-			Email("waitinglist1@redhat.com").
+		waitingListUser1 := NewSignupRequest(s.Awaitilities).
+			Username("waitingList1").
+			Email("waitingList1@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 			Execute(s.T())
+		waitingList1 := waitingListUser1.UserSignup
 
 		// we need to sleep one second to create UserSignup with different creation time
 		time.Sleep(time.Second)
-		waitlinglist2, _, _, _ := NewSignupRequest(s.Awaitilities).
-			Username("waitinglist2").
-			Email("waitinglist2@redhat.com").
+		waitingListUser2 := NewSignupRequest(s.Awaitilities).
+			Username("waitingList2").
+			Email("waitingList2@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 			Execute(s.T())
+		waitingList2 := waitingListUser2.UserSignup
 
 		// then
 		s.userIsNotProvisioned(t, waitingList1)
-		s.userIsNotProvisioned(t, waitlinglist2)
+		s.userIsNotProvisioned(t, waitingList2)
 
 		t.Run("increment the max number of spaces and expect the first unapproved user will be provisioned", func(t *testing.T) {
 			// when
@@ -110,7 +116,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 			require.NoError(t, err)
 
 			VerifyResourcesProvisionedForSignup(t, s.Awaitilities, userSignup, "deactivate30", "base")
-			s.userIsNotProvisioned(t, waitlinglist2)
+			s.userIsNotProvisioned(t, waitingList2)
 
 			t.Run("reset the max number of spaces and expect the second user will be provisioned as well", func(t *testing.T) {
 				// when
@@ -119,7 +125,7 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 				hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 
 				// then
-				userSignup, err := hostAwait.WaitForUserSignup(t, waitlinglist2.Name,
+				userSignup, err := hostAwait.WaitForUserSignup(t, waitingList2.Name,
 					wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...),
 					wait.UntilUserSignupHasStateLabel(toolchainv1alpha1.UserSignupStateLabelValueApproved))
 				require.NoError(t, err)
@@ -136,11 +142,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 
 		// when
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("automatic3").
 			Email("automatic3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 			Execute(t)
+		userSignup := user.UserSignup
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -167,11 +174,12 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasAutoApprovalDomains(domains), wait.UntilToolchainConfigHasVerificationEnabled(false))
 
 		// and
-		waitingList3, _, _, _ := NewSignupRequest(s.Awaitilities).
-			Username("waitinglist3").
-			Email("waitinglist3@redhat.com").
+		waitingListUser3 := NewSignupRequest(s.Awaitilities).
+			Username("waitingList3").
+			Email("waitingList3@redhat.com").
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
 			Execute(s.T())
+		waitingList3 := waitingListUser3.UserSignup
 
 		// then
 		s.userIsNotProvisioned(t, waitingList3)
@@ -191,13 +199,14 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		})
 
 		t.Run("add user with bad email format and expect the user will not be approved nor provisioned", func(t *testing.T) {
-			msg := "unable to determine automatic approval: invalid email address: waitinglist4@somedomain.org@anotherdomain.com"
+			msg := "unable to determine automatic approval: invalid email address: waitingList4@somedomain.org@anotherdomain.com"
 			// when
-			waitingList4, _, _, _ := NewSignupRequest(s.Awaitilities).
-				Username("waitinglist4").
-				Email("waitinglist4@somedomain.org@anotherdomain.com").
+			waitingListUser4 := NewSignupRequest(s.Awaitilities).
+				Username("waitingList4").
+				Email("waitingList4@somedomain.org@anotherdomain.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApprovalWithMsg(msg), wait.PendingApprovalNoClusterWithMsg(msg))...).
 				Execute(s.T())
+			waitingList4 := waitingListUser4.UserSignup
 
 			// then
 			s.userIsNotProvisioned(t, waitingList4)
@@ -216,19 +225,23 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 		// when
-		_, mur1, space1, _ := NewSignupRequest(s.Awaitilities).
+		user1 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-1").
 			Email("multi1@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
+		mur1 := user1.MUR
+		space1 := user1.Space
 
-		_, mur2, space2, _ := NewSignupRequest(s.Awaitilities).
+		user2 := NewSignupRequest(s.Awaitilities).
 			Username("multimember-2").
 			Email("multi2@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(s.T())
+		mur2 := user2.MUR
+		space2 := user2.Space
 
 		// then
 		require.NotEqual(t, mur1.Status.UserAccounts[0].Cluster.Name, mur2.Status.UserAccounts[0].Cluster.Name)
@@ -236,11 +249,12 @@ func (s *userSignupIntegrationTest) TestProvisionToOtherClusterWhenOneIsFull() {
 
 		t.Run("after both members are full then new signups won't be approved nor provisioned", func(t *testing.T) {
 			// when
-			userSignupPending, _, _, _ := NewSignupRequest(s.Awaitilities).
+			userPending := NewSignupRequest(s.Awaitilities).
 				Username("multimember-3").
 				Email("multi3@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval(), wait.PendingApprovalNoCluster())...).
 				Execute(s.T())
+			userSignupPending := userPending.UserSignup
 
 			// then
 			s.userIsNotProvisioned(t, userSignupPending)
@@ -255,7 +269,7 @@ func (s *userSignupIntegrationTest) TestUserIDAndAccountIDClaimsPropagated() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("test-user").
 		Email("test-user@redhat.com").
 		UserID("123456789").
@@ -265,7 +279,7 @@ func (s *userSignupIntegrationTest) TestUserIDAndAccountIDClaimsPropagated() {
 		Execute(s.T())
 
 	// then
-	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
+	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, user.UserSignup, "deactivate30", "base")
 }
 
 func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims() {
@@ -277,7 +291,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 	id := uuid.New()
 
 	// when
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("test-user-identityclaims").
 		Email("test-user-identityclaims@redhat.com").
 		IdentityID(id).
@@ -286,6 +300,7 @@ func (s *userSignupIntegrationTest) TestGetSignupEndpointUpdatesIdentityClaims()
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
+	userSignup := user.UserSignup
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -334,13 +349,14 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-originalsub").
 		Email("test-user-with-originalsub@redhat.com").
 		OriginalSub("abc:fff000111-bbbccc").
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
+	userSignup := user.UserSignup
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -358,7 +374,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 	// 2. user ID and account ID are set by test
 	// 3. no original sub claim is set
 	// This scenario is expected with the regular RHD SSO client
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("test-user-resources-updated").
 		Email("test-user-resources-updated@redhat.com").
 		UserID("43215432").
@@ -366,6 +382,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
+	userSignup := user.UserSignup
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -401,7 +418,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 	identityID := uuid.New()
 
 	// when
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("test-user-with-userid-and-originalsub").
 		Email("test-user-with-userid-and-originalsub@redhat.com").
 		IdentityID(identityID).
@@ -411,6 +428,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesCreatedWhenOriginalSubIsSet
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
+	userSignup := user.UserSignup
 
 	// then
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup, "deactivate30", "base")
@@ -434,23 +452,25 @@ func (s *userSignupIntegrationTest) TestManualApproval() {
 
 		t.Run("user is approved manually", func(t *testing.T) {
 			// when & then
-			userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+			user := NewSignupRequest(s.Awaitilities).
 				Username("manual1").
 				Email("manual1@redhat.com").
 				ManuallyApprove().
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 				Execute(s.T())
+			userSignup := user.UserSignup
 
 			assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		})
 		t.Run("user is not approved manually thus won't be provisioned", func(t *testing.T) {
 			// when
-			userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+			user := NewSignupRequest(s.Awaitilities).
 				Username("manual2").
 				Email("manual2@redhat.com").
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...).
 				Execute(s.T())
+			userSignup := user.UserSignup
 
 			// then
 			s.userIsNotProvisioned(t, userSignup)
@@ -490,12 +510,13 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			Execute(s.T())
 
 		// when
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity3").
 			Email("manualwithcapacity3@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
 			Execute(s.T())
+		userSignup := user.UserSignup
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -522,12 +543,13 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("manualwithcapacity4").
 			Email("manualwithcapacity4@redhat.com").
 			ManuallyApprove().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin(), wait.ApprovedByAdminNoCluster())...).
 			Execute(s.T())
+		userSignup := user.UserSignup
 
 		// then
 		s.userIsNotProvisioned(t, userSignup)
@@ -554,7 +576,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 		hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 
 		// when & then
-		userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+		user := NewSignupRequest(s.Awaitilities).
 			Username("withtargetcluster").
 			Email("withtargetcluster@redhat.com").
 			ManuallyApprove().
@@ -562,6 +584,7 @@ func (s *userSignupIntegrationTest) TestCapacityManagementWithManualApproval() {
 			TargetCluster(memberAwait1).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(s.T())
+		userSignup := user.UserSignup
 
 		assert.Equal(t, toolchainv1alpha1.UserSignupStateLabelValueApproved, userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	})
@@ -640,14 +663,14 @@ func (s *userSignupIntegrationTest) TestSkipSpaceCreation() {
 	hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true))
 
 	// when
-	userSignup, _, _, _ := NewSignupRequest(s.Awaitilities).
+	user := NewSignupRequest(s.Awaitilities).
 		Username("nospace").
 		Email("nospace@redhat.com").
 		NoSpace().
 		WaitForMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 		Execute(s.T())
-
+	userSignup := user.UserSignup
 	// then
 
 	// annotation should be set

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -106,15 +106,14 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 		username := fmt.Sprintf("user-%04d", i)
 
 		// Create UserSignup
-		signupsMember2[username], _, _ = NewSignupRequest(awaitilities).
+		signupsMember2[username], _, _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			ManuallyApprove().
 			EnsureMUR().
 			TargetCluster(memberAwait2).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 	}
 	NewSignupRequest(awaitilities).
 		Username("member1").
@@ -123,8 +122,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).
-		Resources(t)
+		Execute(t)
 
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 3)                                                            // all signups
@@ -203,13 +201,12 @@ func TestMetricsWhenUsersAutomaticallyApprovedAndThenDeactivated(t *testing.T) {
 		username := fmt.Sprintf("userautoapprove-%04d", i)
 
 		// Create UserSignup
-		usersignups[username], _, _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 	}
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 2)                                                            // all signups
@@ -361,14 +358,13 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		username := fmt.Sprintf("user-%04d", i)
 
-		usersignups[username], _, _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
@@ -386,15 +382,14 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 
 			// reactivate the user
 
-			usersignups[username], _, _ = NewSignupRequest(awaitilities).
+			usersignups[username], _, _, _ = NewSignupRequest(awaitilities).
 				IdentityID(uuid.MustParse(usersignups[username].Spec.IdentityClaims.Sub)).
 				Username(username).
 				ManuallyApprove().
 				TargetCluster(memberAwait).
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-				Execute(t).
-				Resources(t)
+				Execute(t)
 		}
 	}
 
@@ -442,13 +437,12 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
-		usersignups[username], _, _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-			Execute(t).
-			Resources(t)
+			Execute(t)
 	}
 
 	// when deleting user "user-0001"
@@ -499,14 +493,14 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
-	userSignup, _, _ := NewSignupRequest(awaitilities).
+	userSignup, _, _, _ := NewSignupRequest(awaitilities).
 		Username("metricsbanprovisioned").
 		Email("metricsbanprovisioned@test.com").
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources(t)
+		Execute(t)
 
 	// when creating the BannedUser resource
 	bannedUser := banUser(t, hostAwait, userSignup.Spec.IdentityClaims.Email)
@@ -571,14 +565,13 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	})
 
 	// Create UserSignup
-	_, mur, _ := NewSignupRequest(awaitilities).
+	_, mur, _, _ := NewSignupRequest(awaitilities).
 		Username("janedoe").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).
-		Resources(t)
+		Execute(t)
 
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 1)
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsApprovedMetric, 1)                                  // approved

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -106,7 +106,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 		username := fmt.Sprintf("user-%04d", i)
 
 		// Create UserSignup
-		signupsMember2[username], _ = NewSignupRequest(awaitilities).
+		signupsMember2[username], _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			ManuallyApprove().
@@ -114,7 +114,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 			TargetCluster(memberAwait2).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 	}
 	NewSignupRequest(awaitilities).
 		Username("member1").
@@ -124,7 +124,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t).
-		Resources()
+		Resources(t)
 
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 3)                                                            // all signups
@@ -203,13 +203,13 @@ func TestMetricsWhenUsersAutomaticallyApprovedAndThenDeactivated(t *testing.T) {
 		username := fmt.Sprintf("userautoapprove-%04d", i)
 
 		// Create UserSignup
-		usersignups[username], _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			Email(username + "@redhat.com").
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 	}
 	// checking the metrics after creation/before deactivation, so we can better understand the changes after deactivations occurred.
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 2)                                                            // all signups
@@ -361,14 +361,14 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 	for i := 1; i <= 3; i++ {
 		username := fmt.Sprintf("user-%04d", i)
 
-		usersignups[username], _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			EnsureMUR().
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
@@ -386,7 +386,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 
 			// reactivate the user
 
-			usersignups[username], _ = NewSignupRequest(awaitilities).
+			usersignups[username], _, _ = NewSignupRequest(awaitilities).
 				IdentityID(uuid.MustParse(usersignups[username].Spec.IdentityClaims.Sub)).
 				Username(username).
 				ManuallyApprove().
@@ -394,7 +394,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 				EnsureMUR().
 				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 				Execute(t).
-				Resources()
+				Resources(t)
 		}
 	}
 
@@ -442,13 +442,13 @@ func TestMetricsWhenUsersDeleted(t *testing.T) {
 
 	for i := 1; i <= 2; i++ {
 		username := fmt.Sprintf("user-%04d", i)
-		usersignups[username], _ = NewSignupRequest(awaitilities).
+		usersignups[username], _, _ = NewSignupRequest(awaitilities).
 			Username(username).
 			ManuallyApprove().
 			TargetCluster(memberAwait).
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t).
-			Resources()
+			Resources(t)
 	}
 
 	// when deleting user "user-0001"
@@ -499,14 +499,14 @@ func TestMetricsWhenUsersBanned(t *testing.T) {
 
 	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false))
 	// Create a new UserSignup and approve it manually
-	userSignup, _ := NewSignupRequest(awaitilities).
+	userSignup, _, _ := NewSignupRequest(awaitilities).
 		Username("metricsbanprovisioned").
 		Email("metricsbanprovisioned@test.com").
 		ManuallyApprove().
 		EnsureMUR().
 		TargetCluster(memberAwait).
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).Resources()
+		Execute(t).Resources(t)
 
 	// when creating the BannedUser resource
 	bannedUser := banUser(t, hostAwait, userSignup.Spec.IdentityClaims.Email)
@@ -571,14 +571,14 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	})
 
 	// Create UserSignup
-	_, mur := NewSignupRequest(awaitilities).
+	_, mur, _ := NewSignupRequest(awaitilities).
 		Username("janedoe").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
 		EnsureMUR().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t).
-		Resources()
+		Resources(t)
 
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsMetric, 1)
 	hostAwait.WaitForMetricDelta(t, wait.UserSignupsApprovedMetric, 1)                                  // approved

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -209,10 +209,9 @@ func (r *SetupMigrationRunner) prepareUser(t *testing.T, name string, targetClus
 		requestBuilder = requestBuilder.DisableCleanup()
 	}
 
-	signup, _, _ := requestBuilder.
+	signup, _, _, _ := requestBuilder.
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
-		Execute(t).
-		Resources(t)
+		Execute(t)
 	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(t, signup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasConditions(wait.Provisioned(), wait.ProvisionedNotificationCRCreated()))
 	require.NoError(t, err)

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -209,10 +209,10 @@ func (r *SetupMigrationRunner) prepareUser(t *testing.T, name string, targetClus
 		requestBuilder = requestBuilder.DisableCleanup()
 	}
 
-	signup, _ := requestBuilder.
+	signup, _, _ := requestBuilder.
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t).
-		Resources()
+		Resources(t)
 	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(t, signup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasConditions(wait.Provisioned(), wait.ProvisionedNotificationCRCreated()))
 	require.NoError(t, err)

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -209,9 +209,10 @@ func (r *SetupMigrationRunner) prepareUser(t *testing.T, name string, targetClus
 		requestBuilder = requestBuilder.DisableCleanup()
 	}
 
-	signup, _, _, _ := requestBuilder.
+	user := requestBuilder.
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		Execute(t)
+	signup := user.UserSignup
 	_, err := r.Awaitilities.Host().WaitForMasterUserRecord(t, signup.Status.CompliantUsername,
 		wait.UntilMasterUserRecordHasConditions(wait.Provisioned(), wait.ProvisionedNotificationCRCreated()))
 	require.NoError(t, err)

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -197,12 +197,11 @@ func (r *namesRegistry) add(t *testing.T, name string) {
 	r.usernames[name] = t.Name()
 }
 
-// Execute executes the request against the Registration service REST endpoint.  This function may only be called
-// once, and must be called after all other functions. It returns four parameters; the first is the UserSignup
-// instance that was created, the second is the MasterUserRecord instance, the third is the space,
-// and the fourth returns the token that was generated for the request.
-// HOWEVER the MUR will only be returned here if EnsureMUR() was also called previously, otherwise a nil value will be returned
-// The space will only be returned here if noSpace is true. If false, a nil value will be returned
+// Execute executes the request against the Registration service REST endpoint. This function may only be called
+// once, and must be called after all other functions. It returns SignupResult that contains the UserSignup,
+// the MasterUserRecord, the Space, and the token that was generated for the request. HOWEVER, the MUR will only be
+// returned here if EnsureMUR() was also called previously, otherwise a nil value will be returned.
+// The space will only be returned here if 'noSpace' is true. If false, a nil value will be returned.
 func (r *SignupRequest) Execute(t *testing.T) *SignupResult {
 	hostAwait := r.awaitilities.Host()
 	err := hostAwait.WaitUntilBaseNSTemplateTierIsUpdated(t)

--- a/testsupport/space/space.go
+++ b/testsupport/space/space.go
@@ -30,13 +30,13 @@ func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...testspace
 func CreateSpaceWithRole(t *testing.T, awaitilities wait.Awaitilities, role string, opts ...testspace.Option) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	// we need to create a MUR & SpaceBinding, otherwise, the Space could be automatically deleted by the SpaceCleanup controller
 	username := uuid.Must(uuid.NewV4()).String()
-	signup, mur, _ := testsupport.NewSignupRequest(awaitilities).
+	signup, mur, _, _ := testsupport.NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		NoSpace().
-		WaitForMUR().Execute(t).Resources(t)
+		WaitForMUR().Execute(t)
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 
 	// create the actual space
@@ -189,7 +189,7 @@ func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awai
 	if !cleanup {
 		builder.DisableCleanup()
 	}
-	signup, mur, _ := builder.Execute(t).Resources(t)
+	signup, mur, _, _ := builder.Execute(t)
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 	var binding *toolchainv1alpha1.SpaceBinding
 	if cleanup {

--- a/testsupport/space/space.go
+++ b/testsupport/space/space.go
@@ -30,13 +30,13 @@ func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...testspace
 func CreateSpaceWithRole(t *testing.T, awaitilities wait.Awaitilities, role string, opts ...testspace.Option) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	// we need to create a MUR & SpaceBinding, otherwise, the Space could be automatically deleted by the SpaceCleanup controller
 	username := uuid.Must(uuid.NewV4()).String()
-	signup, mur := testsupport.NewSignupRequest(awaitilities).
+	signup, mur, _ := testsupport.NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		NoSpace().
-		WaitForMUR().Execute(t).Resources()
+		WaitForMUR().Execute(t).Resources(t)
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 
 	// create the actual space
@@ -189,7 +189,7 @@ func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awai
 	if !cleanup {
 		builder.DisableCleanup()
 	}
-	signup, mur := builder.Execute(t).Resources()
+	signup, mur, _ := builder.Execute(t).Resources(t)
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 	var binding *toolchainv1alpha1.SpaceBinding
 	if cleanup {

--- a/testsupport/space/space.go
+++ b/testsupport/space/space.go
@@ -30,13 +30,15 @@ func CreateSpace(t *testing.T, awaitilities wait.Awaitilities, opts ...testspace
 func CreateSpaceWithRole(t *testing.T, awaitilities wait.Awaitilities, role string, opts ...testspace.Option) (*toolchainv1alpha1.Space, *toolchainv1alpha1.UserSignup, *toolchainv1alpha1.SpaceBinding) {
 	// we need to create a MUR & SpaceBinding, otherwise, the Space could be automatically deleted by the SpaceCleanup controller
 	username := uuid.Must(uuid.NewV4()).String()
-	signup, mur, _, _ := testsupport.NewSignupRequest(awaitilities).
+	user := testsupport.NewSignupRequest(awaitilities).
 		Username(username).
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		NoSpace().
 		WaitForMUR().Execute(t)
+	signup := user.UserSignup
+	mur := user.MUR
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 
 	// create the actual space
@@ -189,7 +191,9 @@ func CreateMurWithAdminSpaceBindingForSpace(t *testing.T, awaitilities wait.Awai
 	if !cleanup {
 		builder.DisableCleanup()
 	}
-	signup, mur, _, _ := builder.Execute(t)
+	user := builder.Execute(t)
+	signup := user.UserSignup
+	mur := user.MUR
 	t.Logf("The UserSignup %s and MUR %s were created", signup.Name, mur.Name)
 	var binding *toolchainv1alpha1.SpaceBinding
 	if cleanup {

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -40,7 +40,7 @@ func createMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			signupRequest = signupRequest.EnsureMUR().RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...)
 		}
 
-		signups[i], _, _ = signupRequest.Execute(t).Resources(t)
+		signups[i], _, _, _ = signupRequest.Execute(t)
 
 	}
 	return signups

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -40,7 +40,8 @@ func createMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			signupRequest = signupRequest.EnsureMUR().RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...)
 		}
 
-		signups[i], _, _, _ = signupRequest.Execute(t)
+		user := signupRequest.Execute(t)
+		signups[i] = user.UserSignup
 
 	}
 	return signups

--- a/testsupport/user_setup.go
+++ b/testsupport/user_setup.go
@@ -40,7 +40,7 @@ func createMultipleSignups(t *testing.T, awaitilities wait.Awaitilities, targetC
 			signupRequest = signupRequest.EnsureMUR().RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...)
 		}
 
-		signups[i], _ = signupRequest.Execute(t).Resources()
+		signups[i], _, _ = signupRequest.Execute(t).Resources(t)
 
 	}
 	return signups


### PR DESCRIPTION
# Description
As discussed [here](https://github.com/codeready-toolchain/toolchain-e2e/pull/986#discussion_r1622348683), we can benefit from also returning space in `Resources`.

However, after discussing in this [PR's conversation](https://github.com/codeready-toolchain/toolchain-e2e/pull/991#discussion_r1625880758), we can move forward to drop Resources and return space and token in `Execute`.


## Issue ticket number and link
[SANDBOX-629](https://issues.redhat.com/browse/SANDBOX-629)