### PR TITLE
fix: replicate member-config for the second member operator

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -386,7 +386,7 @@ create-host-resources: create-spaceprovisionerconfigs-for-members tiers-via-ksct
 		echo "TOOLCHAIN_CLUSTER_NAME $${TOOLCHAIN_CLUSTER_NAME}"; \
 		echo "ENVIRONMENT ${ENVIRONMENT}"; \
 		PATCH_FILE=/tmp/patch-toolchainconfig_${DATE_SUFFIX}.json; \
-		echo "{\"spec\":{\"members\":{\"specificPerMemberCluster\":{\"$${TOOLCHAIN_CLUSTER_NAME}\":{\"webhook\":{\"deploy\":false},\"environment\":\"${ENVIRONMENT}\"}}}}}" > $$PATCH_FILE; \
+		echo "{\"spec\":{\"members\":{\"specificPerMemberCluster\":{\"$${TOOLCHAIN_CLUSTER_NAME}\":$$(oc get toolchainconfig config -n ${HOST_NS} -o jsonpath='{.spec.members.default}' | jq '. += { webhook: { deploy: false } }')}}}}" > $$PATCH_FILE; \
 		oc patch toolchainconfig config -n ${HOST_NS} --type=merge --patch "$$(cat $$PATCH_FILE)"; \
 	fi;
 	echo "Restart host operator pods so that configuration referenced in main.go can get the updated ToolchainConfig CRs at startup"

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/spacebinding"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
@@ -56,8 +55,12 @@ func TestE2EFlow(t *testing.T) {
 			VerifyMemberOperatorConfig(t, hostAwait, memberAwait, wait.UntilMemberConfigMatches(expectedMemberConfiguration))
 		})
 		t.Run("verify MemberOperatorConfig was synced to member 2", func(t *testing.T) {
-			member2ExpectedConfig := testconfig.NewMemberOperatorConfigObj(testconfig.Webhook().Deploy(false), testconfig.MemberEnvironment("e2e-tests"))
-			VerifyMemberOperatorConfig(t, hostAwait, memberAwait2, wait.UntilMemberConfigMatches(member2ExpectedConfig.Spec))
+			// Expected to be the same as for member-1 but with Webhook deployment disabled.
+			// We can't deploy the same cluster-scoped webhook twice (member-1 and member-2) in the same physical cluster.
+			member2ExpectedConfig := expectedMemberConfiguration.DeepCopy()
+			f := false
+			member2ExpectedConfig.Webhook.Deploy = &f
+			VerifyMemberOperatorConfig(t, hostAwait, memberAwait2, wait.UntilMemberConfigMatches(*member2ExpectedConfig))
 		})
 	})
 

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -60,6 +60,7 @@ func TestE2EFlow(t *testing.T) {
 			member2ExpectedConfig := expectedMemberConfiguration.DeepCopy()
 			f := false
 			member2ExpectedConfig.Webhook.Deploy = &f
+			member2ExpectedConfig.Webhook.Secret = nil
 			VerifyMemberOperatorConfig(t, hostAwait, memberAwait2, wait.UntilMemberConfigMatches(*member2ExpectedConfig))
 		})
 	})

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -2163,14 +2163,14 @@ func (a *MemberAwaitility) WaitForMemberOperatorConfig(t *testing.T, hostAwait *
 	t.Logf("waiting for MemberOperatorConfig '%s'", name)
 	memberOperatorConfig := &toolchainv1alpha1.MemberOperatorConfig{}
 	err := wait.Poll(a.RetryInterval, 2*a.Timeout, func() (done bool, err error) {
-		memberOperatorConfig = &toolchainv1alpha1.MemberOperatorConfig{}
+		obj := &toolchainv1alpha1.MemberOperatorConfig{}
 		// retrieve the MemberOperatorConfig from the member namespace
 		err = a.Client.Get(context.TODO(),
 			types.NamespacedName{
 				Namespace: a.Namespace,
 				Name:      name,
 			},
-			memberOperatorConfig)
+			obj)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -2178,12 +2178,16 @@ func (a *MemberAwaitility) WaitForMemberOperatorConfig(t *testing.T, hostAwait *
 			return false, err
 		}
 		for _, match := range criteria {
-			if !match(hostAwait, a, memberOperatorConfig) {
+			if !match(hostAwait, a, obj) {
 				return false, nil
 			}
 		}
+		memberOperatorConfig = obj
 		return true, nil
 	})
+	if err != nil {
+		a.listAndPrint(t, "MemberOperatorConfig", a.Namespace, &toolchainv1alpha1.MemberOperatorConfigList{})
+	}
 	return memberOperatorConfig, err
 }
 


### PR DESCRIPTION
fix for https://github.com/codeready-toolchain/toolchain-e2e/pull/1027#issuecomment-2273284916

We need to replicate the whole member config from the default one and set only `.webhook.deploy: false` for it