### PR TITLE
enable pairing with branches from ksctl repository

### DIFF
--- a/make/ksctl.mk
+++ b/make/ksctl.mk
@@ -1,7 +1,62 @@
-KSCTL_GH_OWNER=kubesaw
-KSCTL_GH_BRANCH=master
+USE_INSTALLED_KSCTL = false
 
 BIN_DIR := $(shell pwd)/build/_output/bin
 
+ifneq ($(USE_INSTALLED_KSCTL),true)
+KSCTL_BIN_DIR = ${BIN_DIR}/
+endif
+
+.PHONY: ksctl
 ksctl:
-	GOBIN=${BIN_DIR} CGO_ENABLED=0 go install github.com/${KSCTL_GH_OWNER}/ksctl/cmd/ksctl@${KSCTL_GH_BRANCH}
+ifneq ($(USE_INSTALLED_KSCTL),true)
+	@$(MAKE) get-ksctl-and-install --no-print-directory
+else
+	@echo "Using local version of ksctl"
+endif
+
+get-ksctl-and-install:
+ifeq ($(strip $(KSCTL_REPO_PATH)),)
+    ifneq ($(CI),)
+        ifneq ($(GITHUB_ACTIONS),)
+			$(eval BRANCH_NAME = ${GITHUB_HEAD_REF})
+			$(eval AUTHOR_LINK = https://github.com/${AUTHOR})
+        else
+			$(eval AUTHOR_LINK = $(shell jq -r '.refs[0].pulls[0].author_link' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
+			@echo "found author link ${AUTHOR_LINK}"
+			$(eval BRANCH_NAME := $(shell jq -r '.refs[0].pulls[0].head_ref' <<< $${CLONEREFS_OPTIONS} | tr -d '[:space:]'))
+        endif
+		@echo "using author link ${AUTHOR_LINK}"
+		@echo "detected branch ${BRANCH_NAME}"
+		# check if a branch with the same ref exists in the user's fork of ksctl repo
+		$(eval REMOTE_KSCTL_BRANCH := $(shell curl ${AUTHOR_LINK}/ksctl.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "refs/heads/${BRANCH_NAME}$$" | awk '{print $$2}'))
+		@echo "branch ref of the user's fork: \"${REMOTE_KSCTL_BRANCH}\" - if empty then not found"
+		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master
+        ifneq ($(REMOTE_KSCTL_BRANCH),"")
+			# define temp dir
+			$(eval KSCTL_REPO_PATH := /tmp/ksctl)
+			# delete to have clear environment
+			rm -rf ${KSCTL_REPO_PATH}
+
+			git config --global user.email "devtools@redhat.com"
+			git config --global user.name "Devtools"
+			# clone
+			git clone --depth=1 https://github.com/kubesaw/ksctl.git ${KSCTL_REPO_PATH}
+			# add the user's fork as remote repo
+			git --git-dir=${KSCTL_REPO_PATH}/.git --work-tree=${KSCTL_REPO_PATH} remote add external ${AUTHOR_LINK}/ksctl.git
+			# fetch the branch
+			git --git-dir=${KSCTL_REPO_PATH}/.git --work-tree=${KSCTL_REPO_PATH} fetch external ${REMOTE_KSCTL_BRANCH}
+			# merge the branch with master
+			git --git-dir=${KSCTL_REPO_PATH}/.git --work-tree=${KSCTL_REPO_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD
+        endif
+    endif
+endif
+	@$(MAKE) install-ksctl KSCTL_REPO_PATH=${KSCTL_REPO_PATH}
+
+install-ksctl:
+ifneq ($(strip $(KSCTL_REPO_PATH)),)
+	@echo "Installing ksctl from directory ${KSCTL_REPO_PATH}"
+	$(MAKE) -C ${KSCTL_REPO_PATH} GOBIN=${BIN_DIR} install
+else
+	@echo "Installing ksctl from master"
+	GOBIN=${BIN_DIR} CGO_ENABLED=0 go install github.com/kubesaw/ksctl/cmd/ksctl@master
+endif

--- a/make/ksctl.mk
+++ b/make/ksctl.mk
@@ -28,6 +28,8 @@ ifeq ($(strip $(KSCTL_REPO_PATH)),)
 		@echo "using author link ${AUTHOR_LINK}"
 		@echo "detected branch ${BRANCH_NAME}"
 		# check if a branch with the same ref exists in the user's fork of ksctl repo
+		@echo "branches of ${AUTHOR_LINK}/ksctl - checking if there is a branch ${BRANCH_NAME} we could pair with."
+		curl ${AUTHOR_LINK}/ksctl.git/info/refs?service=git-upload-pack --output -
 		$(eval REMOTE_KSCTL_BRANCH := $(shell curl ${AUTHOR_LINK}/ksctl.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "refs/heads/${BRANCH_NAME}$$" | awk '{print $$2}'))
 		@echo "branch ref of the user's fork: \"${REMOTE_KSCTL_BRANCH}\" - if empty then not found"
 		# check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master

--- a/make/test.mk
+++ b/make/test.mk
@@ -261,8 +261,8 @@ print-operator-logs:
 
 .PHONY: setup-toolchainclusters
 setup-toolchainclusters: ksctl
-	${BIN_DIR}/ksctl adm register-member --host-ns="$(HOST_NS)" --member-ns="$(MEMBER_NS)" --host-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" --member-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" ${LETS_ENCRYPT_PARAM} -y
-	if [[ ${SECOND_MEMBER_MODE} == true ]]; then ${BIN_DIR}/ksctl adm register-member --host-ns="$(HOST_NS)" --member-ns="$(MEMBER_NS_2)" --host-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" --member-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" ${LETS_ENCRYPT_PARAM} --name-suffix="2" -y ; fi
+	${KSCTL_BIN_DIR}ksctl adm register-member --host-ns="$(HOST_NS)" --member-ns="$(MEMBER_NS)" --host-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" --member-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" ${LETS_ENCRYPT_PARAM} -y
+	if [[ ${SECOND_MEMBER_MODE} == true ]]; then ${KSCTL_BIN_DIR}ksctl adm register-member --host-ns="$(HOST_NS)" --member-ns="$(MEMBER_NS_2)" --host-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" --member-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" ${LETS_ENCRYPT_PARAM} --name-suffix="2" -y ; fi
 	echo "Restart host operator pods so it can get the ToolchainCluster CRs while it's starting up".
 	oc delete pods --namespace ${HOST_NS} -l control-plane=controller-manager
 
@@ -404,7 +404,7 @@ create-spaceprovisionerconfigs-for-members:
 ## Generate and apply appstudio tiers using the latest version of ksctl
 tiers-via-ksctl: ksctl
 	rm -rf /tmp/e2e-tiers-out 2>/dev/null || true
-	${BIN_DIR}/ksctl generate nstemplatetiers --source deploy/nstemplatetiers --out-dir /tmp/e2e-tiers-out
+	${KSCTL_BIN_DIR}ksctl generate nstemplatetiers --source deploy/nstemplatetiers --out-dir /tmp/e2e-tiers-out
 	oc kustomize /tmp/e2e-tiers-out | sed 's/toolchain-host-operator/${HOST_NS}/g' | oc apply -f -
 
 .PHONY: create-thirdparty-crds


### PR DESCRIPTION
Since the e2e test setup is increasingly dependent on ksctl commands, I introduced a possibility of pairing between toolchain-e2e and ksctl.
* It's only one-directional  - the e2e tests are not executed in ksctl repo for now. It can be changed later.
* It's not included into the limit that we can pair only one PR (host/member/reg-service) with only one PR from toolchain-e2e repo. In other words, it can be combined with it.
* it's not included in the migration test suite for now
* local execution uses ksctl version from master if not specified otherwise via env variables `USE_INSTALLED_KSCTL` or `KSCTL_REPO_PATH`. The UX can be changed later.

paired PR https://github.com/kubesaw/ksctl/pull/58 (expecting to fail when generating tier manifests)