### PR TITLE
SANDBOX-838: loop update calls

### DIFF
--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -83,7 +83,7 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 
 	t.Run("user and identity stay there when user is deactivated", func(t *testing.T) {
 		// when
-		userSignup, err := hostAwait.UpdateUserSignup(t, signup.Name,
+		userSignup, err := hostAwait.UpdateUserSignup(t, false, signup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(us, true)
 			})

--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -83,10 +83,11 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 
 	t.Run("user and identity stay there when user is deactivated", func(t *testing.T) {
 		// when
-		userSignup, err := hostAwait.UpdateUserSignup(t, false, signup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(us, true)
-			})
+		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(signup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(us, true)
+				})
 		require.NoError(t, err)
 
 		// Wait until the UserSignup is deactivated

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -160,9 +160,10 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// when
-			_, err = memberAwait.UpdateUser(t, user.Name, func(u *userv1.User) {
-				u.Identities = []string{}
-			})
+			_, err = wait.For(t, memberAwait.Awaitility, &userv1.User{}).
+				Update(user.Name, func(u *userv1.User) {
+					u.Identities = []string{}
+				})
 
 			// then
 			require.NoError(t, err)
@@ -178,9 +179,10 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// when
-			_, err = memberAwait.UpdateIdentity(t, identity.Name, func(i *userv1.Identity) {
-				i.User = corev1.ObjectReference{Name: "", UID: ""}
-			})
+			_, err = wait.For(t, memberAwait.Awaitility, &userv1.Identity{}).
+				Update(identity.Name, func(i *userv1.Identity) {
+					i.User = corev1.ObjectReference{Name: "", UID: ""}
+				})
 
 			// then
 			require.NoError(t, err)
@@ -485,10 +487,11 @@ func TestE2EFlow(t *testing.T) {
 		require.Len(t, userList.Items, 1)
 
 		// Now deactivate the UserSignup
-		userSignup, err := hostAwait.UpdateUserSignup(t, false, originalSubJohnSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(us, true)
-			})
+		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(originalSubJohnSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(us, true)
+				})
 		require.NoError(t, err)
 
 		// Wait until the UserSignup is deactivated

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -160,8 +160,9 @@ func TestE2EFlow(t *testing.T) {
 			require.NoError(t, err)
 
 			// when
-			user.Identities = []string{}
-			err = memberAwait.Client.Update(context.TODO(), user)
+			_, err = memberAwait.UpdateUser(t, user.Name, func(u *userv1.User) {
+				u.Identities = []string{}
+			})
 
 			// then
 			require.NoError(t, err)
@@ -175,10 +176,11 @@ func TestE2EFlow(t *testing.T) {
 			err := memberAwait.Client.Get(context.TODO(), types.NamespacedName{Name: identitypkg.NewIdentityNamingStandard(
 				johnSignup.Spec.IdentityClaims.Sub, "rhd").IdentityName()}, identity)
 			require.NoError(t, err)
-			identity.User = corev1.ObjectReference{Name: "", UID: ""}
 
 			// when
-			err = memberAwait.Client.Update(context.TODO(), identity)
+			_, err = memberAwait.UpdateIdentity(t, identity.Name, func(i *userv1.Identity) {
+				i.User = corev1.ObjectReference{Name: "", UID: ""}
+			})
 
 			// then
 			require.NoError(t, err)
@@ -483,7 +485,7 @@ func TestE2EFlow(t *testing.T) {
 		require.Len(t, userList.Items, 1)
 
 		// Now deactivate the UserSignup
-		userSignup, err := hostAwait.UpdateUserSignup(t, originalSubJohnSignup.Name,
+		userSignup, err := hostAwait.UpdateUserSignup(t, false, originalSubJohnSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(us, true)
 			})

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -169,7 +169,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
 		// Set the deactivating state on the UserSignup
-		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, user.UserSignup.Name,
+		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, false, user.UserSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivating(us, true)
 			})

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -169,10 +169,11 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			Execute(t)
 		// Set the deactivating state on the UserSignup
-		updatedUserSignup, err := hostAwait.UpdateUserSignup(t, false, user.UserSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivating(us, true)
-			})
+		updatedUserSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(user.UserSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivating(us, true)
+				})
 		require.NoError(t, err)
 
 		// Move the MUR to the user tier with longer deactivation time

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -233,14 +233,14 @@ func TestProxyFlow(t *testing.T) {
 				}
 
 				t.Run("use proxy to update a HAS Application CR in the user appstudio namespace via proxy API", func(t *testing.T) {
-					// Get application name
+					// Update application
 					applicationName := user.getApplicationName(0)
+					// Get application
+					proxyApp := user.getApplication(t, proxyCl, applicationName)
 					// Update DisplayName
 					changedDisplayName := fmt.Sprintf("Proxy test for user %s - updated application", tenantNsName(user.compliantUsername))
-					// Update application
-					proxyApp, err := awaitilities.Host().UpdateApplication(t, proxyCl, applicationName, tenantNsName(user.compliantUsername), func(app *appstudiov1.Application) {
-						app.Spec.DisplayName = changedDisplayName
-					})
+					proxyApp.Spec.DisplayName = changedDisplayName
+					err := proxyCl.Update(context.TODO(), proxyApp)
 					require.NoError(t, err)
 
 					// Find application and check, if it is updated
@@ -320,6 +320,7 @@ func TestProxyFlow(t *testing.T) {
 
 			t.Run("get resource from namespace outside of user's workspace", func(t *testing.T) {
 				// given
+
 				// create a namespace which does not belong to the user's workspace
 				anotherNamespace := fmt.Sprintf("outside-%s", user.compliantUsername)
 				user.expectedMemberCluster.CreateNamespace(t, anotherNamespace)

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -412,12 +412,13 @@ func TestSignupOK(t *testing.T) {
 			identity.ID, identity.Username), mp["message"])
 		assert.Equal(t, "error creating UserSignup resource", mp["details"])
 
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-			func(instance *toolchainv1alpha1.UserSignup) {
-				// Approve usersignup.
-				states.SetApprovedManually(instance, true)
-				instance.Spec.TargetCluster = memberAwait.ClusterName
-			})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name,
+				func(instance *toolchainv1alpha1.UserSignup) {
+					// Approve usersignup.
+					states.SetApprovedManually(instance, true)
+					instance.Spec.TargetCluster = memberAwait.ClusterName
+				})
 		require.NoError(t, err)
 
 		// Wait for the resources to be provisioned
@@ -444,10 +445,11 @@ func TestSignupOK(t *testing.T) {
 		t.Logf("Signed up new user %+v", userSignup)
 
 		// Deactivate the usersignup
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(us, true)
-			})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(us, true)
+				})
 		require.NoError(t, err)
 		_, err = hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.DeactivatedWithoutPreDeactivation())...),
@@ -609,11 +611,12 @@ func TestPhoneVerification(t *testing.T) {
 	assert.Equal(t, "PendingApproval", mpStatus["reason"])
 	require.False(t, mpStatus["verificationRequired"].(bool))
 
-	userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-		func(instance *toolchainv1alpha1.UserSignup) {
-			// Now approve the usersignup.
-			states.SetApprovedManually(instance, true)
-		})
+	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name,
+			func(instance *toolchainv1alpha1.UserSignup) {
+				// Now approve the usersignup.
+				states.SetApprovedManually(instance, true)
+			})
 	require.NoError(t, err)
 	transformedUsername := commonsignup.TransformUsername(userSignup.Spec.IdentityClaims.PreferredUsername, []string{"openshift", "kube", "default", "redhat", "sandbox"}, []string{"admin"})
 	// Confirm the MasterUserRecord is provisioned
@@ -666,11 +669,12 @@ func TestPhoneVerification(t *testing.T) {
 	userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name)
 	require.NoError(t, err)
 
-	userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-		func(instance *toolchainv1alpha1.UserSignup) {
-			// Now mark the original UserSignup as deactivated
-			states.SetDeactivated(instance, true)
-		})
+	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name,
+			func(instance *toolchainv1alpha1.UserSignup) {
+				// Now mark the original UserSignup as deactivated
+				states.SetDeactivated(instance, true)
+			})
 	require.NoError(t, err)
 
 	// Ensure the UserSignup is deactivated
@@ -720,10 +724,11 @@ func TestActivationCodeVerification(t *testing.T) {
 			wait.UntilUserSignupHasConditions(wait.ConditionSet(wait.Default(), wait.PendingApproval())...))
 		require.NoError(t, err)
 		// explicitly approve the usersignup (see above, config for parallel test has automatic approval disabled)
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetApprovedManually(us, true)
-			})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetApprovedManually(us, true)
+				})
 		require.NoError(t, err)
 		t.Logf("user signup '%s' approved", userSignup.Name)
 
@@ -793,10 +798,11 @@ func TestActivationCodeVerification(t *testing.T) {
 				Status: corev1.ConditionTrue,
 			})) // need to reload event
 			require.NoError(t, err)
-			event, err = hostAwait.UpdateSocialEvent(t, true, event.Name,
-				func(ev *toolchainv1alpha1.SocialEvent) {
-					ev.Status.ActivationCount = event.Spec.MaxAttendees // activation count identical to `MaxAttendees`
-				})
+			event, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
+				UpdateStatus(event.Name,
+					func(ev *toolchainv1alpha1.SocialEvent) {
+						ev.Status.ActivationCount = event.Spec.MaxAttendees // activation count identical to `MaxAttendees`
+					})
 			require.NoError(t, err)
 
 			userSignup, token := signup(t, hostAwait)

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -1,7 +1,6 @@
 package parallel
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -79,7 +78,10 @@ func TestCreateSocialEvent(t *testing.T) {
 			event.Spec.UserTier = "deactivate30"
 
 			// when
-			err := hostAwait.Client.Update(context.TODO(), event)
+			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
+				func(ev *toolchainv1alpha1.SocialEvent) {
+					ev.Spec.UserTier = "deactivate30"
+				})
 
 			// then
 			require.NoError(t, err)
@@ -115,7 +117,10 @@ func TestCreateSocialEvent(t *testing.T) {
 			event.Spec.SpaceTier = "base"
 
 			// when
-			err := hostAwait.Client.Update(context.TODO(), event)
+			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
+				func(ev *toolchainv1alpha1.SocialEvent) {
+					ev.Spec.SpaceTier = "base"
+				})
 
 			// then
 			require.NoError(t, err)

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -74,9 +74,6 @@ func TestCreateSocialEvent(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("update with valid tier name", func(t *testing.T) {
-			// given
-			event.Spec.UserTier = "deactivate30"
-
 			// when
 			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
 				func(ev *toolchainv1alpha1.SocialEvent) {
@@ -113,9 +110,6 @@ func TestCreateSocialEvent(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("update with valid tier name", func(t *testing.T) {
-			// given
-			event.Spec.SpaceTier = "base"
-
 			// when
 			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
 				func(ev *toolchainv1alpha1.SocialEvent) {

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -75,10 +75,11 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
-			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
-				func(ev *toolchainv1alpha1.SocialEvent) {
-					ev.Spec.UserTier = "deactivate30"
-				})
+			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
+				Update(event.Name,
+					func(ev *toolchainv1alpha1.SocialEvent) {
+						ev.Spec.UserTier = "deactivate30"
+					})
 
 			// then
 			require.NoError(t, err)
@@ -111,10 +112,11 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
-			event, err = hostAwait.UpdateSocialEvent(t, false, event.Name,
-				func(ev *toolchainv1alpha1.SocialEvent) {
-					ev.Spec.SpaceTier = "base"
-				})
+			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
+				Update(event.Name,
+					func(ev *toolchainv1alpha1.SocialEvent) {
+						ev.Spec.SpaceTier = "base"
+					})
 
 			// then
 			require.NoError(t, err)

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -49,10 +49,11 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 			// when
 			// deactivate the UserSignup so that the MUR will be deleted
-			userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-				func(us *toolchainv1alpha1.UserSignup) {
-					states.SetDeactivated(us, true)
-				})
+			userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+				Update(userSignup.Name,
+					func(us *toolchainv1alpha1.UserSignup) {
+						states.SetDeactivated(us, true)
+					})
 			require.NoError(t, err)
 			t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
@@ -74,10 +75,11 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 			// when
 			// we deactivate the UserSignup so that the MUR will be deleted
-			userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-				func(us *toolchainv1alpha1.UserSignup) {
-					states.SetDeactivated(us, true)
-				})
+			userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+				Update(userSignup.Name,
+					func(us *toolchainv1alpha1.UserSignup) {
+						states.SetDeactivated(us, true)
+					})
 			require.NoError(t, err)
 			t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -49,7 +49,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 			// when
 			// deactivate the UserSignup so that the MUR will be deleted
-			userSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+			userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})
@@ -74,7 +74,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 
 			// when
 			// we deactivate the UserSignup so that the MUR will be deleted
-			userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name,
+			userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -203,11 +203,11 @@ func TestSpaceRoles(t *testing.T) {
 	})
 
 	t.Run("set owner user as maintainer instead", func(t *testing.T) {
-		// given an appstudio space with `owner` user as an admin of it
-		ownerBinding.Spec.SpaceRole = "maintainer"
-
 		// when
-		err = hostAwait.Client.Update(context.TODO(), ownerBinding)
+		ownerBinding, err = hostAwait.UpdateSpaceBinding(t, ownerBinding.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
+			// given an appstudio space with `owner` user as an admin of it
+			sb.Spec.SpaceRole = "maintainer"
+		})
 		require.NoError(t, err)
 
 		// then
@@ -222,11 +222,11 @@ func TestSpaceRoles(t *testing.T) {
 	})
 
 	t.Run("set owner user as contributor instead", func(t *testing.T) {
-		// given an appstudio space with `owner` user as an admin of it
-		ownerBinding.Spec.SpaceRole = "contributor"
-
 		// when
-		err := hostAwait.Client.Update(context.TODO(), ownerBinding)
+		ownerBinding, err = hostAwait.UpdateSpaceBinding(t, ownerBinding.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
+			// given an appstudio space with `owner` user as an admin of it
+			sb.Spec.SpaceRole = "contributor"
+		})
 
 		// then
 		require.NoError(t, err)
@@ -335,13 +335,12 @@ func TestSubSpaces(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("we update role in parentSpaceBinding and expect change to be reflected in subSpaces", func(t *testing.T) {
-			// given
-			// the parentSpace role was "downgraded" to maintainer
-			parentSpaceBindings.Spec.SpaceRole = "maintainer"
-
 			// when
 			// we update the parentSpace bindings
-			err := hostAwait.Client.Update(context.TODO(), parentSpaceBindings)
+			parentSpaceBindings, err = hostAwait.UpdateSpaceBinding(t, parentSpaceBindings.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
+				// the parentSpace role was "downgraded" to maintainer
+				sb.Spec.SpaceRole = "maintainer"
+			})
 
 			// then
 			// downgrade of the usernames is done in parentSpace

--- a/test/e2e/parallel/usersignup_test.go
+++ b/test/e2e/parallel/usersignup_test.go
@@ -66,9 +66,10 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 		}()
 
 		// now deactivate the usersignup
-		_, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivated(us, true)
-		})
+		_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(us, true)
+			})
 		require.NoError(t, err)
 
 		// wait until it is deactivated, SpaceBinding is gone, and Space is in terminating state
@@ -81,9 +82,10 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-			states.SetApprovedManually(us, true)
-		})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+				states.SetApprovedManually(us, true)
+			})
 		require.NoError(t, err)
 
 		// then

--- a/test/e2e/parallel/usersignup_test.go
+++ b/test/e2e/parallel/usersignup_test.go
@@ -66,7 +66,7 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 		}()
 
 		// now deactivate the usersignup
-		_, err = hostAwait.UpdateUserSignup(t, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		_, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestTransformUsernameWithSpaceConflict(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 			states.SetApprovedManually(us, true)
 		})
 		require.NoError(t, err)

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -156,7 +156,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			Execute(t)
 
 		// Delete the user's email and set them to deactivated
-		userSignup, err := hostAwait.UpdateUserSignup(t, uNoEmail.UserSignup.Name,
+		userSignup, err := hostAwait.UpdateUserSignup(t, false, uNoEmail.UserSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				us.Spec.IdentityClaims.Email = ""
 				states.SetDeactivated(us, true)
@@ -499,7 +499,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(t, err)
 
 		// Now deactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name,
+		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(us, true)
 			})
@@ -516,7 +516,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			testconfig.Deactivation().UserSignupUnverifiedRetentionDays(0))
 
 		// Reactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name,
+		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivating(us, false)
 				states.SetDeactivated(us, false)
@@ -781,7 +781,7 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 				// when
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)
 				// If TargetCluster is set it will override the last cluster annotation so remove TargetCluster
-				userSignup, err := s.Host().UpdateUserSignup(t, userSignup.Name,
+				userSignup, err := s.Host().UpdateUserSignup(t, false, userSignup.Name,
 					func(us *toolchainv1alpha1.UserSignup) {
 						us.Spec.TargetCluster = ""
 					})

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -156,11 +156,12 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			Execute(t)
 
 		// Delete the user's email and set them to deactivated
-		userSignup, err := hostAwait.UpdateUserSignup(t, false, uNoEmail.UserSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				us.Spec.IdentityClaims.Email = ""
-				states.SetDeactivated(us, true)
-			})
+		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(uNoEmail.UserSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					us.Spec.IdentityClaims.Email = ""
+					states.SetDeactivated(us, true)
+				})
 		require.NoError(t, err)
 		t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
@@ -499,10 +500,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		require.NoError(t, err)
 
 		// Now deactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(us, true)
-			})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(us, true)
+				})
 		require.NoError(t, err)
 
 		userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name,
@@ -516,13 +518,14 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			testconfig.Deactivation().UserSignupUnverifiedRetentionDays(0))
 
 		// Reactivate the user
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-			func(us *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivating(us, false)
-				states.SetDeactivated(us, false)
-				states.SetApprovedManually(us, true)
-				states.SetVerificationRequired(us, true)
-			})
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name,
+				func(us *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivating(us, false)
+					states.SetDeactivated(us, false)
+					states.SetApprovedManually(us, true)
+					states.SetVerificationRequired(us, true)
+				})
 		require.NoError(t, err)
 		t.Logf("user signup '%s' reactivated", userSignup.Name)
 
@@ -781,10 +784,11 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 				// when
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)
 				// If TargetCluster is set it will override the last cluster annotation so remove TargetCluster
-				userSignup, err := s.Host().UpdateUserSignup(t, false, userSignup.Name,
-					func(us *toolchainv1alpha1.UserSignup) {
-						us.Spec.TargetCluster = ""
-					})
+				userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+					Update(userSignup.Name,
+						func(us *toolchainv1alpha1.UserSignup) {
+							us.Spec.TargetCluster = ""
+						})
 				require.NoError(t, err)
 
 				ReactivateAndCheckUser(t, s.Awaitilities, userSignup)

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -405,7 +405,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup)
 
 	// Update the UserSignup
-	userSignup, err := hostAwait.UpdateUserSignup(s.T(), userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+	userSignup, err := hostAwait.UpdateUserSignup(s.T(), false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
 		// Modify the user's AccountID
 		us.Spec.IdentityClaims.AccountID = "nnnbbb111234"
 	})

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -405,10 +405,11 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup)
 
 	// Update the UserSignup
-	userSignup, err := hostAwait.UpdateUserSignup(s.T(), false, userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
-		// Modify the user's AccountID
-		us.Spec.IdentityClaims.AccountID = "nnnbbb111234"
-	})
+	userSignup, err := wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+			// Modify the user's AccountID
+			us.Spec.IdentityClaims.AccountID = "nnnbbb111234"
+		})
 	require.NoError(s.T(), err)
 
 	// Confirm the AccountID is updated

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -147,7 +147,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 
 	// when deactivating the users
 	for username, usersignup := range signupsMember2 {
-		_, err := hostAwait.UpdateUserSignup(t, usersignup.Name,
+		_, err := hostAwait.UpdateUserSignup(t, false, usersignup.Name,
 			func(usersignup *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(usersignup, true)
 			})
@@ -221,7 +221,7 @@ func TestMetricsWhenUsersAutomaticallyApprovedAndThenDeactivated(t *testing.T) {
 
 	// when deactivating the users
 	for username, usersignup := range usersignups {
-		_, err := hostAwait.UpdateUserSignup(t, usersignup.Name,
+		_, err := hostAwait.UpdateUserSignup(t, false, usersignup.Name,
 			func(usersignup *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(usersignup, true)
 			})
@@ -310,7 +310,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 
 		t.Run("no change to metric when user deactivated", func(t *testing.T) {
 			// when deactivating the user
-			_, err = hostAwait.UpdateUserSignup(t, userSignup.Name,
+			_, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 				func(usersignup *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(usersignup, true)
 				})
@@ -371,7 +371,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
-			_, err := hostAwait.UpdateUserSignup(t, usersignups[username].Name,
+			_, err := hostAwait.UpdateUserSignup(t, false, usersignups[username].Name,
 				func(usersignup *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(usersignup, true)
 				})

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -147,10 +147,11 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 
 	// when deactivating the users
 	for username, usersignup := range signupsMember2 {
-		_, err := hostAwait.UpdateUserSignup(t, false, usersignup.Name,
-			func(usersignup *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(usersignup, true)
-			})
+		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(usersignup.Name,
+				func(usersignup *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(usersignup, true)
+				})
 		require.NoError(t, err)
 
 		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
@@ -221,10 +222,11 @@ func TestMetricsWhenUsersAutomaticallyApprovedAndThenDeactivated(t *testing.T) {
 
 	// when deactivating the users
 	for username, usersignup := range usersignups {
-		_, err := hostAwait.UpdateUserSignup(t, false, usersignup.Name,
-			func(usersignup *toolchainv1alpha1.UserSignup) {
-				states.SetDeactivated(usersignup, true)
-			})
+		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(usersignup.Name,
+				func(usersignup *toolchainv1alpha1.UserSignup) {
+					states.SetDeactivated(usersignup, true)
+				})
 		require.NoError(t, err)
 
 		err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)
@@ -310,10 +312,11 @@ func TestVerificationRequiredMetric(t *testing.T) {
 
 		t.Run("no change to metric when user deactivated", func(t *testing.T) {
 			// when deactivating the user
-			_, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-				func(usersignup *toolchainv1alpha1.UserSignup) {
-					states.SetDeactivated(usersignup, true)
-				})
+			_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+				Update(userSignup.Name,
+					func(usersignup *toolchainv1alpha1.UserSignup) {
+						states.SetDeactivated(usersignup, true)
+					})
 
 			// then
 			require.NoError(t, err)
@@ -371,10 +374,11 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
-			_, err := hostAwait.UpdateUserSignup(t, false, usersignups[username].Name,
-				func(usersignup *toolchainv1alpha1.UserSignup) {
-					states.SetDeactivated(usersignup, true)
-				})
+			_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+				Update(usersignups[username].Name,
+					func(usersignup *toolchainv1alpha1.UserSignup) {
+						states.SetDeactivated(usersignup, true)
+					})
 			require.NoError(t, err)
 
 			err = hostAwait.WaitUntilMasterUserRecordAndSpaceBindingsDeleted(t, username)

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -153,10 +153,11 @@ func (r *SetupMigrationRunner) prepareDeactivatedUser(t *testing.T) {
 	hostAwait := r.Awaitilities.Host()
 
 	// deactivate the UserSignup
-	userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-		func(us *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivated(us, true)
-		})
+	userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name,
+			func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(us, true)
+			})
 	require.NoError(t, err)
 	t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -153,7 +153,7 @@ func (r *SetupMigrationRunner) prepareDeactivatedUser(t *testing.T) {
 	hostAwait := r.Awaitilities.Host()
 
 	// deactivate the UserSignup
-	userSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+	userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 		func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})

--- a/testsupport/deactivation.go
+++ b/testsupport/deactivation.go
@@ -16,10 +16,11 @@ import (
 // DeactivateAndCheckUser deactivates the given UserSignups and checks that the MUR is deprovisioned
 func DeactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup) *toolchainv1alpha1.UserSignup {
 	hostAwait := awaitilities.Host()
-	userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-		func(us *toolchainv1alpha1.UserSignup) {
-			states.SetDeactivated(us, true)
-		})
+	userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name,
+			func(us *toolchainv1alpha1.UserSignup) {
+				states.SetDeactivated(us, true)
+			})
 	require.NoError(t, err)
 	t.Logf("user signup '%s' set to deactivated", userSignup.Name)
 
@@ -62,10 +63,11 @@ func ReactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSi
 	}, userSignup)
 	require.NoError(t, err)
 
-	userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
-		func(us *toolchainv1alpha1.UserSignup) {
-			states.SetApprovedManually(us, true)
-		})
+	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+		Update(userSignup.Name,
+			func(us *toolchainv1alpha1.UserSignup) {
+				states.SetApprovedManually(us, true)
+			})
 	require.NoError(t, err)
 	t.Logf("user signup '%s' reactivated", userSignup.Name)
 

--- a/testsupport/deactivation.go
+++ b/testsupport/deactivation.go
@@ -16,7 +16,7 @@ import (
 // DeactivateAndCheckUser deactivates the given UserSignups and checks that the MUR is deprovisioned
 func DeactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup) *toolchainv1alpha1.UserSignup {
 	hostAwait := awaitilities.Host()
-	userSignup, err := hostAwait.UpdateUserSignup(t, userSignup.Name,
+	userSignup, err := hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 		func(us *toolchainv1alpha1.UserSignup) {
 			states.SetDeactivated(us, true)
 		})
@@ -62,7 +62,7 @@ func ReactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSi
 	}, userSignup)
 	require.NoError(t, err)
 
-	userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name,
+	userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name,
 		func(us *toolchainv1alpha1.UserSignup) {
 			states.SetApprovedManually(us, true)
 		})

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -269,7 +269,7 @@ func (r *SignupRequest) Execute(t *testing.T) *SignupResult {
 			}
 		}
 
-		userSignup, err = hostAwait.UpdateUserSignup(t, userSignup.Name, doUpdate)
+		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, doUpdate)
 		require.NoError(t, err)
 	}
 

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -269,7 +269,8 @@ func (r *SignupRequest) Execute(t *testing.T) *SignupResult {
 			}
 		}
 
-		userSignup, err = hostAwait.UpdateUserSignup(t, false, userSignup.Name, doUpdate)
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, doUpdate)
 		require.NoError(t, err)
 	}
 

--- a/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -34,12 +34,13 @@ func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterNam
 
 	originalSpc := spc.DeepCopy()
 
-	spc, err = await.UpdateSpaceProvisionerConfig(t, spc.Name,
-		func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
-			for _, opt := range opts {
-				opt(spcfg)
-			}
-		})
+	spc, err = wait.For(t, await, &toolchainv1alpha1.SpaceProvisionerConfig{}).
+		Update(spc.Name,
+			func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
+				for _, opt := range opts {
+					opt(spcfg)
+				}
+			})
 	require.NoError(t, err)
 
 	// log spc values needed for debugging a problem with random capacity manager e2e test failures
@@ -57,10 +58,11 @@ func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterNam
 			require.Fail(t, err.Error())
 		}
 
-		_, err = await.UpdateSpaceProvisionerConfig(t, originalSpc.Name,
-			func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
-				spcfg.Spec = originalSpc.Spec
-			})
+		_, err = wait.For(t, await, &toolchainv1alpha1.SpaceProvisionerConfig{}).
+			Update(originalSpc.Name,
+				func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
+					spcfg.Spec = originalSpc.Spec
+				})
 
 		require.NoError(t, err)
 	})

--- a/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -59,10 +59,6 @@ func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterNam
 
 		_, err = await.UpdateSpaceProvisionerConfig(t, originalSpc.Name,
 			func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
-				// make the originalSpc look like we freshly obtained it from the server and updated its fields
-				// to look like the original.
-				spcfg.Generation = currentSpc.Generation
-				spcfg.ResourceVersion = currentSpc.ResourceVersion
 				spcfg.Spec = originalSpc.Spec
 			})
 

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -128,8 +128,8 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *C
 		err := modify(hostAwait, tier)
 		require.NoError(t, err)
 	}
-	_, err = hostAwait.UpdateNSTemplateTier(t, tier.NSTemplateTier.Name,
-		func(nstt *toolchainv1alpha1.NSTemplateTier) {
+	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
+		Update(tier.NSTemplateTier.Name, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
 		})
 	require.NoError(t, err)

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -128,7 +128,10 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *C
 		err := modify(hostAwait, tier)
 		require.NoError(t, err)
 	}
-	err = hostAwait.Client.Update(context.TODO(), tier.NSTemplateTier)
+	_, err = hostAwait.UpdateNSTemplateTier(t, tier.NSTemplateTier.Name,
+		func(nstt *toolchainv1alpha1.NSTemplateTier) {
+			nstt.Spec = tier.NSTemplateTier.Spec
+		})
 	require.NoError(t, err)
 	return tier
 }

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -913,13 +913,13 @@ func (w *Waiter[T]) doUpdate(status bool, objectName string, modify func(T)) (T,
 			// Update the Status
 			if err := w.await.Client.Status().Update(context.TODO(), object); err != nil {
 				w.t.Logf("error updating '%v' Status '%s': %s. Will retry again...", w.gvk, objectName, err.Error())
-				return false, err
+				return false, nil
 			}
 		} else {
 			// Update the Spec
 			if err := w.await.Client.Update(context.TODO(), object); err != nil {
 				w.t.Logf("Error updating '%v' Spec '%s': %s. Will retry again...", w.gvk, objectName, err.Error())
-				return false, err
+				return false, nil
 			}
 		}
 		objectToReturn = object
@@ -928,7 +928,7 @@ func (w *Waiter[T]) doUpdate(status bool, objectName string, modify func(T)) (T,
 	return objectToReturn, err
 }
 
-// Update tries to update the Spec of the given object
+// Update tries to update the given object
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated object
 func (w *Waiter[T]) Update(objectName string, modify func(T)) (T, error) {

--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -20,7 +20,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/metrics"
 
-	appstudiov1 "github.com/codeready-toolchain/toolchain-e2e/testsupport/appstudio/api/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/redhat-cop/operator-utils/pkg/util"
@@ -956,25 +955,4 @@ func (a *Awaitility) UpdateSpaceProvisionerConfig(t *testing.T, spcName string, 
 		return true, nil
 	})
 	return spc, err
-}
-
-// UpdateApplication tries to update the Spec of the given Application
-// If it fails with an error (for example if the object has been modified), it retrieves the latest version and retries
-// Returns the updated Application
-func (a *Awaitility) UpdateApplication(t *testing.T, cl client.Client, appName, namespace string, modifyApplication func(app *appstudiov1.Application)) (*appstudiov1.Application, error) {
-	var app *appstudiov1.Application
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshApp := &appstudiov1.Application{}
-		if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: appName}, freshApp); err != nil {
-			return true, err
-		}
-		modifyApplication(freshApp)
-		if err := cl.Update(context.TODO(), freshApp); err != nil {
-			t.Logf("error updating Application '%s': %s.Will retry again...", appName, err.Error())
-			return false, nil
-		}
-		app = freshApp
-		return true, nil
-	})
-	return app, err
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -214,37 +214,6 @@ func (a *HostAwaitility) UpdateMasterUserRecord(t *testing.T, status bool, murNa
 	return m, err
 }
 
-// UpdateUserSignup tries to update the Status or Spec of the given UserSignup
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
-// Returns the updated UserSignup
-func (a *HostAwaitility) UpdateUserSignup(t *testing.T, status bool, userSignupName string, modifyUserSignup func(us *toolchainv1alpha1.UserSignup)) (*toolchainv1alpha1.UserSignup, error) {
-	var userSignup *toolchainv1alpha1.UserSignup
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshUserSignup := &toolchainv1alpha1.UserSignup{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: userSignupName}, freshUserSignup); err != nil {
-			return true, err
-		}
-
-		modifyUserSignup(freshUserSignup)
-		if status {
-			// Update the Status
-			if err := a.Client.Status().Update(context.TODO(), freshUserSignup); err != nil {
-				t.Logf("error updating UserSignup Status '%s': %s. Will retry again...", userSignupName, err.Error())
-				return false, nil
-			}
-		} else {
-			// Update the Spec
-			if err := a.Client.Update(context.TODO(), freshUserSignup); err != nil {
-				t.Logf("error updating UserSignup Spec '%s': %s. Will retry again...", userSignupName, err.Error())
-				return false, nil
-			}
-		}
-		userSignup = freshUserSignup
-		return true, nil
-	})
-	return userSignup, err
-}
-
 // UpdateSpace tries to update the Spec of the given Space
 // If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
 // Returns the updated Space
@@ -2582,61 +2551,4 @@ func (a *HostAwaitility) CreateSpaceAndSpaceBinding(t *testing.T, mur *toolchain
 		return true, nil
 	})
 	return spaceCreated, spaceBinding, err
-}
-
-// UpdateSocialEvent tries to update the Status or Spec of the given SocialEvent
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
-// Returns the updated SocialEvent
-func (a *HostAwaitility) UpdateSocialEvent(t *testing.T, status bool, socialEventName string, modifySocialEvent func(us *toolchainv1alpha1.SocialEvent)) (*toolchainv1alpha1.SocialEvent, error) {
-	var socialEvent *toolchainv1alpha1.SocialEvent
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshSocialEvent := &toolchainv1alpha1.SocialEvent{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: socialEventName}, freshSocialEvent); err != nil {
-			return true, err
-		}
-
-		modifySocialEvent(freshSocialEvent)
-		if status {
-			// Update the Status
-			if err := a.Client.Status().Update(context.TODO(), freshSocialEvent); err != nil {
-				t.Logf("error updating SocialEvent Status '%s': %s. Will retry again...", socialEventName, err.Error())
-				return false, err
-			}
-		} else {
-			// Update the Spec
-			if err := a.Client.Update(context.TODO(), freshSocialEvent); err != nil {
-				t.Logf("Error updating SocialEvent Spec '%s': %s. Will retry again...", socialEventName, err.Error())
-				return false, err
-			}
-		}
-		socialEvent = freshSocialEvent
-		return true, nil
-	})
-	return socialEvent, err
-}
-
-// NSTemplateTier updates the given NSTemplateTier using the provided modifiers.
-// If it encounters an error (e.g., object has been modified), it retrieves the latest version and retries.
-// Returns the updated NSTemplateTier.
-func (a *HostAwaitility) UpdateNSTemplateTier(t *testing.T, tierName string, modifyTier func(tier *toolchainv1alpha1.NSTemplateTier)) (*toolchainv1alpha1.NSTemplateTier, error) {
-	var tier *toolchainv1alpha1.NSTemplateTier
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshTier := &toolchainv1alpha1.NSTemplateTier{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: a.Namespace,
-			Name:      tierName,
-		}, freshTier); err != nil {
-			return true, err
-		}
-
-		modifyTier(freshTier)
-
-		if err := a.Client.Update(context.TODO(), freshTier); err != nil {
-			t.Logf("error updating NSTemplateTier '%s': %s. Will retry again...", tierName, err.Error())
-			return false, nil
-		}
-		tier = freshTier
-		return true, nil
-	})
-	return tier, err
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -2618,12 +2618,12 @@ func (a *HostAwaitility) UpdateSocialEvent(t *testing.T, status bool, socialEven
 // NSTemplateTier updates the given NSTemplateTier using the provided modifiers.
 // If it encounters an error (e.g., object has been modified), it retrieves the latest version and retries.
 // Returns the updated NSTemplateTier.
-func (hostAwait *HostAwaitility) UpdateNSTemplateTier(t *testing.T, tierName string, modifyTier func(tier *toolchainv1alpha1.NSTemplateTier)) (*toolchainv1alpha1.NSTemplateTier, error) {
+func (a *HostAwaitility) UpdateNSTemplateTier(t *testing.T, tierName string, modifyTier func(tier *toolchainv1alpha1.NSTemplateTier)) (*toolchainv1alpha1.NSTemplateTier, error) {
 	var tier *toolchainv1alpha1.NSTemplateTier
-	err := wait.PollUntilContextTimeout(context.TODO(), hostAwait.RetryInterval, hostAwait.Timeout, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
 		freshTier := &toolchainv1alpha1.NSTemplateTier{}
-		if err := hostAwait.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: hostAwait.Namespace,
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{
+			Namespace: a.Namespace,
 			Name:      tierName,
 		}, freshTier); err != nil {
 			return true, err
@@ -2631,7 +2631,7 @@ func (hostAwait *HostAwaitility) UpdateNSTemplateTier(t *testing.T, tierName str
 
 		modifyTier(freshTier)
 
-		if err := hostAwait.Client.Update(context.TODO(), freshTier); err != nil {
+		if err := a.Client.Update(context.TODO(), freshTier); err != nil {
 			t.Logf("error updating NSTemplateTier '%s': %s. Will retry again...", tierName, err.Error())
 			return false, nil
 		}


### PR DESCRIPTION
# Description
#1071 addressed a potential fix, but to ensure we do not face it in the future, we should do the update call in a loop. 

Since other update calls are not being done in a loop, this PR addressed it as well. 

## Issue ticket number and link
[SANDBOX-838](https://issues.redhat.com/browse/SANDBOX-838)