### PR TITLE
proof of concept of the more type-safe way of defining the predicates.

### DIFF
--- a/testsupport/predicates/conditions/conditions.go
+++ b/testsupport/predicates/conditions/conditions.go
@@ -1,0 +1,107 @@
+package conditions
+
+import (
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Predicates are all the predicates that can be defined on any object that has
+// conditions.
+type Predicates[Self any, T client.Object] interface {
+	HasConditionWithType(typ v1alpha1.ConditionType, preds ...predicates.Predicate[v1alpha1.Condition]) Self
+}
+
+// WithStatus checks that a condition has the provided status
+func WithStatus(status corev1.ConditionStatus) predicates.Predicate[v1alpha1.Condition] {
+	return &withStatus{status: status}
+}
+
+// ConditionPredicates is a struct implementing the Predicates interface in this package.
+// It is meant to be embedded into other types implementing the predicate collectors for
+// concrete CRDs.
+type ConditionPredicates[Self any, T client.Object] struct {
+	predicates.EmbedablePredicates[Self, T]
+
+	// Accessor is a function that translates from the object to its conditions.
+	// It returns a pointer to the slice so that the slice can also be initialized
+	// when it is nil and append works even if it re-allocates the array.
+	accessor func(T) *[]v1alpha1.Condition
+}
+
+func (p *ConditionPredicates[Self, T]) HasConditionWithType(typ v1alpha1.ConditionType, predicates ...predicates.Predicate[v1alpha1.Condition]) Self {
+	*p.Preds = append(*p.Preds, &testConditionPred[T]{accessor: p.accessor, typ: typ, preds: predicates})
+	return p.Self
+}
+
+// EmbedInto is a specialized version of the embedding function that sets up the self and predicates but also
+// sets the accessor function that translates from an object of type T into its list of conditions.
+func (p *ConditionPredicates[Self, T]) EmbedInto(self Self, predicates *[]predicates.Predicate[T], accessor func(T) *[]v1alpha1.Condition) {
+	p.EmbedablePredicates.EmbedInto(self, predicates)
+	p.accessor = accessor
+}
+
+type testConditionPred[T client.Object] struct {
+	accessor func(T) *[]v1alpha1.Condition
+	typ      v1alpha1.ConditionType
+	preds    []predicates.Predicate[v1alpha1.Condition]
+}
+
+func (p *testConditionPred[T]) Matches(obj T) (bool, error) {
+	conds := p.accessor(obj)
+	cond, ok := condition.FindConditionByType(*conds, p.typ)
+	if !ok {
+		return false, nil
+	}
+
+	for _, pred := range p.preds {
+		ok, err := pred.Matches(cond)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (p *testConditionPred[T]) FixToMatch(obj T) (T, error) {
+	copy := obj.DeepCopyObject().(T)
+	conds := p.accessor(copy)
+	cond, ok := condition.FindConditionByType(*conds, p.typ)
+	if !ok {
+		return obj, nil
+	}
+
+	for _, pred := range p.preds {
+		if pred, ok := pred.(predicates.PredicateMatchFixer[v1alpha1.Condition]); ok {
+			var err error
+			cond, err = pred.FixToMatch(cond)
+			if err != nil {
+				return obj, err
+			}
+		}
+	}
+
+	*conds, _ = condition.AddOrUpdateStatusConditions(*conds, cond)
+
+	return copy, nil
+}
+
+type withStatus struct {
+	status corev1.ConditionStatus
+}
+
+func (p *withStatus) Matches(cond v1alpha1.Condition) (bool, error) {
+	return cond.Status == p.status, nil
+}
+
+func (p *withStatus) FixToMatch(cond v1alpha1.Condition) (v1alpha1.Condition, error) {
+	// cond is passed by value and is not a pointer so no need to copy
+	cond.Status = p.status
+	return cond, nil
+}

--- a/testsupport/predicates/object/object.go
+++ b/testsupport/predicates/object/object.go
@@ -1,0 +1,69 @@
+package object
+
+import (
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates"
+	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Predicates defines all the predicates that can be applied to any Object.
+type Predicates[Self any, T client.Object] interface {
+	HasName(name string) Self
+	HasFinalizer(finalizerName string) Self
+}
+
+// ObjectPredicates implements the Predicates interface in this package.
+// It is not meant to be used directly but rather embedded into other structs that define
+// the predicates for individual CRDs.
+type ObjectPredicates[Self any, T client.Object] struct {
+	predicates.EmbedablePredicates[Self, T]
+}
+
+func (p *ObjectPredicates[Self, T]) HasName(name string) Self {
+	*p.Preds = append(*p.Preds, &namePredicate[T]{name: name})
+	return p.Self
+}
+
+func (p *ObjectPredicates[Self, T]) HasFinalizer(finalizerName string) Self {
+	*p.Preds = append(*p.Preds, &finalizerPredicate[T]{finalizer: finalizerName})
+	return p.Self
+}
+
+var (
+	_ predicates.Predicate[client.Object]           = (*namePredicate[client.Object])(nil)
+	_ predicates.PredicateMatchFixer[client.Object] = (*namePredicate[client.Object])(nil)
+	_ predicates.Predicate[client.Object]           = (*finalizerPredicate[client.Object])(nil)
+	_ predicates.PredicateMatchFixer[client.Object] = (*finalizerPredicate[client.Object])(nil)
+)
+
+type namePredicate[T client.Object] struct {
+	name string
+}
+
+func (p *namePredicate[T]) Matches(obj T) (bool, error) {
+	return p.name == obj.GetName(), nil
+}
+
+func (p *namePredicate[T]) FixToMatch(obj T) (T, error) {
+	obj = obj.DeepCopyObject().(T)
+	obj.SetName(p.name)
+	return obj, nil
+}
+
+type finalizerPredicate[T client.Object] struct {
+	finalizer string
+}
+
+func (p *finalizerPredicate[T]) Matches(obj T) (bool, error) {
+	return slices.Contains(obj.GetFinalizers(), p.finalizer), nil
+}
+
+func (p *finalizerPredicate[T]) FixToMatch(obj T) (T, error) {
+	obj = obj.DeepCopyObject().(T)
+	fs := obj.GetFinalizers()
+	if !slices.Contains(fs, p.finalizer) {
+		fs = append(fs, p.finalizer)
+	}
+	obj.SetFinalizers(fs)
+	return obj, nil
+}

--- a/testsupport/predicates/predicate.go
+++ b/testsupport/predicates/predicate.go
@@ -1,0 +1,43 @@
+package predicates
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Predicate tests if an instance of some type matches it. It is fallible so that
+// we can do weird stuff like pinging the route endpoints and not have to be weird
+// about error handling in such predicates.
+type Predicate[T any] interface {
+	Matches(T) (bool, error)
+}
+
+type PredicateMatchFixer[T any] interface {
+	// FixToMatch repares the provided object to match the predicate. It needs to return
+	// a copy of the provided object so care needs to be taken if working with slices or
+	// pointers.
+	FixToMatch(T) (T, error)
+}
+
+func Explain[T any](obj T, predicate Predicate[T]) (string, error) {
+	predicateType := reflect.TypeOf(predicate)
+	if predicateType.Kind() == reflect.Pointer {
+		predicateType = predicateType.Elem()
+	}
+
+	prefix := fmt.Sprintf("predicate '%s' didn't match the object", predicateType.String())
+	fix, ok := predicate.(PredicateMatchFixer[T])
+	if !ok {
+		return prefix, nil
+	}
+
+	expected, err := fix.FixToMatch(obj)
+	if err != nil {
+		return prefix, err
+	}
+	diff := cmp.Diff(expected, obj)
+
+	return fmt.Sprintf("%s because of the following differences (- indicates the expected values, + the actual values):\n%s", prefix, diff), nil
+}

--- a/testsupport/predicates/predicatecollector.go
+++ b/testsupport/predicates/predicatecollector.go
@@ -1,0 +1,42 @@
+package predicates
+
+// PredicateCollector is a helper to Waiter struct and its methods, to which it can supply
+// a list of predicates to check. An implementation of the PredicateCollector interface
+// dictates what kind of predicates can be applied. Therefore, a predicate collector implementation
+// is expected to exist for each CRD.
+type PredicateCollector[T any] interface {
+	Predicates() []Predicate[T]
+}
+
+// EmbedablePredicates is meant to be embedded into other structs actually offering some
+// predicates for some type of object. It provides the storage for the predicates and also a
+// "self-reference" that can be used to return right type of the top level struct when calling
+// predicate methods of embedded collectors.
+//
+// See how this is used in ObjectPredicates and ConditionPredicates which are
+// meant to be embedded and SpaceProvisionerConfigPredicates which embeds these two in it.
+type EmbedablePredicates[Self any, T any] struct {
+	// Self is a typed reference to this instance used to return the correct type from methods
+	// of structs embedded in each other.
+	//
+	// THIS IS ONLY MADE PUBLIC SO THAT IT CAN BE ACCESSED FROM OTHER PACKAGES. DO NOT SET
+	// THIS FIELD - USE THE EmbedInto() METHOD.
+	Self Self
+
+	// Preds is the list predicates.
+	// It returns a pointer to the slice so that the slice can also be initialized
+	// when it is nil and append works even if it re-allocates the array.
+	//
+	// THIS IS ONLY MADE PUBLIC SO THAT IT CAN BE ACCESSED FROM OTHER PACKAGES. DO NOT SET
+	// THIS FIELD - USE THE EmbedInto() METHOD.
+	Preds *[]Predicate[T]
+}
+
+// EmbedInto is a helper function meant to be called by the constructor functions
+// to "weave" the pointers to the actual instance that should be used as return type
+// of the various predicate functions and the list of predicates that should be common
+// to all embedded structs.
+func (pc *EmbedablePredicates[Self, T]) EmbedInto(self Self, predicates *[]Predicate[T]) {
+	pc.Self = self
+	pc.Preds = predicates
+}

--- a/testsupport/predicates/spaceprovisionerconfig/spc.go
+++ b/testsupport/predicates/spaceprovisionerconfig/spc.go
@@ -1,0 +1,78 @@
+package spaceprovisionerconfig
+
+import (
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates/conditions"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates/object"
+)
+
+// That is a "constructor" function to instantiate and initialize an instance of
+// SpaceProvisionerConfigPredicates interface.
+//
+// The name is a bit "funny" but will read nicely when used:
+//
+// spaceprovisionerconfig.That().HasName("asdf").ReferencesToolchainCluster("asdf")...
+func That() SpaceProvisionerConfigPredicates {
+	ret := &collector{}
+	ret.ObjectPredicates.EmbedInto(ret, &ret.preds)
+	ret.ConditionPredicates.EmbedInto(ret, &ret.preds,
+		func(spc *v1alpha1.SpaceProvisionerConfig) *[]v1alpha1.Condition {
+			return &spc.Status.Conditions
+		})
+	return ret
+}
+
+// SpaceProvisionerConfigPredicates is an interface defining all the predicates
+// that can be applied on SpaceProvisionerConfig objects.
+type SpaceProvisionerConfigPredicates interface {
+	// This is the actual "top-level" predicate collector, so we need to make sure we implement that interface
+	predicates.PredicateCollector[*v1alpha1.SpaceProvisionerConfig]
+
+	// SpaceProvisionerConfigs are CRDs so we can embed the generic object predicates
+	object.Predicates[SpaceProvisionerConfigPredicates, *v1alpha1.SpaceProvisionerConfig]
+
+	// SpaceProvisionerConfigs use conditions in their status so we can embed the generic condition predicates
+	conditions.Predicates[SpaceProvisionerConfigPredicates, *v1alpha1.SpaceProvisionerConfig]
+
+	// These predicates are specific to SPCs
+
+	ReferencesToolchainCluster(tc string) SpaceProvisionerConfigPredicates
+}
+
+// collector is a private impl of the SpaceProvisionerConfigPredicates interface. This is so
+// that we force the use of the That function in this package that correctly wires stuff up.
+type collector struct {
+	// embed in the impl of the object predicates
+	object.ObjectPredicates[SpaceProvisionerConfigPredicates, *v1alpha1.SpaceProvisionerConfig]
+
+	// embed the impl of the condition predicates
+	conditions.ConditionPredicates[SpaceProvisionerConfigPredicates, *v1alpha1.SpaceProvisionerConfig]
+
+	// this is where all the predicates will be collected so that we can implement the predicate collector
+	// interface
+	preds []predicates.Predicate[*v1alpha1.SpaceProvisionerConfig]
+}
+
+func (p *collector) ReferencesToolchainCluster(tc string) SpaceProvisionerConfigPredicates {
+	p.preds = append(p.preds, &referencesToolchainCluster{tc: tc})
+	return p
+}
+
+func (p *collector) Predicates() []predicates.Predicate[*v1alpha1.SpaceProvisionerConfig] {
+	return p.preds
+}
+
+type referencesToolchainCluster struct {
+	tc string
+}
+
+func (p *referencesToolchainCluster) Matches(spc *v1alpha1.SpaceProvisionerConfig) (bool, error) {
+	return spc.Spec.ToolchainCluster == p.tc, nil
+}
+
+func (p *referencesToolchainCluster) FixToMatch(spc *v1alpha1.SpaceProvisionerConfig) (*v1alpha1.SpaceProvisionerConfig, error) {
+	copy := spc.DeepCopy()
+	copy.Spec.ToolchainCluster = p.tc
+	return copy, nil
+}

--- a/testsupport/predicates/spaceprovisionerconfig/spc_test.go
+++ b/testsupport/predicates/spaceprovisionerconfig/spc_test.go
@@ -1,0 +1,59 @@
+package spaceprovisionerconfig
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/predicates/conditions"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestThat(t *testing.T) {
+	test := That().
+		HasName("expected").
+		HasConditionWithType(v1alpha1.ConditionReady, conditions.WithStatus(corev1.ConditionTrue)).
+		ReferencesToolchainCluster("cluster-1").
+		HasFinalizer("fin")
+
+	preds := test.Predicates()
+	assert.Len(t, preds, 4)
+
+	spc := &v1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "actual",
+		},
+		Spec: v1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster-2",
+		},
+		Status: v1alpha1.SpaceProvisionerConfigStatus{
+			Conditions: []v1alpha1.Condition{
+				{
+					Type:   v1alpha1.ConditionReady,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	// not actual tests here... This is just to visually inspect the test output
+	// to check that the diff actually works in Explain... This should of course
+	// be properly tested if we go with this approach.
+
+	expl, _ := predicates.Explain(spc, preds[0])
+	assert.Equal(t, "this is not the actual output", expl)
+
+	expl, _ = predicates.Explain(spc, preds[1])
+	assert.Equal(t, "this is not the actual output", expl)
+
+	expl, _ = predicates.Explain(spc, preds[2])
+	assert.Equal(t, "this is not the actual output", expl)
+
+	expl, _ = predicates.Explain(spc, preds[1])
+	assert.Equal(t, "this is not the actual output", expl)
+
+	expl, _ = predicates.Explain(spc, preds[3])
+	assert.Equal(t, "this is not the actual output", expl)
+}

--- a/testsupport/predicates/wait.go
+++ b/testsupport/predicates/wait.go
@@ -1,0 +1,28 @@
+package predicates
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitFor[T client.Object](t *testing.T, cl client.Client) *Waiter[T] {
+	return &Waiter[T]{cl: cl}
+}
+
+type Waiter[T client.Object] struct {
+	cl client.Client
+}
+
+func (w *Waiter[T]) First(preds PredicateCollector[T]) (T, error) {
+	_ = preds.Predicates()
+
+	// once we have the list of predicates, the implemetation of this method will be very
+	// similar to what is already present in the wait package.
+	// Or rather, we will change the impl in the wait package to accept the PredicateCollector[T].
+
+	// using this will read as:
+	//
+	// wait.WaitFor[*toolchainv1alpha1.SpaceProvisonerConfig](t, cl).First(spaceprovisionerconfig.That().HasName(...)...)
+	panic("not implemented")
+}


### PR DESCRIPTION
We were recently discussing the state of our assertions across the codebase and came to a couple of conclusions:

* we want to try out a common way of using `wait.For` et al. for all our assertions. This means replacing the large number of ad-hoc assertions in `Awaitility` class as well as a number of `*Criterion` structs. We hope this will consolidate the different kinds of reporting employed in various places, will simplify the codebase and reduce code duplication.
* we want to limit our scope to just `toolchain-e2e` (at least for now). We use the predicates and various utility methods the most in here so it converging them will bring the biggest benefits.

### The problem with the current approach

In this PR I'm trying out a slightly different approach to composing the list of predicates to be used for the test in `wait.For`.

The main problem I'm trying to solve here is the loss of type safety that we currently suffer when using 

```go
wait.For(...).WithNameThat(..., predicates Predicates[client.Object])
```

This method accepts predicates on any `client.Object` regardless of the type it actually tests. This can lead to subtle bugs in the tests that ideally the compiler would have caught were the method signature more typesafe. The reason for this is the limited type-inference the go compiler is trying to make.

We define a couple of generic predicates like 

```go
func Labels(map[string]string) Predicate[client.Object]
```

that checks for the presence of certain labels on an object. This by definition can be done on any `client.Object`. The reason for the predicate constructor function to look like above and NOT like:

```go
func Labels[T client.Object](map[string]string) Predicate[T]
```

is that if we wanted to use such predicate constructor function, we would need to explicitly name the `T` on every use-site - its type would not be inferred. E.g.:

```go
wait.For(..., &corev1.ConfigMap{}).FirstThat(Labels[*corev1.ConfigMap](map[string]string{"key": "value"}))
```

Not nice. The solution that currently exists in the codebase is to use "type erasing" function:

```go
func Has[T client.Object](p Predicate[T]) Predicate[client.Object])
```

so that the above call would read:

```go
wait.For(..., &corev1.ConfigMap{}).FirstThat(Has(Labels(map[string]string{"key": "value"}))
```
Nicer, but at the cost of lost type safety.

### The proposed solution

The proposed solution takes inspiration in the `*Assertion` classes that we use in the unit tests that basically compile together all the predicates that can be asserted on given object. 

Such assertion types as they exist in the codebase test eagerly - the test is performed as soon as the method testing an individual condition is invoked on the assertion object. This is insufficient in the case of `wait.For` because that method needs to be able to execute these tests repeatedly. Therefore we'd need to either pass in a function that would contain all the tests or we need to pass a list of predicates that the `wait.For` could repeatedly invoke. The proposed approach uses the latter. The advantage of having a list of predicates instead of a more or less opaque function is that we can use the predicates to produce the diff output and more fine-grained error reporting generically.

The invocation of `wait.For` is changed to look like in this hypothetical example:

```go
wait.For[*corev1.ConfigMap](...).FirstThat(NewConfigMapPredicates().HasLabel("key", "value").HasData("config_key", "config value"))
```

i.e. in a signature-like notation it would be:

```go
wait.For[T any](...).FirstThat[T](PredicateCollector[T])
```

Notice that the `NewConfigMapPredicates()` function returns "something" that has both the `HasLabel`, which ideally should be defined just once and reused in appropriate `*Predicates` and `HasData` which tests for the presence of a key in config map's `data`.

So hypothetically we could do this:

```go

type ObjectPredicates struct {
  ...
}

func (p *ObjectPredicates) HasLabel(key, value string) ObjectPredicates {
   ...
}

func (p *ObjectPredicates) GetPredicates() []Predicate[client.Object] {
   ...
}

type ConfigMapPredicates struct {
   ObjectPredicates
}
   
func (p *ConfigMapPredicates) HasData(key, value string) ConfigMapPredicates {
   ...
}

func (p *ConfigMapPredicates) GetPredicates() []Predicate[*corev1.ConfigMap] {
   ... // hmmm, how to even join the object predicates and config map predicates?
}
```

Obviously, there's a couple of problems there. 

First, there's the problem of actually presuading Go that it is safe to put the object predicates (which would have type `[]Predicate[client.Object]`) and configmap predicates (with type `[]Predicate[*corev1.ConfigMap]`) into one slice that could then be used in `wait.For`. We'd probably have to resort to "type erasure" again.

Not nice.

One would also have to be very peculiar about the order in which one composes the "chain" of the `Has*()` methods on the `ConfigMapPredicates`.

One could:

```go
ps := &ConfigMapPredicates{}
ps.HasData("a", "b").HasLabel("k", "v")
```

but this would NOT work:
```go
ps := &ConfigMapPredicates{}
ps.HasLabel("k", "v").HasData("a", "b")
```

Not intuitive and not nice.

So, let's go down the rabbit hole like this:

```go
type ObjectPredicates[Self any, T client.Object] struct {
   ...
}

func (p *ObjectPredicates[Self, T]) HasLabel(key, value string) Self {
   ...
}

func (p *ObjectPredicates[Self, T]) GetPredicates() []Predicate[T] {
   ...
}

type ConfigMapPredicates struct {
   ObjectPredicates[ConfigMapPredicates, *corev1.ConfigMap]
}

func (p *ConfigMapPredicates) HasData(key, value string) ConfigMapPredicates {
   ...
}

func (p *ConfigMapPredicates) GetPredicates() []Predicate[*corev1.ConfigMap] {
  return slices.Concat(p.ObjectPredicates.GetPredicates(), p.predicates)
}
```

Ok, much nicer. We get compose the "inherited" predicates with our own predicates in `ConfigMapPredicates.GetPredicates()` method, because they now have the same type (`[]Predicates[*corev1.ConfigMap]`).

We can also put the methods in the "chain" in any order we like:
```go
preds.HasData("a", "b").HasLabel("k", "v") // works as before
preds.HasLabel("k", "v").HasData("a", "b") // works now, too!
```

Noice. But where's the catch?

We can no longer just use the default value of `ConfigMapPredicates`.

```go
preds := &ConfigMapPredicates{}
preds.HasLabel("k", "v") // returns nil, because we have no way of knowing the value of "Self"
```

Not nice. So what if we tried to "hide" the `ConfigMapPredicates` struct behind an interface and used a "constructor function" for it that would wire stuff up? yeah, that could work:

```go
type ObjectPredicates[Self any] interface {
  HasLabel(key, value string) Self
}

type EmbedableObjectPredicates[Self any, T client.Object] struct {
   Self Self
}

// EmbedableObjectPredicates implements the ObjectPredicates interface

type ConfigMapPredicates interface {
  ObjectPredicates[ConfigMapPredicates]
  
  HasData(key, value string) ConfigMapPredicates
}

type configMapPredicates struct {
   EmbedableObjectPredicates[ConfigMapPredicates, *corev1.ConfigMap]
}

// configMapPredicates implements ConfigMapPredicates interface

func NewConfigMapPredicates() ConfigMapPredicates {
   preds := &configMapPredicates{}
   preds.Self = preds

   return preds
}

```

... and we're done. Everything kinda works.

That's the gist of the implementation in this PR. It only refines the above approach a bit further so that the predicates don't have to be copied, etc, but is very similar to the above.

We achieved type-safety of the callers, because we can ensure at compile time that we only use compatible predicates on compatible types. We also achieved code reuse because the more generic predicates can be defined only once and can be embedded into the more concrete predicates.

The code in the PR is just a proof of concept. It is not wired up to the rest of the codebase and is all contained in the new `testsupport/predicates` package.

Take a look at `testsupport/predicates/spaceprovisionerconfig/spc_test.go` that contains the test of the chaining and the test of the `Explain` function that (as is the case in our current codebase) can take a predicate and a value and produce a diff between the object and what it should have looked like to match the predicate.

In `testsupport/predicates/wait.go` there is a stub of what could `wait.For` look like if we adopt this approach.