### PR TITLE
test: SANDBOX-814 align replica count in registration-service

### DIFF
--- a/deploy/host-operator/e2e-tests/toolchainconfig.yaml
+++ b/deploy/host-operator/e2e-tests/toolchainconfig.yaml
@@ -15,7 +15,8 @@ spec:
           segmentWriteKey: 'test devspaces segment write key'
         segmentWriteKey: 'test sandbox segment write key'
       environment: 'e2e-tests'
-      replicas: 2
+      # same number that is set in https://github.com/codeready-toolchain/host-operator/blob/master/deploy/registration-service/registration-service.yaml#L272-L273
+      replicas: 3
       verification:
         enabled: true
         excludedEmailDomains: 'redhat.com,acme.com'

--- a/test/e2e/toolchain_config_test.go
+++ b/test/e2e/toolchain_config_test.go
@@ -1,0 +1,31 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestToolchainConfig(t *testing.T) {
+	awaitilities := testsupport.WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
+
+	t.Run("update replica count for registration-service", func(t *testing.T) {
+		// get current replica count in registration-service
+		registrationServiceName := "registration-service"
+		rs := &appsv1.Deployment{}
+		err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{Namespace: hostAwait.Namespace, Name: registrationServiceName}, rs)
+		require.NoError(t, err)
+		currentNrReplicas := *rs.Spec.Replicas
+
+		// update replica count in registration-service
+		newNrReplicas := currentNrReplicas + 1
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Replicas(newNrReplicas))
+		hostAwait.WaitForDeploymentToGetReady(t, registrationServiceName, int(newNrReplicas))
+	})
+}

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -82,7 +82,7 @@ func waitForOperators(t *testing.T) {
 	initHostAwait.WaitForDeploymentToGetReady(t, "host-operator-controller-manager", 1)
 
 	// wait for registration service to be ready
-	initHostAwait.WaitForDeploymentToGetReady(t, "registration-service", 2)
+	initHostAwait.WaitForDeploymentToGetReady(t, "registration-service", 3)
 
 	// set registration service values
 	registrationServiceRoute, err := initHostAwait.WaitForRouteToBeAvailable(t, registrationServiceNs, "registration-service", "/")


### PR DESCRIPTION
# Description
Currently, running `make e2e-tests` deploys registration-service with 2 replicas, while `make dev-deploy-e2e` deploys it with 3 replicas. So, this PR aligns replica count in registration-service within the e2e and dev environment and adds a test to ensure that we can update the replica count trough ToolchainConfig.


## Issue ticket number and link
[SANDBOX-814](https://issues.redhat.com/browse/SANDBOX-814)