### PR TITLE
fix: add DEV_SSO=true in appstudio related make targets

### DIFF
--- a/make/appstudio.mk
+++ b/make/appstudio.mk
@@ -1,11 +1,13 @@
 .PHONY: appstudio-dev-deploy-latest
 appstudio-dev-deploy-latest: DEV_ENVIRONMENT=appstudio-dev
 appstudio-dev-deploy-latest: DEPLOY_LATEST=true
+appstudio-dev-deploy-latest: DEV_SSO=true
 appstudio-dev-deploy-latest: dev-deploy-e2e
 
 .PHONY: appstudio-e2e-deploy-latest
 appstudio-e2e-deploy-latest: DEV_ENVIRONMENT=appstudio-e2e
 appstudio-e2e-deploy-latest: DEPLOY_LATEST=true
+appstudio-e2e-deploy-latest: DEV_SSO=true
 appstudio-e2e-deploy-latest: dev-deploy-e2e
 
 .PHONY: appstudio-cleanup


### PR DESCRIPTION
After [this change](https://github.com/codeready-toolchain/toolchain-e2e/pull/996) got introduced, we have to pass the params in appstudio related make targets