### PR TITLE
SANDBOX-677 use go-version-file

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,14 +14,14 @@ jobs:
     name: GolangCI Lint
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
+        go-version-file: go.mod
+
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
@@ -34,14 +34,14 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
+        go-version-file: go.mod
+
     - name: Unit Tests
       run: |
         make test

--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   GOPATH: /tmp/go
-  GO_VERSION: 1.20.x
 
 jobs:
   binary:
@@ -49,7 +48,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Cache dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
uses go-version-file instead of go-version. One less place to change when making updates.
Changes order in github action to first checkout code and then install go.

related PRs:
https://github.com/codeready-toolchain/api/pull/434
https://github.com/codeready-toolchain/toolchain-common/pull/415
https://github.com/codeready-toolchain/member-operator/pull/584
https://github.com/codeready-toolchain/registration-service/pull/445
https://github.com/codeready-toolchain/host-operator/pull/1060