### PR TITLE
Reinstate webhook tests

### DIFF
--- a/test/migration/setup/setup_migration_test.go
+++ b/test/migration/setup/setup_migration_test.go
@@ -9,10 +9,6 @@ import (
 
 func TestSetupMigration(t *testing.T) {
 	// given
-	// set env var to skip the mutating webhook check on migration setup temporarily since the old deployment
-	// will deploy the webhooks with the old configuration but the tests will be expecting the new configuration
-	// This should be removed after PR https://github.com/codeready-toolchain/toolchain-e2e/pull/809 is merged
-	t.Setenv("skip-webhook-checks-on-setup", "true")
 	awaitilities := WaitForOperators(t)
 
 	runner := migration.SetupMigrationRunner{

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -2296,11 +2295,6 @@ func (a *MemberAwaitility) verifySecret(t *testing.T) []byte {
 }
 
 func (a *MemberAwaitility) verifyMutatingWebhookConfig(t *testing.T, ca []byte) {
-	if val := os.Getenv("skip-webhook-checks-on-setup"); val == "true" {
-		// skipped temporarily only for setup migration test but applies for after migration test
-		// This should be removed after PR https://github.com/codeready-toolchain/toolchain-e2e/pull/1070 is merged
-		return
-	}
 	t.Logf("checking MutatingWebhookConfiguration")
 	actualMutWbhConf := &admv1.MutatingWebhookConfiguration{}
 	a.waitForResource(t, "", "member-operator-webhook-"+a.Namespace, actualMutWbhConf)
@@ -2380,11 +2374,6 @@ func (a *MemberAwaitility) verifyMutatingWebhookConfig(t *testing.T, ca []byte) 
 }
 
 func (a *MemberAwaitility) verifyValidatingWebhookConfig(t *testing.T, ca []byte) {
-	if val := os.Getenv("skip-webhook-checks-on-setup"); val == "true" {
-		// skipped temporarily only for setup migration test but applies for after migration test
-		// This should be removed after PR https://github.com/codeready-toolchain/toolchain-e2e/pull/1070 is merged
-		return
-	}
 	t.Logf("checking ValidatingWebhookConfiguration '%s'", "member-operator-validating-webhook"+a.Namespace)
 	actualValWbhConf := &admv1.ValidatingWebhookConfiguration{}
 	a.waitForResource(t, "", "member-operator-validating-webhook-"+a.Namespace, actualValWbhConf)


### PR DESCRIPTION
It's the follow up to https://github.com/codeready-toolchain/toolchain-e2e/pull/1070 to re-enable the webhook tests