### PR TITLE
install ksctl via go install in a separate file

### DIFF
--- a/make/ksctl.mk
+++ b/make/ksctl.mk
@@ -1,0 +1,7 @@
+KSCTL_GH_OWNER=kubesaw
+KSCTL_GH_BRANCH=master
+
+BIN_DIR := $(shell pwd)/build/_output/bin
+
+ksctl:
+	GOBIN=${BIN_DIR} CGO_ENABLED=0 go install github.com/${KSCTL_GH_OWNER}/ksctl/cmd/ksctl@${KSCTL_GH_BRANCH}

--- a/make/test.mk
+++ b/make/test.mk
@@ -437,7 +437,7 @@ test:
 
 .PHONY: tiers-via-ksctl
 ## Regenerate and re-apply appstudio tiers using the latest version of ksctl
-tiers-via-ksctl:
+tiers-via-ksctl: ksctl
 	$(eval HOST_REPO_LOC = $(or ${HOST_REPO_PATH}, /tmp/host-operator-master))
 ifeq ($(HOST_REPO_PATH),)
 	rm -rf /tmp/host-operator-master 2>/dev/null || true
@@ -449,8 +449,5 @@ endif
 	cp -r ${HOST_REPO_LOC}/deploy/templates/nstemplatetiers/appstudio /tmp/e2e-tiers/
 	cp -r ${HOST_REPO_LOC}/deploy/templates/nstemplatetiers/appstudio-env /tmp/e2e-tiers/
 	cp -r ${HOST_REPO_LOC}/deploy/templates/nstemplatetiers/appstudiolarge /tmp/e2e-tiers
-	rm -rf /tmp/ksctl-master 2>/dev/null || true
-	git clone https://github.com/kubesaw/ksctl.git /tmp/ksctl-master
-	$(MAKE) -C /tmp/ksctl-master install GOBIN=/tmp/ksctl-master/bin
-	/tmp/ksctl-master/bin/ksctl generate nstemplatetiers --source /tmp/e2e-tiers --out-dir /tmp/e2e-tiers-out
+	${BIN_DIR}/ksctl generate nstemplatetiers --source /tmp/e2e-tiers --out-dir /tmp/e2e-tiers-out
 	oc kustomize /tmp/e2e-tiers-out | sed 's/toolchain-host-operator/${HOST_NS}/g;s/^metadata:/metadata:\n  annotations:\n    generated-by: ksctl/g' | oc apply -f -


### PR DESCRIPTION
simplified the installation of the ksctl binary and moved it to a separate makefile to not mix the things in the huge test file.
Later, we can think about:
1. either incorporating ksctl into the pairing mechanism
2. or specify the ksctl dependency in the go.mod file

But for now, let's do this simple install process and use always the master branch. In this way, we can also easily point any PR to a specific fork/branch if needed (to test any fixes of bugs).

The new `ksctl` makefile target can be also used later for making sure that the binary is present for example before calling `ksctl adm register-member` command.