### PR TITLE
Don't use the ToolchainCluster.Spec fields

### DIFF
--- a/setup/users/create_users.go
+++ b/setup/users/create_users.go
@@ -53,13 +53,11 @@ func getMemberClusterName(cl client.Client, hostOperatorNamespace, memberOperato
 	var memberCluster toolchainv1alpha1.ToolchainCluster
 	err := k8swait.Poll(configuration.DefaultRetryInterval, configuration.DefaultTimeout, func() (bool, error) {
 		clusters := &toolchainv1alpha1.ToolchainClusterList{}
-		if err := cl.List(context.TODO(), clusters, client.InNamespace(hostOperatorNamespace), client.MatchingLabels{
-			"namespace": memberOperatorNamespace,
-		}); err != nil {
+		if err := cl.List(context.TODO(), clusters, client.InNamespace(hostOperatorNamespace)); err != nil {
 			return false, err
 		}
 		for _, cluster := range clusters.Items {
-			if condition.IsTrue(cluster.Status.Conditions, toolchainv1alpha1.ConditionReady) {
+			if cluster.Status.OperatorNamespace == memberOperatorNamespace && condition.IsTrue(cluster.Status.Conditions, toolchainv1alpha1.ConditionReady) {
 				memberCluster = cluster
 				return true, nil
 			}

--- a/setup/users/create_users_test.go
+++ b/setup/users/create_users_test.go
@@ -30,11 +30,9 @@ func TestCreate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: hostOperatorNamespace,
 				Name:      "member-abcd",
-				Labels: map[string]string{
-					"namespace": memberOperatorNamespace,
-				},
 			},
 			Status: toolchainv1alpha1.ToolchainClusterStatus{
+				OperatorNamespace: memberOperatorNamespace,
 				Conditions: []toolchainv1alpha1.Condition{
 					{
 						Type:   toolchainv1alpha1.ConditionReady,

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -53,7 +53,6 @@ func TestLandingPageReachable(t *testing.T) {
 }
 
 func TestRegistrationServiceMetricsEndpoint(t *testing.T) {
-
 	// given
 	await := WaitForDeployments(t)
 	t.Parallel()
@@ -108,7 +107,6 @@ func TestRegistrationServiceMetricsEndpoint(t *testing.T) {
 		assert.Contains(t, string(samples), "sandbox_promhttp_request_duration_seconds_sum")
 		assert.Contains(t, string(samples), "sandbox_promhttp_request_duration_seconds_count")
 	})
-
 }
 
 func TestHealth(t *testing.T) {
@@ -463,6 +461,7 @@ func TestSignupOK(t *testing.T) {
 		signupUser(token, emailAddress, identity.Username, identity)
 	})
 }
+
 func TestUserSignupFoundWhenNamedWithEncodedUsername(t *testing.T) {
 	// given
 	t.Parallel()
@@ -960,7 +959,7 @@ func signupIsProvisioned(client *GetSignupClient) {
 	transformedUsername := commonsignup.TransformUsername(client.username, []string{"openshift", "kube", "default", "redhat", "sandbox"}, []string{"admin"})
 	require.NoError(client.t, err)
 	require.True(client.t, found)
-	assert.Equal(client.t, memberCluster.Spec.APIEndpoint, client.responseBody["apiEndpoint"])
+	assert.Equal(client.t, memberCluster.Status.APIEndpoint, client.responseBody["apiEndpoint"])
 	assert.Equal(client.t, hostAwait.APIProxyURL, client.responseBody["proxyURL"])
 	assert.Equal(client.t, fmt.Sprintf("%s-dev", transformedUsername), client.responseBody["defaultUserNamespace"])
 	assertRHODSClusterURL(client.t, memberAwait, client.responseBody)

--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -48,7 +48,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
 			UntilSpaceRequestHasNamespaceAccess(subSpace),
 		)
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
 			UntilSpaceRequestHasNamespaceAccess(subSpace),
 			UntilSpaceRequestHasDisableInheritance(true),
 		)
@@ -165,7 +165,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
 			UntilSpaceRequestHasNamespaceAccess(subSpace))
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
@@ -221,7 +221,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster2.Spec.APIEndpoint),
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster2.Status.APIEndpoint),
 			UntilSpaceRequestHasNamespaceAccess(subSpace))
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait2.Client, spaceRequest) // space request has access to ns on member2
@@ -272,7 +272,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
 		_, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
 			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
 			UntilSpaceRequestHasNamespaceAccess(subSpace),
 			UntilSpaceRequestHasNamespaceAccessWithoutSecretRef(), // check that namespace access is present but without a SecretRef set
 		)
@@ -323,7 +323,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		//then
+		// then
 		// wait for both spaceRequest and subSpace to have same tierName
 		subSpace, err = hostAwait.WaitForSpace(t, subSpace.Name,
 			UntilSpaceHasTier("base"),

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -75,12 +75,9 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 			secretCopy)
 
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
-			apiEndpoint(current.Spec.APIEndpoint),
-			caBundle(current.Spec.CABundle),
 			secretRef(secretCopy.Name),
 			owner(current.Labels["ownerClusterName"]),
 			namespace(current.Labels["namespace"]),
-			disableTLS(current.Spec.DisabledTLSValidations),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
 
@@ -117,12 +114,9 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 			client.ObjectKey{Name: name, Namespace: current.Namespace}, secretCopy, kubeconfig.Modify(t, kubeconfig.ApiEndpoint("https://1.2.3.4:8443")))
 
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
-			apiEndpoint("https://1.2.3.4:8443"),
-			caBundle(current.Spec.CABundle),
 			secretRef(secretCopy.Name),
 			owner(current.Labels["ownerClusterName"]),
 			namespace(current.Labels["namespace"]),
-			disableTLS(current.Spec.DisabledTLSValidations),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
 
@@ -167,8 +161,6 @@ func newToolchainCluster(namespace, name string, options ...clusterOption) *tool
 			SecretRef: toolchainv1alpha1.LocalSecretReference{
 				Name: "", // default
 			},
-			APIEndpoint: "", // default
-			CABundle:    "", // default
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -212,26 +204,5 @@ func secretRef(ref string) clusterOption {
 		c.Spec.SecretRef = toolchainv1alpha1.LocalSecretReference{
 			Name: ref,
 		}
-	}
-}
-
-// APIEndpoint sets the APIEndpoint in the cluster's Spec
-func apiEndpoint(url string) clusterOption {
-	return func(c *toolchainv1alpha1.ToolchainCluster) {
-		c.Spec.APIEndpoint = url
-	}
-}
-
-// CABundle sets the CABundle in the cluster's Spec
-func caBundle(bundle string) clusterOption {
-	return func(c *toolchainv1alpha1.ToolchainCluster) {
-		c.Spec.CABundle = bundle
-	}
-}
-
-// disableTLS sets the DisabledTLSValidations field
-func disableTLS(validations []toolchainv1alpha1.TLSValidation) clusterOption {
-	return func(c *toolchainv1alpha1.ToolchainCluster) {
-		c.Spec.DisabledTLSValidations = validations
 	}
 }

--- a/test/e2e/toolchaincluster_test.go
+++ b/test/e2e/toolchaincluster_test.go
@@ -76,8 +76,6 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			secretRef(secretCopy.Name),
-			owner(current.Labels["ownerClusterName"]),
-			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
 
@@ -115,8 +113,6 @@ func verifyToolchainCluster(t *testing.T, await *wait.Awaitility, otherAwait *wa
 
 		toolchainCluster := newToolchainCluster(await.Namespace, name,
 			secretRef(secretCopy.Name),
-			owner(current.Labels["ownerClusterName"]),
-			namespace(current.Labels["namespace"]),
 			capacityExhausted, // make sure this cluster cannot be used in other e2e tests
 		)
 
@@ -182,20 +178,6 @@ type clusterOption func(*toolchainv1alpha1.ToolchainCluster)
 // capacityExhausted an option to state that the cluster capacity has exhausted
 var capacityExhausted clusterOption = func(c *toolchainv1alpha1.ToolchainCluster) {
 	c.Labels["toolchain.dev.openshift.com/capacity-exhausted"] = strconv.FormatBool(true)
-}
-
-// Owner sets the 'ownerClusterName' label
-func owner(name string) clusterOption {
-	return func(c *toolchainv1alpha1.ToolchainCluster) {
-		c.Labels["ownerClusterName"] = name
-	}
-}
-
-// Namespace sets the 'namespace' label
-func namespace(name string) clusterOption {
-	return func(c *toolchainv1alpha1.ToolchainCluster) {
-		c.Labels["namespace"] = name
-	}
 }
 
 // SecretRef sets the SecretRef in the cluster's Spec

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -147,7 +147,7 @@ func verifyProvisionedSubSpace(t *testing.T, awaitilities wait.Awaitilities) {
 			Namespace: subSpaceNamespace,
 			Name:      migration.ProvisionedSpaceRequest,
 		},
-		wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Spec.APIEndpoint),
+		wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
 		wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
 		wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
 	)

--- a/testsupport/toolchain_status_assertions.go
+++ b/testsupport/toolchain_status_assertions.go
@@ -24,7 +24,7 @@ func VerifyToolchainStatus(t *testing.T, hostAwait *wait.HostAwaitility, memberA
 	require.True(t, found)
 	_, err = hostAwait.WaitForToolchainStatus(t, wait.UntilToolchainStatusHasConditions(wait.ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
 		wait.UntilAllMembersHaveUsageSet(),
-		wait.UntilAllMembersHaveAPIEndpoint(memberCluster.Spec.APIEndpoint),
+		wait.UntilAllMembersHaveAPIEndpoint(memberCluster.Status.APIEndpoint),
 		wait.UntilProxyURLIsPresent(hostAwait.APIProxyURL))
 	require.NoError(t, err, "failed while waiting for ToolchainStatus")
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1416,7 +1416,7 @@ func UntilAllMembersHaveUsageSet() ToolchainStatusWaitCriterion {
 func UntilAllMembersHaveAPIEndpoint(apiEndpoint string) ToolchainStatusWaitCriterion {
 	return ToolchainStatusWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.ToolchainStatus) bool {
-			//Since all member operators currently run in the same cluster in the e2e test environment, then using the same memberCluster.Spec.APIEndpoint for all the member clusters should be fine.
+			// Since all member operators currently run in the same cluster in the e2e test environment, then using the same api endpoint for all the member clusters should be fine.
 			for _, member := range actual.Status.Members {
 				// check Member field ApiEndpoint is assigned
 				if member.APIEndpoint != apiEndpoint {


### PR DESCRIPTION
Instead, use their replacements in the ToolchainCluster status. This will enable us to remove the fields from the spec and only rely on the kubeconfig (and the status fields that project the values out of the kubeconfig).