### PR TITLE
KUBESAW-248: Drop NSTemplateTier.Status.Updates field

### DIFF
--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -141,18 +141,6 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cookieUsers, cookieTier)
 	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier)
 
-	// finally, verify the counters in the status.history for both 'cheesecake' and 'cookie' tiers
-	// cheesecake tier
-	// there should be 2 entries in the status.history (1 create + 1 update)
-	verifyStatus(t, hostAwait, "cheesecake", 2)
-
-	// cookie tier
-	// there should be 2 entries in the status.history (1 create + 1 update)
-	verifyStatus(t, hostAwait, "cookie", 2)
-
-	// chocolate tier
-	// there should be 2 entries in the status.history (1 create + 1 update)
-	verifyStatus(t, hostAwait, "chocolate", 2)
 }
 
 func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {
@@ -231,11 +219,6 @@ func setupAccounts(t *testing.T, awaitilities wait.Awaitilities, tier *tiers.Cus
 		tiers.MoveSpaceToTier(t, hostAwait, username, tier.Name)
 	}
 	return userSignups
-}
-
-func verifyStatus(t *testing.T, hostAwait *wait.HostAwaitility, tierName string, expectedCount int) {
-	_, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, tierName, wait.UntilNSTemplateTierStatusUpdates(expectedCount))
-	require.NoError(t, err)
 }
 
 func verifyResourceUpdatesForUserSignups(t *testing.T, hostAwait *wait.HostAwaitility, memberAwaitility *wait.MemberAwaitility, userSignups []*toolchainv1alpha1.UserSignup, tier *tiers.CustomNSTemplateTier) {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -229,10 +229,6 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		err = initHostAwait.WaitUntilBaseNSTemplateTierIsUpdated(t)
 		require.NoError(t, err)
 
-		// check that the default user tier exists and is updated to the current version, an outdated version is applied from deploy/e2e-tests/usertier-base.yaml as
-		// part of the e2e test setup make target for the purpose of verifying the user tier update mechanism on startup of the host operator
-		err = initHostAwait.WaitUntilBaseUserTierIsUpdated(t)
-		require.NoError(t, err)
 	})
 
 	if !IsSecondMemberMode(t) {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -229,6 +229,10 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		err = initHostAwait.WaitUntilBaseNSTemplateTierIsUpdated(t)
 		require.NoError(t, err)
 
+		// check that the default user tier exists and is updated to the current version, an outdated version is applied from deploy/e2e-tests/usertier-base.yaml as
+		// part of the e2e test setup make target for the purpose of verifying the user tier update mechanism on startup of the host operator
+		err = initHostAwait.WaitUntilBaseUserTierIsUpdated(t)
+		require.NoError(t, err)
 	})
 
 	if !IsSecondMemberMode(t) {

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -860,7 +860,7 @@ func (a *HostAwaitility) printUserTierWaitCriterionDiffs(t *testing.T, actual *t
 	t.Log(buf.String())
 }
 
-// UntilUserTierHasDeactivationTimeoutDays verify that the UserTier status.Updates has the specified number of entries
+// UntilUserTierHasDeactivationTimeoutDays verify that the UserTier spec.DeactivationTimeoutDays is equal to the expected nummber
 func UntilUserTierHasDeactivationTimeoutDays(expected int) UserTierWaitCriterion {
 	return UserTierWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.UserTier) bool {
@@ -1011,18 +1011,6 @@ func UntilNSTemplateTierSpec(matcher NSTemplateTierSpecMatcher) NSTemplateTierWa
 		},
 		Diff: func(actual *toolchainv1alpha1.NSTemplateTier) string {
 			return matcher.Diff(actual.Spec)
-		},
-	}
-}
-
-// UntilNSTemplateTierStatusUpdates verify that the NSTemplateTier status.Updates has the specified number of entries
-func UntilNSTemplateTierStatusUpdates(expected int) NSTemplateTierWaitCriterion {
-	return NSTemplateTierWaitCriterion{
-		Match: func(actual *toolchainv1alpha1.NSTemplateTier) bool {
-			return len(actual.Status.Updates) == expected
-		},
-		Diff: func(actual *toolchainv1alpha1.NSTemplateTier) string {
-			return fmt.Sprintf("expected status.updates count %d. Actual: %d", expected, len(actual.Status.Updates))
 		},
 	}
 }


### PR DESCRIPTION
This PR is to remove the NSTemplateTier.Status.Updates field(already optional in API) and its related code since it's not used anywhere

Paired and Related PR
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1115