### PR TITLE
fix(flaky): ensure that the space is always unblocked for its deletion

### DIFF
--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -77,6 +77,8 @@ func TestCreateSpace(t *testing.T) {
 		// then
 		VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
 
+		// ensure that the space is reset back to the original (valid) target cluster
+		// so the cleanup logic can delete the Space
 		var resetOnce sync.Once
 		reset := func() {
 			resetOnce.Do(func() {

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -3,6 +3,7 @@ package parallel
 import (
 	"context"
 	"sort"
+	"sync"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -13,7 +14,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -77,6 +77,18 @@ func TestCreateSpace(t *testing.T) {
 		// then
 		VerifyResourcesProvisionedForSpace(t, awaitilities, space.Name)
 
+		var resetOnce sync.Once
+		reset := func() {
+			resetOnce.Do(func() {
+				_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
+					Update(space.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
+						s.Spec.TargetCluster = memberAwait.ClusterName
+					})
+				require.NoError(t, err)
+			})
+		}
+		defer reset()
+
 		t.Run("unable to delete space that was already provisioned", func(t *testing.T) {
 			// given
 			s, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
@@ -97,11 +109,7 @@ func TestCreateSpace(t *testing.T) {
 
 			t.Run("update target cluster to unblock deletion", func(t *testing.T) {
 				// when
-				s, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.Space{}).
-					Update(s.Name, hostAwait.Namespace, func(s *toolchainv1alpha1.Space) {
-						s.Spec.TargetCluster = memberAwait.ClusterName
-					})
-				require.NoError(t, err)
+				reset()
 
 				// then
 				// space should be finally deleted


### PR DESCRIPTION
make sure that the space is unblocked for the cleanup, even for the cases when the test execution is stopped in the middle and the sub-test (that is supposed to unblock the space) is not triggered: https://redhat-internal.slack.com/archives/C06MJ2DVBU4/p1736342796950679?thread_ts=1736333943.812749&cid=C06MJ2DVBU4