### PR TITLE
add banned user scenario to get and list workspaces tests

### DIFF
--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -984,25 +984,14 @@ func TestSpaceLister(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("banned user cannot get workspace", func(t *testing.T) {
+	t.Run("banned user cannot create proxy client", func(t *testing.T) {
 		// when
-		workspace, err := users["banneduser"].getWorkspace(t, hostAwait, users["banneduser"].compliantUsername)
+		_, err := hostAwait.CreateAPIProxyClient(t, users["banneduser"].token, hostAwait.APIProxyURL)
 
 		// then
 		// this is the error expected to be returned by the proxy when the user is banned
 		require.EqualError(t, err, "unable to get target cluster: no member cluster found for the user")
-		require.Nil(t, workspace)
 	})
-
-	t.Run("banned user cannot list workspaces", func(t *testing.T) {
-		// when
-		workspaces := users["banneduser"].listWorkspaces(t, hostAwait)
-
-		// then
-		// banned user should not see any workspace
-		require.Empty(t, workspaces)
-	})
-
 }
 
 func tenantNsName(username string) string {

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -999,7 +999,7 @@ func TestSpaceLister(t *testing.T) {
 
 		// then
 		// banned user should not see any workspace
-		require.Len(t, workspaces, 0)
+		require.Empty(t, workspaces)
 	})
 
 }

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -989,7 +989,7 @@ func TestSpaceLister(t *testing.T) {
 		workspace, err := users["banneduser"].getWorkspace(t, hostAwait, users["banneduser"].compliantUsername)
 
 		// then
-		require.EqualError(t, err, "the server could not find the requested resource (get workspaces.toolchain.dev.openshift.com bus)")
+		require.EqualError(t, err, "the server could not find the requested resource (get workspaces.toolchain.dev.openshift.com banneduser)")
 		assert.Empty(t, workspace)
 	})
 

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -990,7 +990,7 @@ func TestSpaceLister(t *testing.T) {
 
 		// then
 		require.EqualError(t, err, "the server could not find the requested resource (get workspaces.toolchain.dev.openshift.com banneduser)")
-		assert.Empty(t, workspace)
+		require.Nil(t, workspace)
 	})
 
 	t.Run("banned user cannot list workspaces", func(t *testing.T) {

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -989,7 +989,8 @@ func TestSpaceLister(t *testing.T) {
 		workspace, err := users["banneduser"].getWorkspace(t, hostAwait, users["banneduser"].compliantUsername)
 
 		// then
-		require.EqualError(t, err, "the server could not find the requested resource (get workspaces.toolchain.dev.openshift.com banneduser)")
+		// this is the error expected to be returned by the proxy when the user is banned
+		require.EqualError(t, err, "unable to get target cluster: no member cluster found for the user")
 		require.Nil(t, workspace)
 	})
 

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -990,7 +990,7 @@ func TestSpaceLister(t *testing.T) {
 
 		// then
 		// this is the error expected to be returned by the proxy when the user is banned
-		require.EqualError(t, err, "unable to get target cluster: no member cluster found for the user")
+		require.ErrorContains(t, err, "unable to get target cluster: no member cluster found for the user")
 	})
 }
 


### PR DESCRIPTION
This PR add test scenarios in which a banned user cannot get and list workspaces.

It is related to this PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/1036 which adds tests for banned users in proxy.