### PR TITLE
Increase quotas in appstudio and appstudiolarge

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -453,7 +453,7 @@ func commonAppstudioTierChecks() []namespaceObjectsCheck {
 func (a *appstudioTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObjectsCheck {
 	checks := []namespaceObjectsCheck{
 		resourceQuotaStorage("50Gi", "200Gi", "50Gi", "90"),
-		resourceQuotaComputeBuild("120", "128Gi", "12", "64Gi"),
+		resourceQuotaComputeBuild("120", "128Gi", "60", "64Gi"),
 	}
 	checks = append(checks, commonAppstudioTierChecks()...)
 	checks = append(checks, append(commonNetworkPolicyChecks(), networkPolicyAllowFromCRW(), numberOfNetworkPolicies(6))...)
@@ -545,8 +545,8 @@ type appstudiolargeTierChecks struct {
 
 func (a *appstudiolargeTierChecks) GetNamespaceObjectChecks(_ string) []namespaceObjectsCheck {
 	checks := []namespaceObjectsCheck{
-		resourceQuotaComputeBuild("480", "512Gi", "48", "128Gi"),
-		resourceQuotaStorage("50Gi", "200Gi", "50Gi", "180"),
+		resourceQuotaComputeBuild("480", "512Gi", "240", "256Gi"),
+		resourceQuotaStorage("50Gi", "400Gi", "50Gi", "180"),
 	}
 	checks = append(checks, commonAppstudioTierChecks()...)
 	checks = append(checks, append(commonNetworkPolicyChecks(), networkPolicyAllowFromCRW(), numberOfNetworkPolicies(6))...)


### PR DESCRIPTION
appstudio:
* Parametrize request storage, keep same value of 200Gi
* Set build CPU request to half of limit, i.e. 60.

appstudiolarge:
* Set request storage to double of appstudio tier, i.e. 400Gi.
* Set build CPU request to half of limit, i.e. 240.
* Set build memory request to half of limit, i.e. 256Gi.

Paired with https://github.com/codeready-toolchain/host-operator/pull/1045

[KFLUXINFRA-632](https://issues.redhat.com//browse/KFLUXINFRA-632)