### PR TITLE
add deploy-toolchain-resources-e2e

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -149,9 +149,11 @@ If you are still confused by the different e2e/operator location, execution and 
 
 All e2e resources (host operator, member operator, registration-service, CRDs, etc) can be deployed without running tests:
 
-* `make dev-deploy-e2e-local` - deploys the same resources as `make test-e2e-local` but doesn't run tests.
+* `make dev-deploy-e2e-local` - deploys the same resources as `make test-e2e-local` in dev environment but doesn't run tests.
 
-* `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.
+* `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` in dev environment but doesn't run tests.
+
+* `make deploy-toolchain-resources-e2e` - deploys the same resources as `make test-e2e` but doesn't run tests.
 
 NOTE: By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
 

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -1,8 +1,4 @@
-DEV_MEMBER_NS := toolchain-member-operator
-DEV_MEMBER_NS_2 := toolchain-member2-operator
-DEV_HOST_NS := toolchain-host-operator
 DEV_SSO_NS := toolchain-dev-sso
-DEV_REGISTRATION_SERVICE_NS := $(DEV_HOST_NS)
 DEV_ENVIRONMENT := dev
 
 SHOW_CLEAN_COMMAND="make clean-dev-resources"
@@ -25,12 +21,12 @@ dev-deploy-e2e-two-members: deploy-e2e-to-dev-namespaces-two-members print-reg-s
 
 .PHONY: deploy-e2e-to-dev-namespaces
 deploy-e2e-to-dev-namespaces:
-	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD} DEPLOY_LATEST=${DEPLOY_LATEST}
+	$(MAKE) deploy-e2e MEMBER_NS=${DEFAULT_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEFAULT_HOST_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD} DEPLOY_LATEST=${DEPLOY_LATEST}
 	$(MAKE) setup-dev-sso DEV_SSO=${DEV_SSO}
 
 .PHONY: deploy-e2e-to-dev-namespaces-two-members
 deploy-e2e-to-dev-namespaces-two-members:
-	$(MAKE) deploy-e2e MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e MEMBER_NS=${DEFAULT_MEMBER_NS} MEMBER_NS_2=${DEFAULT_MEMBER_NS_2} HOST_NS=${DEFAULT_HOST_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 	$(MAKE) setup-dev-sso DEV_SSO=${DEV_SSO}
 
 setup-dev-sso:
@@ -46,12 +42,12 @@ dev-deploy-e2e-local-two-members: deploy-e2e-local-to-dev-namespaces-two-members
 
 .PHONY: deploy-e2e-local-to-dev-namespaces
 deploy-e2e-local-to-dev-namespaces:
-	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEFAULT_MEMBER_NS} SECOND_MEMBER_MODE=false HOST_NS=${DEFAULT_HOST_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 	$(MAKE) setup-dev-sso DEV_SSO=${DEV_SSO}
 
 .PHONY: deploy-e2e-local-to-dev-namespaces-two-members
 deploy-e2e-local-to-dev-namespaces-two-members:
-	$(MAKE) deploy-e2e-local MEMBER_NS=${DEV_MEMBER_NS} MEMBER_NS_2=${DEV_MEMBER_NS_2} HOST_NS=${DEV_HOST_NS} REGISTRATION_SERVICE_NS=${DEV_REGISTRATION_SERVICE_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
+	$(MAKE) deploy-e2e-local MEMBER_NS=${DEFAULT_MEMBER_NS} MEMBER_NS_2=${DEFAULT_MEMBER_NS_2} HOST_NS=${DEFAULT_HOST_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS} ENVIRONMENT=${DEV_ENVIRONMENT} E2E_TEST_EXECUTION=false IS_OSD=${IS_OSD}
 	$(MAKE) setup-dev-sso DEV_SSO=${DEV_SSO}
 
 
@@ -61,7 +57,7 @@ print-reg-service-link:
 	@echo "Deployment complete!"
 	@echo "Waiting for the registration-service route being available"
 	@echo -n "."
-	@while [[ -z `oc get routes registration-service -n ${DEV_REGISTRATION_SERVICE_NS} 2>/dev/null || true` ]]; do \
+	@while [[ -z `oc get routes registration-service -n ${DEFAULT_HOST_NS} 2>/dev/null || true` ]]; do \
 		if [[ $${NEXT_WAIT_TIME} -eq 100 ]]; then \
             echo ""; \
             echo "The timeout of waiting for the registration-service route has been reached. Try to run 'make  print-reg-service-link' later or check the deployment logs"; \
@@ -73,7 +69,7 @@ print-reg-service-link:
 	@echo ""
 	@echo "Waiting for the api route (that is used by proxy) being available"
 	@echo -n "."
-	@while [[ -z `oc get routes api -n ${DEV_REGISTRATION_SERVICE_NS} 2>/dev/null || true` ]]; do \
+	@while [[ -z `oc get routes api -n ${DEFAULT_HOST_NS} 2>/dev/null || true` ]]; do \
 		if [[ $${NEXT_WAIT_TIME} -eq 100 ]]; then \
             echo ""; \
             echo "The timeout of waiting for the api route (that is used by proxy) has been reached. Try to run 'make  print-reg-service-link' later or check the deployment logs"; \
@@ -85,8 +81,8 @@ print-reg-service-link:
 	@echo ""
 	@echo ""
 	@echo "==========================================================================================================================================="
-	@echo Access the Landing Page here:   https://$$(oc get routes registration-service -n ${DEV_REGISTRATION_SERVICE_NS} -o=jsonpath='{.spec.host}')
-	@echo Access Proxy here:              https://$$(oc get routes api -n ${DEV_REGISTRATION_SERVICE_NS} -o=jsonpath='{.spec.host}')
+	@echo Access the Landing Page here:   https://$$(oc get routes registration-service -n ${DEFAULT_HOST_NS} -o=jsonpath='{.spec.host}')
+	@echo Access Proxy here:              https://$$(oc get routes api -n ${DEFAULT_HOST_NS} -o=jsonpath='{.spec.host}')
 	@echo "==========================================================================================================================================="
 	@echo ""
 	@echo "To clean the cluster run '${SHOW_CLEAN_COMMAND}'"

--- a/make/test.mk
+++ b/make/test.mk
@@ -267,6 +267,13 @@ setup-toolchainclusters: ksctl
 	echo "Restart host operator pods so it can get the ToolchainCluster CRs while it's starting up".
 	oc delete pods --namespace ${HOST_NS} -l control-plane=controller-manager
 
+E2E_MEMBER_NS := toolchain-member-operator
+E2E_HOST_NS := toolchain-host-operator
+
+.PHONY: deploy-toolchain-resources-e2e
+## Deploy the toolchain resources in e2e environment
+deploy-toolchain-resources-e2e:
+	$(MAKE) prepare-e2e deploy-e2e SECOND_MEMBER_MODE=false HOST_NS=${E2E_HOST_NS} MEMBER_NS=${E2E_MEMBER_NS} REGISTRATION_SERVICE_NS=${E2E_HOST_NS}
 
 ###########################################################
 #

--- a/make/test.mk
+++ b/make/test.mk
@@ -8,6 +8,9 @@ QUAY_NAMESPACE ?= codeready-toolchain-test
 DATE_SUFFIX := $(shell date +'%d%H%M%S')
 HOST_NS ?= toolchain-host-${DATE_SUFFIX}
 MEMBER_NS ?= toolchain-member-${DATE_SUFFIX}
+DEFAULT_HOST_NS= toolchain-host-operator
+DEFAULT_MEMBER_NS= toolchain-member-operator
+DEFAULT_MEMBER_NS_2= toolchain-member2-operator
 # it can be used to customize the install wait timeout parameter for the ksctl adm install-operator
 # for eg. on slow systems you can customize it like so: KSCTL_INSTALL_TIMEOUT_PARAM="--timeout=15m"
 KSCTL_INSTALL_TIMEOUT_PARAM ?= ""
@@ -271,10 +274,14 @@ setup-toolchainclusters: ksctl
 E2E_MEMBER_NS := toolchain-member-operator
 E2E_HOST_NS := toolchain-host-operator
 
-.PHONY: deploy-toolchain-resources-e2e
-## Deploy the toolchain resources in e2e environment
-deploy-toolchain-resources-e2e:
-	$(MAKE) prepare-e2e deploy-e2e SECOND_MEMBER_MODE=false HOST_NS=${E2E_HOST_NS} MEMBER_NS=${E2E_MEMBER_NS} REGISTRATION_SERVICE_NS=${E2E_HOST_NS}
+.PHONY: deploy-single-member-e2e
+## Deploy operators in e2e mode with single member without running tests
+deploy-single-member-e2e: SECOND_MEMBER_MODE=false
+deploy-single-member-e2e: HOST_NS=${DEFAULT_HOST_NS}
+deploy-single-member-e2e: MEMBER_NS=${DEFAULT_MEMBER_NS}
+deploy-single-member-e2e: REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS}
+deploy-single-member-e2e: prepare-e2e deploy-e2e
+
 
 ###########################################################
 #

--- a/make/test.mk
+++ b/make/test.mk
@@ -276,11 +276,8 @@ E2E_HOST_NS := toolchain-host-operator
 
 .PHONY: deploy-single-member-e2e
 ## Deploy operators in e2e mode with single member without running tests
-deploy-single-member-e2e: SECOND_MEMBER_MODE=false
-deploy-single-member-e2e: HOST_NS=${DEFAULT_HOST_NS}
-deploy-single-member-e2e: MEMBER_NS=${DEFAULT_MEMBER_NS}
-deploy-single-member-e2e: REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS}
-deploy-single-member-e2e: prepare-e2e deploy-e2e
+deploy-single-member-e2e: 
+	$(MAKE) prepare-and-deploy-e2e SECOND_MEMBER_MODE=false HOST_NS=${DEFAULT_HOST_NS} MEMBER_NS=${DEFAULT_MEMBER_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS}
 
 
 ###########################################################
@@ -384,7 +381,9 @@ create-member1:
 
 .PHONY: create-member2
 create-member2:
+	@echo SECOND_MEMBER_MODE=$(SECOND_MEMBER_MODE) 
 ifeq ($(SECOND_MEMBER_MODE),true)
+	@echo SECOND_MEMBER_MODE inside=$(SECOND_MEMBER_MODE) 
 	@echo "Preparing namespace for second member operator: ${MEMBER_NS_2}..."
 	$(MAKE) create-project PROJECT_NAME=${MEMBER_NS_2}
 	-oc label ns --overwrite=true ${MEMBER_NS_2} app=member-operator


### PR DESCRIPTION
# Description
- add `deploy-toolchain-resources-e2e` to deploy the same resources as `make test-e2e` but doesn't run tests. It will be useful for wa


## Issue ticket number and link
[SANDBOX-811](https://issues.redhat.com/browse/SANDBOX-811)