### PR TITLE
change deploy-single-member-e2e to deploy-single-member-e2e-latest

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -153,7 +153,7 @@ All e2e resources (host operator, member operator, registration-service, CRDs, e
 
 * `make dev-deploy-e2e` - deploys the same resources as `make test-e2e` in dev environment but doesn't run tests.
 
-* `make deploy-single-member-e2e` - deploys the same resources as `make test-e2e` but with only one member and doesn't run tests.
+* `make deploy-single-member-e2e-latest` - deploys the same resources (using the latest and greatest images of Toolchain operators) as `make test-e2e` but with only one member and doesn't run tests.
 
 NOTE: By default these targets deploy resources to `toolchain-host-operator` and `toolchain-member-operator` namespaces.
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -267,10 +267,10 @@ setup-toolchainclusters: ksctl
 	if [[ ${SECOND_MEMBER_MODE} == true ]]; then ${KSCTL_BIN_DIR}ksctl adm register-member --host-ns="$(HOST_NS)" --member-ns="$(MEMBER_NS_2)" --host-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" --member-kubeconfig="$(or ${KUBECONFIG}, ${HOME}/.kube/config)" ${KSCTL_TLS_VERIFY_PARAM} --name-suffix="2" -y ; fi
 
 
-.PHONY: deploy-single-member-e2e
-## Deploy operators in e2e mode with single member without running tests
-deploy-single-member-e2e: 
-	$(MAKE) prepare-and-deploy-e2e SECOND_MEMBER_MODE=false HOST_NS=${DEFAULT_HOST_NS} MEMBER_NS=${DEFAULT_MEMBER_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS}
+.PHONY: deploy-single-member-e2e-latest
+## Deploy operators using the latest and greatest images of Toolchain operators in e2e mode with single member without running tests
+deploy-single-member-e2e-latest: 
+	$(MAKE) prepare-and-deploy-e2e SECOND_MEMBER_MODE=false HOST_NS=${DEFAULT_HOST_NS} MEMBER_NS=${DEFAULT_MEMBER_NS} REGISTRATION_SERVICE_NS=${DEFAULT_HOST_NS} DEPLOY_LATEST=true
 
 
 ###########################################################


### PR DESCRIPTION
# Description
`deploy-single-member-e2e` was added to be used in wa. Since we do not need a pairing mechanism there, we can simply use the latest and greatest images of Toolchain operators


## Issue ticket number and link
[SANDBOX-812](https://issues.redhat.com/browse/SANDBOX-812)