### PR TITLE
apply generic update

### DIFF
--- a/test/e2e/no_user_identity_test.go
+++ b/test/e2e/no_user_identity_test.go
@@ -84,7 +84,7 @@ func TestCreationOfUserAndIdentityIsSkipped(t *testing.T) {
 	t.Run("user and identity stay there when user is deactivated", func(t *testing.T) {
 		// when
 		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(signup.Name,
+			Update(signup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})

--- a/test/e2e/parallel/e2e_test.go
+++ b/test/e2e/parallel/e2e_test.go
@@ -161,7 +161,7 @@ func TestE2EFlow(t *testing.T) {
 
 			// when
 			_, err = wait.For(t, memberAwait.Awaitility, &userv1.User{}).
-				Update(user.Name, func(u *userv1.User) {
+				Update(user.Name, memberAwait.Namespace, func(u *userv1.User) {
 					u.Identities = []string{}
 				})
 
@@ -180,7 +180,7 @@ func TestE2EFlow(t *testing.T) {
 
 			// when
 			_, err = wait.For(t, memberAwait.Awaitility, &userv1.Identity{}).
-				Update(identity.Name, func(i *userv1.Identity) {
+				Update(identity.Name, memberAwait.Namespace, func(i *userv1.Identity) {
 					i.User = corev1.ObjectReference{Name: "", UID: ""}
 				})
 
@@ -325,9 +325,10 @@ func TestE2EFlow(t *testing.T) {
 
 		t.Run("remove finalizer", func(t *testing.T) {
 			// when removing the finalizer from the CM
-			_, err = memberAwait.UpdateConfigMap(t, cm.Namespace, cmName, func(cm *corev1.ConfigMap) {
-				cm.Finalizers = nil
-			})
+			_, err = wait.For(t, memberAwait.Awaitility, &corev1.ConfigMap{}).
+				Update(cmName, cm.Namespace, func(cm *corev1.ConfigMap) {
+					cm.Finalizers = nil
+				})
 			require.NoError(t, err)
 
 			// then check remaining resources are deleted
@@ -488,7 +489,7 @@ func TestE2EFlow(t *testing.T) {
 
 		// Now deactivate the UserSignup
 		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(originalSubJohnSignup.Name,
+			Update(originalSubJohnSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -170,7 +170,7 @@ func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
 			Execute(t)
 		// Set the deactivating state on the UserSignup
 		updatedUserSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(user.UserSignup.Name,
+			Update(user.UserSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivating(us, true)
 				})
@@ -344,9 +344,11 @@ func TestFeatureToggles(t *testing.T) {
 			// when
 
 			// Now let's disable the feature for the Space by removing the feature annotation
-			_, err := hostAwait.UpdateSpace(t, user.Space.Name, func(s *toolchainv1alpha1.Space) {
-				delete(s.Annotations, toolchainv1alpha1.FeatureToggleNameAnnotationKey)
-			})
+			_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+				Update(user.Space.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+					delete(s.Annotations, toolchainv1alpha1.FeatureToggleNameAnnotationKey)
+				})
+
 			require.NoError(t, err)
 
 			// then
@@ -359,12 +361,14 @@ func TestFeatureToggles(t *testing.T) {
 				// when
 
 				// Now let's re-enable the feature for the Space by restoring the feature annotation
-				_, err := hostAwait.UpdateSpace(t, user.Space.Name, func(s *toolchainv1alpha1.Space) {
-					if s.Annotations == nil {
-						s.Annotations = make(map[string]string)
-					}
-					s.Annotations[toolchainv1alpha1.FeatureToggleNameAnnotationKey] = "test-feature"
-				})
+				_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+					Update(user.Space.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+						if s.Annotations == nil {
+							s.Annotations = make(map[string]string)
+						}
+						s.Annotations[toolchainv1alpha1.FeatureToggleNameAnnotationKey] = "test-feature"
+					})
+
 				require.NoError(t, err)
 
 				// then

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -21,7 +21,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commonproxy "github.com/codeready-toolchain/toolchain-common/pkg/proxy"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testspace "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	spacebindingrequesttestcommon "github.com/codeready-toolchain/toolchain-common/pkg/test/spacebindingrequest"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
@@ -1084,9 +1083,10 @@ func TestSpaceLister(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		_, err = memberAwait.UpdateSpaceBindingRequest(t, test.NamespacedName(failingSBR.Namespace, failingSBR.Name), func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
-			sbr.Spec.SpaceRole = "admin"
-		})
+		_, err = wait.For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
+			Update(failingSBR.Name, failingSBR.Namespace, func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
+				sbr.Spec.SpaceRole = "admin"
+			})
 
 		// then
 		require.NoError(t, err)

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -413,7 +413,7 @@ func TestSignupOK(t *testing.T) {
 		assert.Equal(t, "error creating UserSignup resource", mp["details"])
 
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name,
+			Update(userSignup.Name, hostAwait.Namespace,
 				func(instance *toolchainv1alpha1.UserSignup) {
 					// Approve usersignup.
 					states.SetApprovedManually(instance, true)
@@ -446,7 +446,7 @@ func TestSignupOK(t *testing.T) {
 
 		// Deactivate the usersignup
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name,
+			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})
@@ -612,7 +612,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.False(t, mpStatus["verificationRequired"].(bool))
 
 	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name,
+		Update(userSignup.Name, hostAwait.Namespace,
 			func(instance *toolchainv1alpha1.UserSignup) {
 				// Now approve the usersignup.
 				states.SetApprovedManually(instance, true)
@@ -670,7 +670,7 @@ func TestPhoneVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name,
+		Update(userSignup.Name, hostAwait.Namespace,
 			func(instance *toolchainv1alpha1.UserSignup) {
 				// Now mark the original UserSignup as deactivated
 				states.SetDeactivated(instance, true)
@@ -725,7 +725,7 @@ func TestActivationCodeVerification(t *testing.T) {
 		require.NoError(t, err)
 		// explicitly approve the usersignup (see above, config for parallel test has automatic approval disabled)
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name,
+			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetApprovedManually(us, true)
 				})
@@ -799,7 +799,7 @@ func TestActivationCodeVerification(t *testing.T) {
 			})) // need to reload event
 			require.NoError(t, err)
 			event, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
-				UpdateStatus(event.Name,
+				UpdateStatus(event.Name, hostAwait.Namespace,
 					func(ev *toolchainv1alpha1.SocialEvent) {
 						ev.Status.ActivationCount = event.Spec.MaxAttendees // activation count identical to `MaxAttendees`
 					})

--- a/test/e2e/parallel/retarget_test.go
+++ b/test/e2e/parallel/retarget_test.go
@@ -28,9 +28,10 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsNotShared(t *testing
 		Execute(t)
 
 	// when
-	space, err := hostAwait.UpdateSpace(t, user.Space.Name, func(s *toolchainv1alpha1.Space) {
-		s.Spec.TargetCluster = member2Await.ClusterName
-	})
+	space, err := For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+		Update(user.Space.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+			s.Spec.TargetCluster = member2Await.ClusterName
+		})
 	require.NoError(t, err)
 
 	// then
@@ -89,9 +90,10 @@ func TestRetargetUserByChangingSpaceTargetClusterWhenSpaceIsShared(t *testing.T)
 	require.NoError(t, err)
 
 	// when
-	spaceToMove, err = hostAwait.UpdateSpace(t, spaceToMove.Name, func(s *toolchainv1alpha1.Space) {
-		s.Spec.TargetCluster = member2Await.ClusterName
-	})
+	spaceToMove, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+		Update(spaceToMove.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+			s.Spec.TargetCluster = member2Await.ClusterName
+		})
 	require.NoError(t, err)
 
 	// then
@@ -169,9 +171,10 @@ func TestRetargetUserWithSBRByChangingSpaceTargetClusterWhenSpaceIsShared(t *tes
 	require.NoError(t, err)
 
 	// when
-	spaceToMove, err = hostAwait.UpdateSpace(t, spaceToMove.Name, func(s *toolchainv1alpha1.Space) {
-		s.Spec.TargetCluster = member2Await.ClusterName
-	})
+	spaceToMove, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+		Update(spaceToMove.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+			s.Spec.TargetCluster = member2Await.ClusterName
+		})
 	require.NoError(t, err)
 
 	// then

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -76,7 +76,7 @@ func TestCreateSocialEvent(t *testing.T) {
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
 			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
-				Update(event.Name,
+				Update(event.Name, hostAwait.Namespace,
 					func(ev *toolchainv1alpha1.SocialEvent) {
 						ev.Spec.UserTier = "deactivate30"
 					})
@@ -113,7 +113,7 @@ func TestCreateSocialEvent(t *testing.T) {
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
 			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
-				Update(event.Name,
+				Update(event.Name, hostAwait.Namespace,
 					func(ev *toolchainv1alpha1.SocialEvent) {
 						ev.Spec.SpaceTier = "base"
 					})

--- a/test/e2e/parallel/socialevent_test.go
+++ b/test/e2e/parallel/socialevent_test.go
@@ -8,7 +8,7 @@ import (
 	commonsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/socialevent"
 	testsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/test/socialevent"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, wait.UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.ConditionReady,
 			Status: corev1.ConditionTrue,
 		}))
@@ -65,7 +65,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, wait.UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidUserTierReason,
@@ -75,7 +75,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
-			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
+			event, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
 				Update(event.Name, hostAwait.Namespace,
 					func(ev *toolchainv1alpha1.SocialEvent) {
 						ev.Spec.UserTier = "deactivate30"
@@ -83,7 +83,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			_, err = hostAwait.WaitForSocialEvent(t, event.Name, wait.UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))
@@ -102,7 +102,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		event, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+		event, err = hostAwait.WaitForSocialEvent(t, event.Name, wait.UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SocialEventInvalidSpaceTierReason,
@@ -112,7 +112,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 		t.Run("update with valid tier name", func(t *testing.T) {
 			// when
-			event, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
+			event, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.SocialEvent{}).
 				Update(event.Name, hostAwait.Namespace,
 					func(ev *toolchainv1alpha1.SocialEvent) {
 						ev.Spec.SpaceTier = "base"
@@ -120,7 +120,7 @@ func TestCreateSocialEvent(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			_, err = hostAwait.WaitForSocialEvent(t, event.Name, UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
+			_, err = hostAwait.WaitForSocialEvent(t, event.Name, wait.UntilSocialEventHasConditions(toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.ConditionReady,
 				Status: corev1.ConditionTrue,
 			}))

--- a/test/e2e/parallel/space_cleanup_test.go
+++ b/test/e2e/parallel/space_cleanup_test.go
@@ -50,7 +50,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 			// when
 			// deactivate the UserSignup so that the MUR will be deleted
 			userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-				Update(userSignup.Name,
+				Update(userSignup.Name, hostAwait.Namespace,
 					func(us *toolchainv1alpha1.UserSignup) {
 						states.SetDeactivated(us, true)
 					})
@@ -76,7 +76,7 @@ func TestSpaceAndSpaceBindingCleanup(t *testing.T) {
 			// when
 			// we deactivate the UserSignup so that the MUR will be deleted
 			userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-				Update(userSignup.Name,
+				Update(userSignup.Name, hostAwait.Namespace,
 					func(us *toolchainv1alpha1.UserSignup) {
 						states.SetDeactivated(us, true)
 					})

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -79,9 +79,10 @@ func TestCreateSpace(t *testing.T) {
 
 		t.Run("unable to delete space that was already provisioned", func(t *testing.T) {
 			// given
-			s, err := hostAwait.UpdateSpace(t, space.Name, func(s *toolchainv1alpha1.Space) {
-				s.Spec.TargetCluster = "unknown"
-			})
+			s, err := For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+				Update(space.Name, hostAwait.Namespace, func(ss *toolchainv1alpha1.Space) {
+					ss.Spec.TargetCluster = "unknown"
+				})
 			require.NoError(t, err)
 
 			// when
@@ -96,9 +97,10 @@ func TestCreateSpace(t *testing.T) {
 
 			t.Run("update target cluster to unblock deletion", func(t *testing.T) {
 				// when
-				s, err = hostAwait.UpdateSpace(t, s.Name, func(s *toolchainv1alpha1.Space) {
-					s.Spec.TargetCluster = memberAwait.ClusterName
-				})
+				s, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+					Update(s.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+						s.Spec.TargetCluster = memberAwait.ClusterName
+					})
 				require.NoError(t, err)
 
 				// then
@@ -204,10 +206,11 @@ func TestSpaceRoles(t *testing.T) {
 
 	t.Run("set owner user as maintainer instead", func(t *testing.T) {
 		// when
-		ownerBinding, err = hostAwait.UpdateSpaceBinding(t, ownerBinding.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
-			// given an appstudio space with `owner` user as an admin of it
-			sb.Spec.SpaceRole = "maintainer"
-		})
+		ownerBinding, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
+			Update(ownerBinding.Name, hostAwait.Namespace, func(sb *toolchainv1alpha1.SpaceBinding) {
+				// given an appstudio space with `owner` user as an admin of it
+				sb.Spec.SpaceRole = "maintainer"
+			})
 		require.NoError(t, err)
 
 		// then
@@ -223,10 +226,11 @@ func TestSpaceRoles(t *testing.T) {
 
 	t.Run("set owner user as contributor instead", func(t *testing.T) {
 		// when
-		ownerBinding, err = hostAwait.UpdateSpaceBinding(t, ownerBinding.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
-			// given an appstudio space with `owner` user as an admin of it
-			sb.Spec.SpaceRole = "contributor"
-		})
+		ownerBinding, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
+			Update(ownerBinding.Name, hostAwait.Namespace, func(sb *toolchainv1alpha1.SpaceBinding) {
+				// given an appstudio space with `owner` user as an admin of it
+				sb.Spec.SpaceRole = "contributor"
+			})
 
 		// then
 		require.NoError(t, err)
@@ -337,10 +341,11 @@ func TestSubSpaces(t *testing.T) {
 		t.Run("we update role in parentSpaceBinding and expect change to be reflected in subSpaces", func(t *testing.T) {
 			// when
 			// we update the parentSpace bindings
-			parentSpaceBindings, err = hostAwait.UpdateSpaceBinding(t, parentSpaceBindings.Name, func(sb *toolchainv1alpha1.SpaceBinding) {
-				// the parentSpace role was "downgraded" to maintainer
-				sb.Spec.SpaceRole = "maintainer"
-			})
+			parentSpaceBindings, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
+				Update(parentSpaceBindings.Name, hostAwait.Namespace, func(sb *toolchainv1alpha1.SpaceBinding) {
+					// the parentSpace role was "downgraded" to maintainer
+					sb.Spec.SpaceRole = "maintainer"
+				})
 
 			// then
 			// downgrade of the usernames is done in parentSpace

--- a/test/e2e/parallel/spacebindingrequest_test.go
+++ b/test/e2e/parallel/spacebindingrequest_test.go
@@ -65,9 +65,10 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 					// something/someone updates the SpaceRole directly on the SpaceBinding object
 
 					// when
-					spaceBinding, err = hostAwait.UpdateSpaceBinding(t, spaceBinding.Name, func(s *toolchainv1alpha1.SpaceBinding) {
-						s.Spec.SpaceRole = "maintainer" // let's change the role
-					})
+					spaceBinding, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
+						Update(spaceBinding.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.SpaceBinding) {
+							s.Spec.SpaceRole = "maintainer" // let's change the role
+						})
 					require.NoError(t, err)
 
 					// then
@@ -138,9 +139,10 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 
 			t.Run("update SBR to fix invalid SpaceRole", func(t *testing.T) {
 				// when
-				_, err = memberAwait.UpdateSpaceBindingRequest(t, client.ObjectKeyFromObject(spaceBindingRequest), func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
-					sbr.Spec.SpaceRole = "admin"
-				})
+				_, err = For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
+					Update(spaceBindingRequest.Name, spaceBindingRequest.Namespace, func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
+						sbr.Spec.SpaceRole = "admin"
+					})
 
 				// then
 				require.NoError(t, err)
@@ -163,11 +165,11 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 	t.Run("update space binding request SpaceRole", func(t *testing.T) {
 		// when
 		space, spaceBindingRequest, _ := NewSpaceBindingRequest(t, awaitilities, memberAwait, hostAwait, "contributor")
-		_, err := memberAwait.UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
-			func(s *toolchainv1alpha1.SpaceBindingRequest) {
-				s.Spec.SpaceRole = "admin" // set to admin from contributor
-			},
-		)
+		_, err := For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
+			Update(spaceBindingRequest.Name, spaceBindingRequest.Namespace, func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
+				sbr.Spec.SpaceRole = "admin"
+			})
+
 		require.NoError(t, err)
 
 		//then

--- a/test/e2e/parallel/spacebindingrequest_test.go
+++ b/test/e2e/parallel/spacebindingrequest_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	testsupportspace "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/spacebinding"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -51,12 +51,12 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 				// with the same name but different UID.
 				require.NoError(t, err)
 				spaceBinding, err = hostAwait.WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-					UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
-					UntilSpaceBindingHasSpaceName(space.Name),
-					UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
-					UntilSpaceBindingHasDifferentUID(oldUID),
-					UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
-					UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
+					wait.UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
+					wait.UntilSpaceBindingHasSpaceName(space.Name),
+					wait.UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
+					wait.UntilSpaceBindingHasDifferentUID(oldUID),
+					wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
+					wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
 				)
 				require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 					// something/someone updates the SpaceRole directly on the SpaceBinding object
 
 					// when
-					spaceBinding, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
+					spaceBinding, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.SpaceBinding{}).
 						Update(spaceBinding.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.SpaceBinding) {
 							s.Spec.SpaceRole = "maintainer" // let's change the role
 						})
@@ -74,11 +74,11 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 					// then
 					// spaceBindingRequest should reset back the SpaceRole
 					spaceBinding, err = hostAwait.WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-						UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
-						UntilSpaceBindingHasSpaceName(space.Name),
-						UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole), // should have back the role from the SBR
-						UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
-						UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
+						wait.UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
+						wait.UntilSpaceBindingHasSpaceName(space.Name),
+						wait.UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole), // should have back the role from the SBR
+						wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
+						wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
 					)
 					require.NoError(t, err)
 
@@ -105,19 +105,19 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 			user1 := NewSignupRequest(awaitilities).
 				ManuallyApprove().
 				TargetCluster(memberAwait).
-				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 				SpaceTier("appstudio").
 				EnsureMUR().
 				Execute(t)
 
 			// wait for the namespace to be provisioned since we will be creating the SpaceBindingRequest into it.
-			space, err := hostAwait.WaitForSpace(t, user1.Space.Name, UntilSpaceHasAnyProvisionedNamespaces())
+			space, err := hostAwait.WaitForSpace(t, user1.Space.Name, wait.UntilSpaceHasAnyProvisionedNamespaces())
 			require.NoError(t, err)
 			// let's create a new MUR that will have access to the space
 			user2 := NewSignupRequest(awaitilities).
 				ManuallyApprove().
 				TargetCluster(memberAwait).
-				RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+				RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 				NoSpace().
 				WaitForMUR().Execute(t)
 			// create the spacebinding request
@@ -130,7 +130,7 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 			// then
 			// wait for spacebinding request status to be set
 			_, err = memberAwait.WaitForSpaceBindingRequest(t, client.ObjectKeyFromObject(spaceBindingRequest),
-				UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.UnableToCreateSpaceBinding(fmt.Sprintf("invalid role 'invalid' for space '%s'", space.Name))),
+				wait.UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.UnableToCreateSpaceBinding(fmt.Sprintf("invalid role 'invalid' for space '%s'", space.Name))),
 			)
 			require.NoError(t, err)
 			bindings, err := hostAwait.ListSpaceBindings(space.Name)
@@ -139,7 +139,7 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 
 			t.Run("update SBR to fix invalid SpaceRole", func(t *testing.T) {
 				// when
-				_, err = For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
+				_, err = wait.For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
 					Update(spaceBindingRequest.Name, spaceBindingRequest.Namespace, func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
 						sbr.Spec.SpaceRole = "admin"
 					})
@@ -147,7 +147,7 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 				// then
 				require.NoError(t, err)
 				_, err = awaitilities.Host().WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-					UntilSpaceBindingHasSpaceRole("admin"))
+					wait.UntilSpaceBindingHasSpaceRole("admin"))
 				require.NoError(t, err)
 			})
 		})
@@ -165,7 +165,7 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 	t.Run("update space binding request SpaceRole", func(t *testing.T) {
 		// when
 		space, spaceBindingRequest, _ := NewSpaceBindingRequest(t, awaitilities, memberAwait, hostAwait, "contributor")
-		_, err := For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
+		_, err := wait.For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceBindingRequest{}).
 			Update(spaceBindingRequest.Name, spaceBindingRequest.Namespace, func(sbr *toolchainv1alpha1.SpaceBindingRequest) {
 				sbr.Spec.SpaceRole = "admin"
 			})
@@ -175,17 +175,17 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 		//then
 		// wait for both SpaceBindingRequest and SpaceBinding to have same SpaceRole
 		spaceBindingRequest, err = memberAwait.WaitForSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.GetNamespace(), Name: spaceBindingRequest.GetName()},
-			UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
-			UntilSpaceBindingRequestHasSpecSpaceRole("admin"), // has admin role
-			UntilSpaceBindingRequestHasSpecMUR(spaceBindingRequest.Spec.MasterUserRecord),
+			wait.UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
+			wait.UntilSpaceBindingRequestHasSpecSpaceRole("admin"), // has admin role
+			wait.UntilSpaceBindingRequestHasSpecMUR(spaceBindingRequest.Spec.MasterUserRecord),
 		)
 		require.NoError(t, err)
 		_, err = hostAwait.WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-			UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
-			UntilSpaceBindingHasSpaceName(space.Name),
-			UntilSpaceBindingHasSpaceRole("admin"), // has admin role
-			UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
-			UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
+			wait.UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
+			wait.UntilSpaceBindingHasSpaceName(space.Name),
+			wait.UntilSpaceBindingHasSpaceRole("admin"), // has admin role
+			wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
+			wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
 		)
 		require.NoError(t, err)
 	})
@@ -200,12 +200,12 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 			Email(username + "@acme.com").
 			ManuallyApprove().
 			TargetCluster(memberAwait).
-			RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+			RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 			NoSpace().
 			WaitForMUR().Execute(t)
 		// and we try to update the MUR in the SBR
 		// with lower timeout since it will fail as expected
-		_, err := memberAwait.WithRetryOptions(TimeoutOption(time.Second*2)).UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
+		_, err := memberAwait.WithRetryOptions(wait.TimeoutOption(time.Second*2)).UpdateSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.Namespace, Name: spaceBindingRequest.Name},
 			func(s *toolchainv1alpha1.SpaceBindingRequest) {
 				s.Spec.MasterUserRecord = newUser.MUR.GetName() // set to the new MUR
 			},
@@ -216,31 +216,31 @@ func TestUpdateSpaceBindingRequest(t *testing.T) {
 		//then
 		// wait for both SpaceBindingRequest and SpaceBinding to have same MUR
 		spaceBindingRequest, err = memberAwait.WaitForSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.GetNamespace(), Name: spaceBindingRequest.GetName()},
-			UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
-			UntilSpaceBindingRequestHasSpecSpaceRole(spaceBindingRequest.Spec.SpaceRole),
-			UntilSpaceBindingRequestHasSpecMUR(spaceBindingRequest.Spec.MasterUserRecord), // MUR should be the same
+			wait.UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
+			wait.UntilSpaceBindingRequestHasSpecSpaceRole(spaceBindingRequest.Spec.SpaceRole),
+			wait.UntilSpaceBindingRequestHasSpecMUR(spaceBindingRequest.Spec.MasterUserRecord), // MUR should be the same
 		)
 		require.NoError(t, err)
 		_, err = hostAwait.WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-			UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord), // MUR should be the same
-			UntilSpaceBindingHasSpaceName(space.Name),
-			UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
+			wait.UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord), // MUR should be the same
+			wait.UntilSpaceBindingHasSpaceName(space.Name),
+			wait.UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
 		)
 		require.NoError(t, err)
 	})
 }
 
-func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait *MemberAwaitility, hostAwait *HostAwaitility, spaceRole string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBindingRequest, *toolchainv1alpha1.SpaceBinding) {
+func NewSpaceBindingRequest(t *testing.T, awaitilities wait.Awaitilities, memberAwait *wait.MemberAwaitility, hostAwait *wait.HostAwaitility, spaceRole string) (*toolchainv1alpha1.Space, *toolchainv1alpha1.SpaceBindingRequest, *toolchainv1alpha1.SpaceBinding) {
 	user := NewSignupRequest(awaitilities).
 		ManuallyApprove().
 		TargetCluster(memberAwait).
-		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		SpaceTier("appstudio").
 		EnsureMUR().
 		Execute(t)
 	firstUserSignup := user.UserSignup
 	// wait for the namespace to be provisioned since we will be creating the SpaceBindingRequest into it.
-	space, err := hostAwait.WaitForSpace(t, user.Space.Name, UntilSpaceHasAnyProvisionedNamespaces())
+	space, err := hostAwait.WaitForSpace(t, user.Space.Name, wait.UntilSpaceHasAnyProvisionedNamespaces())
 	require.NoError(t, err)
 	// let's create a new MUR that will have access to the space
 	username := uuid.Must(uuid.NewV4()).String()
@@ -249,7 +249,7 @@ func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait
 		Email(username + "@acme.com").
 		ManuallyApprove().
 		TargetCluster(memberAwait).
-		RequireConditions(ConditionSet(Default(), ApprovedByAdmin())...).
+		RequireConditions(wait.ConditionSet(wait.Default(), wait.ApprovedByAdmin())...).
 		NoSpace().
 		WaitForMUR().Execute(t)
 	secondUserMUR := secondUser.MUR
@@ -263,16 +263,16 @@ func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait
 	// then
 	// check for the spaceBinding creation
 	spaceBinding, err := hostAwait.WaitForSpaceBinding(t, spaceBindingRequest.Spec.MasterUserRecord, space.Name,
-		UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
-		UntilSpaceBindingHasSpaceName(space.Name),
-		UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
-		UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
-		UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
+		wait.UntilSpaceBindingHasMurName(spaceBindingRequest.Spec.MasterUserRecord),
+		wait.UntilSpaceBindingHasSpaceName(space.Name),
+		wait.UntilSpaceBindingHasSpaceRole(spaceBindingRequest.Spec.SpaceRole),
+		wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestLabelKey, spaceBindingRequest.GetName()),
+		wait.UntilSpaceBindingHasLabel(toolchainv1alpha1.SpaceBindingRequestNamespaceLabelKey, spaceBindingRequest.GetNamespace()),
 	)
 	require.NoError(t, err)
 	// wait for spacebinding request status
 	spaceBindingRequest, err = memberAwait.WaitForSpaceBindingRequest(t, types.NamespacedName{Namespace: spaceBindingRequest.GetNamespace(), Name: spaceBindingRequest.GetName()},
-		UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
+		wait.UntilSpaceBindingRequestHasConditions(spacebindingrequesttestcommon.Ready()),
 	)
 	require.NoError(t, err)
 	tier, err := awaitilities.Host().WaitForNSTemplateTier(t, space.Spec.TierName)
@@ -281,14 +281,14 @@ func NewSpaceBindingRequest(t *testing.T, awaitilities Awaitilities, memberAwait
 		usernamesSorted := []string{firstUserSignup.Status.CompliantUsername, secondUserMUR.Name}
 		sort.Strings(usernamesSorted)
 		_, err = memberAwait.WaitForNSTmplSet(t, space.Name,
-			UntilNSTemplateSetHasSpaceRoles(
-				SpaceRole(tier.Spec.SpaceRoles[spaceRole].TemplateRef, usernamesSorted[0], usernamesSorted[1])))
+			wait.UntilNSTemplateSetHasSpaceRoles(
+				wait.SpaceRole(tier.Spec.SpaceRoles[spaceRole].TemplateRef, usernamesSorted[0], usernamesSorted[1])))
 		require.NoError(t, err)
 	} else {
 		_, err = memberAwait.WaitForNSTmplSet(t, space.Name,
-			UntilNSTemplateSetHasSpaceRoles(
-				SpaceRole(tier.Spec.SpaceRoles["admin"].TemplateRef, firstUserSignup.Status.CompliantUsername),
-				SpaceRole(tier.Spec.SpaceRoles[spaceRole].TemplateRef, secondUserMUR.Name)))
+			wait.UntilNSTemplateSetHasSpaceRoles(
+				wait.SpaceRole(tier.Spec.SpaceRoles["admin"].TemplateRef, firstUserSignup.Status.CompliantUsername),
+				wait.SpaceRole(tier.Spec.SpaceRoles[spaceRole].TemplateRef, secondUserMUR.Name)))
 		require.NoError(t, err)
 	}
 	testsupportspace.VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)

--- a/test/e2e/parallel/spaceprovisionerconfig_test.go
+++ b/test/e2e/parallel/spaceprovisionerconfig_test.go
@@ -71,9 +71,10 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 			&corev1.Secret{})
 
 		// when
-		_, err = host.UpdateToolchainCluster(t, tc.Name, func(updatedTc *toolchainv1alpha1.ToolchainCluster) {
-			updatedTc.Spec.SecretRef.Name = newSecretName
-		})
+		_, err = wait.For(t, host.Awaitility, &toolchainv1alpha1.ToolchainCluster{}).
+			Update(tc.Name, host.Namespace, func(updatedTc *toolchainv1alpha1.ToolchainCluster) {
+				updatedTc.Spec.SecretRef.Name = newSecretName
+			})
 		require.NoError(t, err)
 
 		// then

--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -82,9 +82,10 @@ func TestCreateSpaceRequest(t *testing.T) {
 				// something/someone updates the tierName directly on the Space object
 
 				// when
-				subSpace, err = hostAwait.UpdateSpace(t, subSpace.Name, func(s *toolchainv1alpha1.Space) {
-					s.Spec.TierName = "base1ns" // let's change the tier
-				})
+				subSpace, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+					Update(subSpace.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+						s.Spec.TierName = "base1ns" // let's change the tier
+					})
 				require.NoError(t, err)
 
 				// then
@@ -316,11 +317,11 @@ func TestUpdateSpaceRequest(t *testing.T) {
 
 	t.Run("update space request tierName", func(t *testing.T) {
 		// when
-		_, err := memberAwait.UpdateSpaceRequest(t, spaceRequestNamespacedName,
-			func(s *toolchainv1alpha1.SpaceRequest) {
-				s.Spec.TierName = "base"
-			},
-		)
+		_, err := For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceRequest{}).
+			Update(spaceRequestNamespacedName.Name, spaceRequestNamespacedName.Namespace,
+				func(s *toolchainv1alpha1.SpaceRequest) {
+					s.Spec.TierName = "base"
+				})
 		require.NoError(t, err)
 
 		// then

--- a/test/e2e/parallel/spacerequest_test.go
+++ b/test/e2e/parallel/spacerequest_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/space"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/spaceprovisionerconfig"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,17 +39,17 @@ func TestCreateSpaceRequest(t *testing.T) {
 		// then
 		// check for the subSpace creation
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-			UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-			UntilSpaceHasTier("appstudio-env"),
-			UntilSpaceHasDisableInheritance(false),
-			UntilSpaceHasAnyProvisionedNamespaces(),
+			wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
+			wait.UntilSpaceHasTier("appstudio-env"),
+			wait.UntilSpaceHasDisableInheritance(false),
+			wait.UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
-		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
+		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, wait.UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
-			UntilSpaceRequestHasNamespaceAccess(subSpace),
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
 		)
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
@@ -69,11 +69,11 @@ func TestCreateSpaceRequest(t *testing.T) {
 			// with the same name but creation timestamp should be greater (more recent).
 			require.NoError(t, err)
 			subSpace, err = awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-				UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-				UntilSpaceHasTier("appstudio-env"),
-				UntilSpaceHasDisableInheritance(false),
-				UntilSpaceHasAnyProvisionedNamespaces(),
-				UntilSpaceHasCreationTimestampGreaterThan(oldSpaceCreationTimeStamp.Time),
+				wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
+				wait.UntilSpaceHasTier("appstudio-env"),
+				wait.UntilSpaceHasDisableInheritance(false),
+				wait.UntilSpaceHasAnyProvisionedNamespaces(),
+				wait.UntilSpaceHasCreationTimestampGreaterThan(oldSpaceCreationTimeStamp.Time),
 			)
 			require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				// something/someone updates the tierName directly on the Space object
 
 				// when
-				subSpace, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+				subSpace, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
 					Update(subSpace.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
 						s.Spec.TierName = "base1ns" // let's change the tier
 					})
@@ -91,10 +91,10 @@ func TestCreateSpaceRequest(t *testing.T) {
 				// then
 				// spaceRequest should reset back the tierName
 				_, err = awaitilities.Host().WaitForSpace(t, subSpace.GetName(),
-					UntilSpaceHasTier("appstudio-env"), // tierName is back as the one on spaceRequest
-					UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-					UntilSpaceHasDisableInheritance(false),
-					UntilSpaceHasAnyProvisionedNamespaces(),
+					wait.UntilSpaceHasTier("appstudio-env"), // tierName is back as the one on spaceRequest
+					wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
+					wait.UntilSpaceHasDisableInheritance(false),
+					wait.UntilSpaceHasAnyProvisionedNamespaces(),
 				)
 				require.NoError(t, err)
 
@@ -130,18 +130,18 @@ func TestCreateSpaceRequest(t *testing.T) {
 		// then
 		// check for the subSpace creation
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-			UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-			UntilSpaceHasTier("appstudio-env"),
-			UntilSpaceHasDisableInheritance(true),
-			UntilSpaceHasAnyProvisionedNamespaces(),
+			wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
+			wait.UntilSpaceHasTier("appstudio-env"),
+			wait.UntilSpaceHasDisableInheritance(true),
+			wait.UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
-		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
+		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, wait.UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
-			UntilSpaceRequestHasNamespaceAccess(subSpace),
-			UntilSpaceRequestHasDisableInheritance(true),
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
+			wait.UntilSpaceRequestHasDisableInheritance(true),
 		)
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
@@ -156,18 +156,18 @@ func TestCreateSpaceRequest(t *testing.T) {
 		// then
 		// check for the subSpace creation with same target cluster as parent one
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-			UntilSpaceHasTargetClusterRoles([]string(nil)),                     // empty target cluster roles
-			UntilSpaceHasStatusTargetCluster(parentSpace.Status.TargetCluster), // subSpace should have same target cluster as parent space
-			UntilSpaceHasTier("appstudio-env"),
-			UntilSpaceHasDisableInheritance(false),
-			UntilSpaceHasAnyProvisionedNamespaces(),
+			wait.UntilSpaceHasTargetClusterRoles([]string(nil)),                     // empty target cluster roles
+			wait.UntilSpaceHasStatusTargetCluster(parentSpace.Status.TargetCluster), // subSpace should have same target cluster as parent space
+			wait.UntilSpaceHasTier("appstudio-env"),
+			wait.UntilSpaceHasDisableInheritance(false),
+			wait.UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
-		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
+		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, wait.UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
-			UntilSpaceRequestHasNamespaceAccess(subSpace))
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace))
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
 
@@ -213,17 +213,17 @@ func TestCreateSpaceRequest(t *testing.T) {
 
 		// then
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-			UntilSpaceHasTargetClusterRoles([]string{cluster.RoleLabel("member-2")}), // member-2 target cluster roles
-			UntilSpaceHasStatusTargetCluster(memberCluster2.Name),                    // subSpace should have member-2 target cluster
-			UntilSpaceHasTier("appstudio-env"),
-			UntilSpaceHasAnyProvisionedNamespaces(),
+			wait.UntilSpaceHasTargetClusterRoles([]string{cluster.RoleLabel("member-2")}), // member-2 target cluster roles
+			wait.UntilSpaceHasStatusTargetCluster(memberCluster2.Name),                    // subSpace should have member-2 target cluster
+			wait.UntilSpaceHasTier("appstudio-env"),
+			wait.UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
-		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
+		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, wait.UntilSpaceHasAnyTargetClusterSet())
 		spaceRequest, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster2.Status.APIEndpoint),
-			UntilSpaceRequestHasNamespaceAccess(subSpace))
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster2.Status.APIEndpoint),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace))
 		require.NoError(t, err)
 		VerifyNamespaceAccessForSpaceRequest(t, memberAwait2.Client, spaceRequest) // space request has access to ns on member2
 
@@ -265,17 +265,17 @@ func TestCreateSpaceRequest(t *testing.T) {
 		// then
 		// check for the subSpace creation
 		subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-			UntilSpaceHasTargetClusterRoles(targetClusterRoles),
-			UntilSpaceHasTier("base1ns"),
-			UntilSpaceHasAnyProvisionedNamespaces(),
+			wait.UntilSpaceHasTargetClusterRoles(targetClusterRoles),
+			wait.UntilSpaceHasTier("base1ns"),
+			wait.UntilSpaceHasAnyProvisionedNamespaces(),
 		)
 		require.NoError(t, err)
-		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, UntilSpaceHasAnyTargetClusterSet())
+		subSpace, _ = VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name, wait.UntilSpaceHasAnyTargetClusterSet())
 		_, err = memberAwait.WaitForSpaceRequest(t, types.NamespacedName{Namespace: spaceRequest.GetNamespace(), Name: spaceRequest.GetName()},
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
-			UntilSpaceRequestHasNamespaceAccess(subSpace),
-			UntilSpaceRequestHasNamespaceAccessWithoutSecretRef(), // check that namespace access is present but without a SecretRef set
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasStatusTargetClusterURL(memberCluster.Status.APIEndpoint),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
+			wait.UntilSpaceRequestHasNamespaceAccessWithoutSecretRef(), // check that namespace access is present but without a SecretRef set
 		)
 		require.NoError(t, err)
 	})
@@ -297,27 +297,27 @@ func TestUpdateSpaceRequest(t *testing.T) {
 	// then
 	// check for the subSpace creation
 	subSpace, err := awaitilities.Host().WaitForSubSpace(t, spaceRequest.Name, spaceRequest.Namespace, parentSpace.GetName(),
-		UntilSpaceHasAnyTargetClusterSet(),
-		UntilSpaceHasTier("appstudio"),
-		UntilSpaceHasAnyProvisionedNamespaces(),
+		wait.UntilSpaceHasAnyTargetClusterSet(),
+		wait.UntilSpaceHasTier("appstudio"),
+		wait.UntilSpaceHasAnyProvisionedNamespaces(),
 	)
 	require.NoError(t, err)
 	VerifyResourcesProvisionedForSpace(t, awaitilities, subSpace.Name,
-		UntilSpaceHasAnyTargetClusterSet(),
-		UntilSpaceHasTier(spaceRequest.Spec.TierName),
+		wait.UntilSpaceHasAnyTargetClusterSet(),
+		wait.UntilSpaceHasTier(spaceRequest.Spec.TierName),
 	)
 	spaceRequestNamespacedName := types.NamespacedName{Namespace: spaceRequest.Namespace, Name: spaceRequest.Name}
 	_, err = memberAwait.WaitForSpaceRequest(t, spaceRequestNamespacedName,
-		UntilSpaceRequestHasTierName("appstudio"),
-		UntilSpaceRequestHasConditions(Provisioned()),
-		UntilSpaceRequestHasNamespaceAccess(subSpace),
+		wait.UntilSpaceRequestHasTierName("appstudio"),
+		wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+		wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
 	)
 	require.NoError(t, err)
 	VerifyNamespaceAccessForSpaceRequest(t, memberAwait.Client, spaceRequest)
 
 	t.Run("update space request tierName", func(t *testing.T) {
 		// when
-		_, err := For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceRequest{}).
+		_, err := wait.For(t, memberAwait.Awaitility, &toolchainv1alpha1.SpaceRequest{}).
 			Update(spaceRequestNamespacedName.Name, spaceRequestNamespacedName.Namespace,
 				func(s *toolchainv1alpha1.SpaceRequest) {
 					s.Spec.TierName = "base"
@@ -327,15 +327,15 @@ func TestUpdateSpaceRequest(t *testing.T) {
 		// then
 		// wait for both spaceRequest and subSpace to have same tierName
 		subSpace, err = hostAwait.WaitForSpace(t, subSpace.Name,
-			UntilSpaceHasTier("base"),
-			UntilSpaceHasConditions(Provisioned()),
-			UntilSpaceHasExpectedProvisionedNamespacesNumber(2))
+			wait.UntilSpaceHasTier("base"),
+			wait.UntilSpaceHasConditions(wait.Provisioned()),
+			wait.UntilSpaceHasExpectedProvisionedNamespacesNumber(2))
 		require.NoError(t, err)
 
 		_, err = memberAwait.WaitForSpaceRequest(t, spaceRequestNamespacedName,
-			UntilSpaceRequestHasTierName("base"),
-			UntilSpaceRequestHasConditions(Provisioned()),
-			UntilSpaceRequestHasNamespaceAccess(subSpace),
+			wait.UntilSpaceRequestHasTierName("base"),
+			wait.UntilSpaceRequestHasConditions(wait.Provisioned()),
+			wait.UntilSpaceRequestHasNamespaceAccess(subSpace),
 		)
 		require.NoError(t, err)
 	})

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -53,8 +53,12 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	externalNsPodsNoise := prepareWorkloads(t, await.Member1(), "workloads-noise", wait.WithOriginalPriorityClass())
 
 	// Set a short timeout for one of the idler to trigger pod idling
-	idler.Spec.TimeoutSeconds = 5
-	idler, err = memberAwait.UpdateIdlerSpec(t, idler) // The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
+	// The idler is currently updating its status since it's already been idling the pods. So we need to keep trying to update.
+	idler, err = wait.For(t, memberAwait.Awaitility, &toolchainv1alpha1.Idler{}).
+		Update(idler.Name, memberAwait.Namespace, func(i *toolchainv1alpha1.Idler) {
+			i.Spec.TimeoutSeconds = 5
+		})
+
 	require.NoError(t, err)
 
 	// Wait for the pods to be deleted

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -157,7 +157,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		// Delete the user's email and set them to deactivated
 		userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(uNoEmail.UserSignup.Name,
+			Update(uNoEmail.UserSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					us.Spec.IdentityClaims.Email = ""
 					states.SetDeactivated(us, true)
@@ -198,10 +198,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		manyManyDaysAgo := 999999999999999
 		durationDelta := time.Duration(manyManyDaysAgo) * time.Hour * 24
 		updatedProvisionedTime := &metav1.Time{Time: time.Now().Add(-durationDelta)}
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Status.ProvisionedTime = updatedProvisionedTime
-			})
+		murMember1, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			UpdateStatus(murMember1.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Status.ProvisionedTime = updatedProvisionedTime
+				})
 		require.NoError(t, err)
 		t.Logf("masteruserrecord '%s' provisioned time adjusted", murMember1.Name)
 
@@ -227,7 +228,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		murMember1 := userMember1.MUR
 
 		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
+		s.promoteToDefaultUserTier(murMember1)
 
 		deactivationExcludedUserMember1 := NewSignupRequest(s.Awaitilities).
 			Username("userdeactivationexcluded").
@@ -241,7 +242,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		excludedMurMember1 := deactivationExcludedUserMember1.MUR
 
 		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, excludedMurMember1)
+		s.promoteToDefaultUserTier(excludedMurMember1)
 
 		// Get the provisioned account's tier
 		baseUserTier, err := hostAwait.WaitForUserTier(t, "deactivate30")
@@ -251,18 +252,20 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// to a time far enough in the past to trigger auto deactivation. Subtracting the given period from the current time and setting this as the provisioned
 		// time should test the behaviour of the deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-			})
+		murMember1, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			UpdateStatus(murMember1.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+				})
 		require.NoError(t, err)
 		t.Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name, murMember1.Status.ProvisionedTime.String())
 
 		// Use the same method above to change the provisioned time for the excluded user
-		excludedMurMember1, err = hostAwait.UpdateMasterUserRecordStatus(t, excludedMurMember1.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-			})
+		excludedMurMember1, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			UpdateStatus(excludedMurMember1.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+				})
 		require.NoError(t, err)
 		t.Logf("masteruserrecord '%s' provisioned time adjusted to %s", excludedMurMember1.Name, excludedMurMember1.Status.ProvisionedTime.String())
 
@@ -314,7 +317,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		murMember1 := userMember1.MUR
 
 		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, murMember1)
+		s.promoteToDefaultUserTier(murMember1)
 
 		// Get the provisioned account's tier
 		baseUserTier, err := hostAwait.WaitForUserTier(t, "deactivate30")
@@ -325,10 +328,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		// period from the current time and setting this as the provisioned time should test the behaviour of the
 		// deactivation controller reconciliation.
 		tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-		murMember1, err = hostAwait.UpdateMasterUserRecordStatus(t, murMember1.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-			})
+		murMember1, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			UpdateStatus(murMember1.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+				})
 		require.NoError(t, err)
 		t.Logf("masteruserrecord '%s' provisioned time adjusted to %s", murMember1.Name,
 			murMember1.Status.ProvisionedTime.String())
@@ -361,7 +365,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 		userSignup := user.UserSignup
 
 		// TODO remove once UserTier migration is completed
-		s.promoteToDefaultUserTier(hostAwait.Client, user.MUR)
+		s.promoteToDefaultUserTier(user.MUR)
 
 		// Wait for the UserSignup to have the desired state
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
@@ -383,10 +387,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			// period from the current time and setting this as the provisioned time should test the behaviour of the
 			// deactivation controller reconciliation.
 			tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+1) * time.Hour * 24
-			mur, err = hostAwait.UpdateMasterUserRecordStatus(t, mur.Name,
-				func(mur *toolchainv1alpha1.MasterUserRecord) {
-					mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-				})
+			mur, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+				UpdateStatus(mur.Name, hostAwait.Namespace,
+					func(mur *toolchainv1alpha1.MasterUserRecord) {
+						mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+					})
 			require.NoError(t, err)
 			t.Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
 				mur.Status.ProvisionedTime.String())
@@ -410,10 +415,11 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 			t.Run("user set to deactivated after deactivating", func(t *testing.T) {
 				// Set the provisioned time even further back
 				tierDeactivationDuration := time.Duration(baseUserTier.Spec.DeactivationTimeoutDays+4) * time.Hour * 24
-				mur, err = hostAwait.UpdateMasterUserRecordStatus(t, mur.Name,
-					func(mur *toolchainv1alpha1.MasterUserRecord) {
-						mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
-					})
+				mur, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+					UpdateStatus(mur.Name, hostAwait.Namespace,
+						func(mur *toolchainv1alpha1.MasterUserRecord) {
+							mur.Status.ProvisionedTime = &metav1.Time{Time: time.Now().Add(-tierDeactivationDuration)}
+						})
 				murName := mur.Name
 				require.NoError(t, err)
 				t.Logf("masteruserrecord '%s' provisioned time adjusted to %s", mur.Name,
@@ -448,16 +454,22 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 				require.Equal(t, deactivatingLastTransitionTime, updated.LastTransitionTime)
 
 				// Save the updated UserSignup's Status
-				require.NoError(t, hostAwait.Client.Status().Update(context.TODO(), userSignup))
+				userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+					UpdateStatus(userSignup.Name, hostAwait.Namespace, func(u *toolchainv1alpha1.UserSignup) {
+						u.Status.Conditions = userSignup.Status.Conditions
+					})
+
+				require.NoError(t, err)
 
 				// Trigger a reconciliation of the deactivation controller by updating the MUR annotation
-				_, err := hostAwait.UpdateMasterUserRecordSpec(t, murName,
-					func(mur *toolchainv1alpha1.MasterUserRecord) {
-						if mur.Annotations == nil {
-							mur.Annotations = map[string]string{}
-						}
-						mur.Annotations["update-from-e2e-tests"] = "trigger"
-					})
+				_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+					Update(murName, hostAwait.Namespace,
+						func(mur *toolchainv1alpha1.MasterUserRecord) {
+							if mur.Annotations == nil {
+								mur.Annotations = map[string]string{}
+							}
+							mur.Annotations["update-from-e2e-tests"] = "trigger"
+						})
 				if err != nil {
 					// the mur might already be deleted, so we can continue as long as the error is the mur was not found
 					require.EqualError(t, err, fmt.Sprintf("masteruserrecords.toolchain.dev.openshift.com \"%s\" not found", murName))
@@ -501,7 +513,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		// Now deactivate the user
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name,
+			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(us, true)
 				})
@@ -519,7 +531,7 @@ func (s *userManagementTestSuite) TestUserDeactivation() {
 
 		// Reactivate the user
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name,
+			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivating(us, false)
 					states.SetDeactivated(us, false)
@@ -715,8 +727,8 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 	VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup)
 
 	// Disable MUR
-	mur, err := hostAwait.UpdateMasterUserRecordSpec(s.T(),
-		u.MUR.Name, func(mur *toolchainv1alpha1.MasterUserRecord) {
+	mur, err := wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+		Update(u.MUR.Name, hostAwait.Namespace, func(mur *toolchainv1alpha1.MasterUserRecord) {
 			mur.Spec.Disabled = true
 		})
 	require.NoError(s.T(), err)
@@ -748,10 +760,11 @@ func (s *userManagementTestSuite) TestUserDisabled() {
 
 	s.Run("re-enabled mur", func() {
 		// Re-enable MUR
-		mur, err = hostAwait.UpdateMasterUserRecordSpec(s.T(), mur.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Spec.Disabled = false
-			})
+		mur, err = wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			Update(mur.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Spec.Disabled = false
+				})
 		require.NoError(s.T(), err)
 
 		VerifyResourcesProvisionedForSignup(s.T(), s.Awaitilities, userSignup)
@@ -785,7 +798,7 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 				DeactivateAndCheckUser(t, s.Awaitilities, userSignup)
 				// If TargetCluster is set it will override the last cluster annotation so remove TargetCluster
 				userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-					Update(userSignup.Name,
+					Update(userSignup.Name, hostAwait.Namespace,
 						func(us *toolchainv1alpha1.UserSignup) {
 							us.Spec.TargetCluster = ""
 						})
@@ -805,8 +818,12 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 }
 
 // TODO remove once UserTier migration is completed
-func (s *userManagementTestSuite) promoteToDefaultUserTier(cl client.Client, mur *toolchainv1alpha1.MasterUserRecord) {
-	mur.Spec.TierName = "deactivate30"
-	err := cl.Update(context.TODO(), mur)
+func (s *userManagementTestSuite) promoteToDefaultUserTier(mur *toolchainv1alpha1.MasterUserRecord) {
+	hostAwait := s.Awaitilities.Host()
+	_, err := wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+		Update(mur.Name, hostAwait.Namespace, func(m *toolchainv1alpha1.MasterUserRecord) {
+			m.Spec.TierName = "deactivate30"
+		})
+
 	require.NoError(s.T(), err)
 }

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -406,7 +406,7 @@ func (s *userSignupIntegrationTest) TestUserResourcesUpdatedWhenPropagatedClaims
 
 	// Update the UserSignup
 	userSignup, err := wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name, func(us *toolchainv1alpha1.UserSignup) {
+		Update(userSignup.Name, hostAwait.Namespace, func(us *toolchainv1alpha1.UserSignup) {
 			// Modify the user's AccountID
 			us.Spec.IdentityClaims.AccountID = "nnnbbb111234"
 		})

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -148,7 +148,7 @@ func TestMetricsWhenUsersManuallyApprovedAndThenDeactivated(t *testing.T) {
 	// when deactivating the users
 	for username, usersignup := range signupsMember2 {
 		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(usersignup.Name,
+			Update(usersignup.Name, hostAwait.Namespace,
 				func(usersignup *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(usersignup, true)
 				})
@@ -223,7 +223,7 @@ func TestMetricsWhenUsersAutomaticallyApprovedAndThenDeactivated(t *testing.T) {
 	// when deactivating the users
 	for username, usersignup := range usersignups {
 		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(usersignup.Name,
+			Update(usersignup.Name, hostAwait.Namespace,
 				func(usersignup *toolchainv1alpha1.UserSignup) {
 					states.SetDeactivated(usersignup, true)
 				})
@@ -313,7 +313,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 		t.Run("no change to metric when user deactivated", func(t *testing.T) {
 			// when deactivating the user
 			_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-				Update(userSignup.Name,
+				Update(userSignup.Name, hostAwait.Namespace,
 					func(usersignup *toolchainv1alpha1.UserSignup) {
 						states.SetDeactivated(usersignup, true)
 					})
@@ -375,7 +375,7 @@ func TestMetricsWhenUsersDeactivatedAndReactivated(t *testing.T) {
 		for j := 1; j < i; j++ { // deactivate and reactivate as many times as necessary (based on its "number")
 			// deactivate the user
 			_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-				Update(usersignups[username].Name,
+				Update(usersignups[username].Name, hostAwait.Namespace,
 					func(usersignup *toolchainv1alpha1.UserSignup) {
 						states.SetDeactivated(usersignup, true)
 					})
@@ -595,10 +595,11 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 	hostAwait.WaitForMetricDelta(t, wait.SpacesMetric, 0, "cluster_name", memberAwait2.ClusterName) // no space on member2
 
 	// when disabling MUR
-	_, err := hostAwait.UpdateMasterUserRecordSpec(t, mur.Name,
-		func(mur *toolchainv1alpha1.MasterUserRecord) {
-			mur.Spec.Disabled = true
-		})
+	_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+		Update(mur.Name, hostAwait.Namespace,
+			func(mur *toolchainv1alpha1.MasterUserRecord) {
+				mur.Spec.Disabled = true
+			})
 	require.NoError(t, err)
 
 	// then
@@ -615,10 +616,11 @@ func TestMetricsWhenUserDisabled(t *testing.T) {
 
 	t.Run("re-enabled mur", func(t *testing.T) {
 		// When re-enabling MUR
-		mur, err = hostAwait.UpdateMasterUserRecordSpec(t, mur.Name,
-			func(mur *toolchainv1alpha1.MasterUserRecord) {
-				mur.Spec.Disabled = false
-			})
+		mur, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+			Update(mur.Name, hostAwait.Namespace,
+				func(mur *toolchainv1alpha1.MasterUserRecord) {
+					mur.Spec.Disabled = false
+				})
 		require.NoError(t, err)
 
 		// then

--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -154,7 +154,7 @@ func (r *SetupMigrationRunner) prepareDeactivatedUser(t *testing.T) {
 
 	// deactivate the UserSignup
 	userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name,
+		Update(userSignup.Name, hostAwait.Namespace,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(us, true)
 			})

--- a/testsupport/deactivation.go
+++ b/testsupport/deactivation.go
@@ -17,7 +17,7 @@ import (
 func DeactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSignup *toolchainv1alpha1.UserSignup) *toolchainv1alpha1.UserSignup {
 	hostAwait := awaitilities.Host()
 	userSignup, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name,
+		Update(userSignup.Name, hostAwait.Namespace,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetDeactivated(us, true)
 			})
@@ -64,7 +64,7 @@ func ReactivateAndCheckUser(t *testing.T, awaitilities wait.Awaitilities, userSi
 	require.NoError(t, err)
 
 	userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-		Update(userSignup.Name,
+		Update(userSignup.Name, hostAwait.Namespace,
 			func(us *toolchainv1alpha1.UserSignup) {
 				states.SetApprovedManually(us, true)
 			})

--- a/testsupport/signup_request.go
+++ b/testsupport/signup_request.go
@@ -270,7 +270,7 @@ func (r *SignupRequest) Execute(t *testing.T) *SignupResult {
 		}
 
 		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
-			Update(userSignup.Name, doUpdate)
+			Update(userSignup.Name, hostAwait.Namespace, doUpdate)
 		require.NoError(t, err)
 	}
 

--- a/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/testsupport/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -35,7 +35,7 @@ func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterNam
 	originalSpc := spc.DeepCopy()
 
 	spc, err = wait.For(t, await, &toolchainv1alpha1.SpaceProvisionerConfig{}).
-		Update(spc.Name,
+		Update(spc.Name, await.Namespace,
 			func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
 				for _, opt := range opts {
 					opt(spcfg)
@@ -59,7 +59,7 @@ func UpdateForCluster(t *testing.T, await *wait.Awaitility, referencedClusterNam
 		}
 
 		_, err = wait.For(t, await, &toolchainv1alpha1.SpaceProvisionerConfig{}).
-			Update(originalSpc.Name,
+			Update(originalSpc.Name, await.Namespace,
 				func(spcfg *toolchainv1alpha1.SpaceProvisionerConfig) {
 					spcfg.Spec = originalSpc.Spec
 				})

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -129,7 +129,7 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *C
 		require.NoError(t, err)
 	}
 	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
-		Update(tier.NSTemplateTier.Name, func(nstt *toolchainv1alpha1.NSTemplateTier) {
+		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
 		})
 	require.NoError(t, err)
@@ -168,10 +168,11 @@ func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierNam
 	_, err := hostAwait.WaitForSpace(t, spacename)
 	require.NoError(t, err)
 
-	_, err = hostAwait.UpdateSpace(t, spacename,
-		func(s *toolchainv1alpha1.Space) {
-			s.Spec.TierName = tierName
-		})
+	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+		Update(spacename, hostAwait.Namespace,
+			func(s *toolchainv1alpha1.Space) {
+				s.Spec.TierName = tierName
+			})
 	require.NoError(t, err)
 }
 
@@ -180,10 +181,11 @@ func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName s
 	mur, err := hostAwait.WaitForMasterUserRecord(t, username)
 	require.NoError(t, err)
 
-	_, err = hostAwait.UpdateMasterUserRecord(t, false, mur.Name,
-		func(mur *toolchainv1alpha1.MasterUserRecord) {
-			mur.Spec.TierName = tierName
-		})
+	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+		Update(mur.Name, hostAwait.Namespace,
+			func(mur *toolchainv1alpha1.MasterUserRecord) {
+				mur.Spec.TierName = tierName
+			})
 	require.NoError(t, err)
 }
 

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -8,7 +8,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	. "github.com/codeready-toolchain/toolchain-e2e/testsupport/wait" // nolint:revive
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -28,12 +28,12 @@ type CustomNSTemplateTier struct {
 	SpaceRolesTier *toolchainv1alpha1.NSTemplateTier
 }
 
-type CustomNSTemplateTierModifier func(*HostAwaitility, *CustomNSTemplateTier) error
+type CustomNSTemplateTierModifier func(*wait.HostAwaitility, *CustomNSTemplateTier) error
 
 type TierTemplateModifier func(*toolchainv1alpha1.TierTemplate) error
 
 func WithClusterResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier, modifiers ...TierTemplateModifier) CustomNSTemplateTierModifier {
-	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
+	return func(hostAwait *wait.HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.ClusterResourcesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
 		tmplRef, err := duplicateTierTemplate(t, hostAwait, otherTier.Namespace, tier.Name, otherTier.Spec.ClusterResources.TemplateRef, modifiers...)
@@ -48,7 +48,7 @@ func WithClusterResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateT
 }
 
 func WithNamespaceResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
-	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
+	return func(hostAwait *wait.HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.NamespaceResourcesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
 		tier.Spec.Namespaces = make([]toolchainv1alpha1.NSTemplateTierNamespace, len(otherTier.Spec.Namespaces))
@@ -64,7 +64,7 @@ func WithNamespaceResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplat
 }
 
 func WithSpaceRoles(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) CustomNSTemplateTierModifier {
-	return func(hostAwait *HostAwaitility, tier *CustomNSTemplateTier) error {
+	return func(hostAwait *wait.HostAwaitility, tier *CustomNSTemplateTier) error {
 		tier.SpaceRolesTier = otherTier
 		// configure the "wrapped" NSTemplateTier
 		tier.Spec.SpaceRoles = make(map[string]toolchainv1alpha1.NSTemplateTierSpaceRole, len(otherTier.Spec.SpaceRoles))
@@ -84,7 +84,7 @@ func WithSpaceRoles(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier) C
 // CreateCustomNSTemplateTier creates a custom tier.
 // If no modifiers provided then the new tier will use copies of the baseTier cluster, namespace and space roles templates
 // without any modifications.
-func CreateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, name string, baseTier *toolchainv1alpha1.NSTemplateTier, modifiers ...CustomNSTemplateTierModifier) *CustomNSTemplateTier {
+func CreateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, name string, baseTier *toolchainv1alpha1.NSTemplateTier, modifiers ...CustomNSTemplateTierModifier) *CustomNSTemplateTier {
 	tier := &CustomNSTemplateTier{
 		NSTemplateTier: &toolchainv1alpha1.NSTemplateTier{
 			ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +118,7 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, name st
 
 // UpdateCustomNSTemplateTier updates the given "tier" using the modifiers
 // returns the latest version of the NSTemplateTier
-func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *CustomNSTemplateTier, modifiers ...CustomNSTemplateTierModifier) *CustomNSTemplateTier {
+func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, tier *CustomNSTemplateTier, modifiers ...CustomNSTemplateTierModifier) *CustomNSTemplateTier {
 	// reload the underlying NSTemplateTier resource before modifying it
 	tmplTier, err := hostAwait.WaitForNSTemplateTier(t, tier.Name)
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *C
 		err := modify(hostAwait, tier)
 		require.NoError(t, err)
 	}
-	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
+	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
 		})
@@ -136,7 +136,7 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *HostAwaitility, tier *C
 	return tier
 }
 
-func duplicateTierTemplate(t *testing.T, hostAwait *HostAwaitility, namespace, tierName, origTemplateRef string, modifiers ...TierTemplateModifier) (string, error) {
+func duplicateTierTemplate(t *testing.T, hostAwait *wait.HostAwaitility, namespace, tierName, origTemplateRef string, modifiers ...TierTemplateModifier) (string, error) {
 	origTierTemplate := &toolchainv1alpha1.TierTemplate{}
 	if err := hostAwait.Client.Get(context.TODO(), test.NamespacedName(hostAwait.Namespace, origTemplateRef), origTierTemplate); err != nil {
 		return "", err
@@ -163,12 +163,12 @@ func duplicateTierTemplate(t *testing.T, hostAwait *HostAwaitility, namespace, t
 	return newTierTemplate.Name, nil
 }
 
-func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierName string) {
+func MoveSpaceToTier(t *testing.T, hostAwait *wait.HostAwaitility, spacename, tierName string) {
 	t.Logf("moving space '%s' to space tier '%s'", spacename, tierName)
 	_, err := hostAwait.WaitForSpace(t, spacename)
 	require.NoError(t, err)
 
-	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
 		Update(spacename, hostAwait.Namespace,
 			func(s *toolchainv1alpha1.Space) {
 				s.Spec.TierName = tierName
@@ -176,12 +176,12 @@ func MoveSpaceToTier(t *testing.T, hostAwait *HostAwaitility, spacename, tierNam
 	require.NoError(t, err)
 }
 
-func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName string) {
+func MoveMURToTier(t *testing.T, hostAwait *wait.HostAwaitility, username, tierName string) {
 	t.Logf("moving masteruserrecord '%s' to user tier '%s'", username, tierName)
 	mur, err := hostAwait.WaitForMasterUserRecord(t, username)
 	require.NoError(t, err)
 
-	_, err = For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
+	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
 		Update(mur.Name, hostAwait.Namespace,
 			func(mur *toolchainv1alpha1.MasterUserRecord) {
 				mur.Spec.TierName = tierName
@@ -189,7 +189,7 @@ func MoveMURToTier(t *testing.T, hostAwait *HostAwaitility, username, tierName s
 	require.NoError(t, err)
 }
 
-func GetDefaultSpaceTierName(t *testing.T, hostAwait *HostAwaitility) string {
+func GetDefaultSpaceTierName(t *testing.T, hostAwait *wait.HostAwaitility) string {
 	toolchainConfig := hostAwait.GetToolchainConfig(t)
 	return configuration.GetString(toolchainConfig.Spec.Host.Tiers.DefaultSpaceTier, "base")
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -172,90 +172,6 @@ func (a *HostAwaitility) GetMasterUserRecord(name string) (*toolchainv1alpha1.Ma
 	return mur, nil
 }
 
-// UpdateMasterUserRecordSpec tries to update the Spec of the given MasterUserRecord
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
-// Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecordSpec(t *testing.T, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
-	return a.UpdateMasterUserRecord(t, false, murName, modifyMur)
-}
-
-// UpdateMasterUserRecordStatus tries to update the Status of the given MasterUserRecord
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
-// Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecordStatus(t *testing.T, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
-	return a.UpdateMasterUserRecord(t, true, murName, modifyMur)
-}
-
-// UpdateMasterUserRecord tries to update the Spec or the Status of the given MasterUserRecord
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and and tries again
-// Returns the updated MasterUserRecord
-func (a *HostAwaitility) UpdateMasterUserRecord(t *testing.T, status bool, murName string, modifyMur func(mur *toolchainv1alpha1.MasterUserRecord)) (*toolchainv1alpha1.MasterUserRecord, error) {
-	var m *toolchainv1alpha1.MasterUserRecord
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshMur := &toolchainv1alpha1.MasterUserRecord{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: murName}, freshMur); err != nil {
-			return true, err
-		}
-
-		modifyMur(freshMur)
-		if status {
-			// Update status
-			if err := a.Client.Status().Update(context.TODO(), freshMur); err != nil {
-				t.Logf("error updating MasterUserRecord.Status '%s': %s. Will retry again...", murName, err.Error())
-				return false, nil
-			}
-		} else if err := a.Client.Update(context.TODO(), freshMur); err != nil {
-			t.Logf("error updating MasterUserRecord.Spec '%s': %s. Will retry again...", murName, err.Error())
-			return false, nil
-		}
-		m = freshMur
-		return true, nil
-	})
-	return m, err
-}
-
-// UpdateSpace tries to update the Spec of the given Space
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
-// Returns the updated Space
-func (a *HostAwaitility) UpdateSpace(t *testing.T, spaceName string, modifySpace func(s *toolchainv1alpha1.Space)) (*toolchainv1alpha1.Space, error) {
-	var s *toolchainv1alpha1.Space
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshSpace := &toolchainv1alpha1.Space{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: spaceName}, freshSpace); err != nil {
-			return true, err
-		}
-		modifySpace(freshSpace)
-		if err := a.Client.Update(context.TODO(), freshSpace); err != nil {
-			t.Logf("error updating Space '%s': %s. Will retry again...", spaceName, err.Error())
-			return false, nil
-		}
-		s = freshSpace
-		return true, nil
-	})
-	return s, err
-}
-
-// UpdateSpaceBinding tries to update the Spec of the given SpaceBinding
-// If it fails with an error (for example if the object has been modified) then it retrieves the latest version and tries again
-// Returns the updated SpaceBinding
-func (a *HostAwaitility) UpdateSpaceBinding(t *testing.T, spaceBindingName string, modifySpaceBinding func(s *toolchainv1alpha1.SpaceBinding)) (*toolchainv1alpha1.SpaceBinding, error) {
-	var s *toolchainv1alpha1.SpaceBinding
-	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		freshSpaceBinding := &toolchainv1alpha1.SpaceBinding{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Namespace, Name: spaceBindingName}, freshSpaceBinding); err != nil {
-			return true, err
-		}
-		modifySpaceBinding(freshSpaceBinding)
-		if err := a.Client.Update(context.TODO(), freshSpaceBinding); err != nil {
-			t.Logf("error updating SpaceBinding '%s': %s. Will retry again...", spaceBindingName, err.Error())
-			return false, nil
-		}
-		s = freshSpaceBinding
-		return true, nil
-	})
-	return s, err
-}
-
 // MasterUserRecordWaitCriterion a struct to compare with an expected MasterUserRecord
 type MasterUserRecordWaitCriterion struct {
 	Match func(*toolchainv1alpha1.MasterUserRecord) bool
@@ -769,7 +685,7 @@ func (a *HostAwaitility) WaitAndVerifyThatUserSignupIsNotCreated(t *testing.T, n
 	}
 }
 
-// WaitForBannedUser waits until there is a BannedUser available with the given email
+// WaitForBannedUser waits until there is a BannedUser available with the given email hash
 func (a *HostAwaitility) WaitForBannedUser(t *testing.T, email string) (*toolchainv1alpha1.BannedUser, error) {
 	t.Logf("waiting for BannedUser for user '%s' in namespace '%s'", email, a.Namespace)
 	var bannedUser *toolchainv1alpha1.BannedUser


### PR DESCRIPTION
# Description
This PR cleans up all the update functions that are very similar to the `Update` generic function, addressing the necessary changes.  

Please, note that I did not clean up `UpdateSpaceBindingRequest` because `UpdateTestUpdateSpaceBindingRequest` returns err when there is an error while updating, it is needed for this [assertion](https://github.com/codeready-toolchain/toolchain-e2e/blob/master/test/e2e/parallel/spacebindingrequest_test.go#L212)

## Issue ticket number and link
[SANDBOX-838](https://issues.redhat.com/browse/SANDBOX-838)