### PR TITLE
test: SANDBOX-816 refactor WaitForDeployments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ NOTE: you can disable SSL/TLS certificate verification in tests setting the `DIS
 
 NOTE: you can specify a regular expression to selectively run particular test cases by setting the `TESTS_RUN_FILTER_REGEXP` variable. eg.: `make test-e2e TESTS_RUN_FILTER_REGEXP="TestSetupMigration"`. For more information see the https://pkg.go.dev/cmd/go#hdr-Testing_flags[go test -run documentation].
 
-NOTE: you should not override `SECOND_MEMBER_MODE` in test-e2e, since the e2e tests require a second member operator.
+NOTE: you should not override `SECOND_MEMBER_MODE` in test-e2e, since the some e2e tests require a second member operator.
 
 === Running/Debugging e2e tests from your IDE
 
@@ -99,6 +99,7 @@ import (
 
 func TestCreateSpaceRequest(t *testing.T) {
 	os.Setenv("MEMBER_NS","toolchain-member-18161051")
+	os.Setenv("SECOND_MEMBER_MODE","true")
 	os.Setenv("MEMBER_NS_2","toolchain-member2-18161051")
 	os.Setenv("HOST_NS","toolchain-host-18161051")
 	os.Setenv("REGISTRATION_SERVICE_NS","toolchain-host-18161051")

--- a/README.adoc
+++ b/README.adoc
@@ -70,6 +70,8 @@ NOTE: you can disable SSL/TLS certificate verification in tests setting the `DIS
 
 NOTE: you can specify a regular expression to selectively run particular test cases by setting the `TESTS_RUN_FILTER_REGEXP` variable. eg.: `make test-e2e TESTS_RUN_FILTER_REGEXP="TestSetupMigration"`. For more information see the https://pkg.go.dev/cmd/go#hdr-Testing_flags[go test -run documentation].
 
+NOTE: you should not override `SECOND_MEMBER_MODE` in test-e2e, since the e2e tests require a second member operator.
+
 === Running/Debugging e2e tests from your IDE
 
 In order to run/debug tests from your IDE you'll need to export some required env variables, those will be used by the test framework to interact with the operator namespaces and the other toolchain resources in you cluster.
@@ -77,6 +79,8 @@ Following snippet of code should be TEMPORARILY added at the top of the test you
 
 ```
 os.Setenv("MEMBER_NS","toolchain-member-18161051")
+// `SECOND_MEMBER_MODE` should be set to true, since the e2e tests require a second member operator.
+os.Setenv("SECOND_MEMBER_MODE","true")
 os.Setenv("MEMBER_NS_2","toolchain-member2-18161051")
 os.Setenv("HOST_NS","toolchain-host-18161051")
 os.Setenv("REGISTRATION_SERVICE_NS","toolchain-host-18161051")

--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ NOTE: you can disable SSL/TLS certificate verification in tests setting the `DIS
 
 NOTE: you can specify a regular expression to selectively run particular test cases by setting the `TESTS_RUN_FILTER_REGEXP` variable. eg.: `make test-e2e TESTS_RUN_FILTER_REGEXP="TestSetupMigration"`. For more information see the https://pkg.go.dev/cmd/go#hdr-Testing_flags[go test -run documentation].
 
-NOTE: you should not override `SECOND_MEMBER_MODE` in test-e2e, since the some e2e tests require a second member operator.
+NOTE: you should not override `SECOND_MEMBER_MODE` in test-e2e, since the e2e tests require a second member operator.
 
 === Running/Debugging e2e tests from your IDE
 

--- a/README.adoc
+++ b/README.adoc
@@ -153,9 +153,11 @@ All e2e resources (host operator, member operator, registration-service, CRDs, e
 
 * `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.
 
-By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
+NOTE: By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
 
 NOTE: If running in CodeReady Containers `eval $(crc oc-env)` is required.
+
+NOTE: By default, `SECOND_MEMBER_MODE` is set to false.
 
 == How to Test Mailgun/Twilio Notifications in a Dev Environment
 * Get a cluster and setup the following env vars

--- a/make/test.mk
+++ b/make/test.mk
@@ -164,7 +164,7 @@ execute-tests:
 	@echo "Status of ToolchainStatus"
 	-oc get ToolchainStatus -n ${HOST_NS} -o yaml
 	@echo "Starting test $(shell date)"
-	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} go test ${TESTS_TO_EXECUTE} -run ${TESTS_RUN_FILTER_REGEXP} -p 1 -v -timeout=90m -failfast || \
+	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} SECOND_MEMBER_MODE=true go test ${TESTS_TO_EXECUTE} -run ${TESTS_RUN_FILTER_REGEXP} -p 1 -v -timeout=90m -failfast || \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs

--- a/make/test.mk
+++ b/make/test.mk
@@ -164,7 +164,7 @@ execute-tests:
 	@echo "Status of ToolchainStatus"
 	-oc get ToolchainStatus -n ${HOST_NS} -o yaml
 	@echo "Starting test $(shell date)"
-	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} SECOND_MEMBER_MODE=true go test ${TESTS_TO_EXECUTE} -run ${TESTS_RUN_FILTER_REGEXP} -p 1 -v -timeout=90m -failfast || \
+	MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} HOST_NS=${HOST_NS} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} SECOND_MEMBER_MODE=${SECOND_MEMBER_MODE} go test ${TESTS_TO_EXECUTE} -run ${TESTS_RUN_FILTER_REGEXP} -p 1 -v -timeout=90m -failfast || \
 	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} MEMBER_NS_2=${MEMBER_NS_2} REGISTRATION_SERVICE_NS=${REGISTRATION_SERVICE_NS} && exit 1)
 
 .PHONY: print-logs

--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSetupMigration(t *testing.T) {
 	// given
-	awaitilities := WaitForOperators(t)
+	awaitilities := WaitForOperators(t, IsSecondMemberMode(t))
 
 	runner := migration.SetupMigrationRunner{
 		Awaitilities: awaitilities,

--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSetupMigration(t *testing.T) {
 	// given
-	awaitilities := WaitForOperators(t, IsSecondMemberMode(t))
+	awaitilities := WaitForOperators(t)
 
 	runner := migration.SetupMigrationRunner{
 		Awaitilities: awaitilities,

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -44,6 +44,7 @@ const (
 	DefaultTimeout                   = time.Second * 120
 	MemberNsVar                      = "MEMBER_NS"
 	MemberNsVar2                     = "MEMBER_NS_2"
+	SecondMemberModeVar              = "SECOND_MEMBER_MODE"
 	HostNsVar                        = "HOST_NS"
 	RegistrationServiceVar           = "REGISTRATION_SERVICE_NS"
 	ToolchainClusterConditionTimeout = 180 * time.Second


### PR DESCRIPTION
# Description
To reuse the function `WaitForDeployments` in WA E2E tests, we need to refactor `WaitForDeployments` to take into consideration when SECOND_MEMBER_MODE is set to false.


## Issue ticket number and link
[SANDBOX-816](https://issues.redhat.com/browse/SANDBOX-816)