### PR TITLE
Fix flaky e2e test

### DIFF
--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -377,8 +377,9 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 				mur.Status.ProvisionedTime.String())
 
 			// The user should be set to deactivating, but not deactivated
-			userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name, wait.UntilUserSignupHasConditions(
-				wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically(), wait.Deactivating())...))
+			userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name, wait.UntilUserSignupHasScheduledDeactivationTime(),
+				wait.UntilUserSignupHasConditions(
+					wait.ConditionSet(wait.Default(), wait.ApprovedAutomatically(), wait.Deactivating())...))
 			require.NoError(t, err)
 
 			// The scheduled deactivation time should have also been updated, and should now expire in ~3 days


### PR DESCRIPTION
Add a wait condition to ensure that the scheduled deactivation time is set before continuing.