### PR TITLE
fix kube-root-ca.crt not found

### DIFF
--- a/testsupport/wait/awaitility.go
+++ b/testsupport/wait/awaitility.go
@@ -416,23 +416,12 @@ func (a *Awaitility) CreateNamespace(t *testing.T, name string) {
 			Name: name,
 		},
 	}
-	err := a.Client.Create(context.TODO(), ns)
+	err := a.CreateWithCleanup(t, ns)
 	require.NoError(t, err)
-	err = wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (done bool, err error) {
-		ns := &corev1.Namespace{}
-		if err := a.Client.Get(context.TODO(), types.NamespacedName{Name: name}, ns); err != nil && apierrors.IsNotFound(err) {
-			return false, nil
-		} else if err != nil {
-			return false, err
-		}
-		return ns.Status.Phase == corev1.NamespaceActive, nil
+	_, err = For(t, a, &corev1.Namespace{}).WithNameMatching(name, func(c *corev1.Namespace) bool {
+		return ns.Status.Phase == corev1.NamespaceActive
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := a.Client.Delete(context.TODO(), ns); err != nil && !apierrors.IsNotFound(err) {
-			require.NoError(t, err)
-		}
-	})
 }
 
 // WaitForDeploymentToGetReady waits until the deployment with the given name is ready together with the given number of replicas
@@ -730,6 +719,22 @@ func (w *Waiter[T]) FirstThat(predicates ...assertions.Predicate[client.Object])
 		w.t.Logf(sb.String(), args...)
 	}
 	return returnedObject, err
+}
+
+// WithNameMatching waits for a single object with the provided name in the namespace of the awaitality that additionally
+// matches the provided predicate function.
+func (w *Waiter[T]) WithNameMatching(name string, predicate func(T) bool) (T, error) {
+	return w.WithNameThat(name, &customPredicate[T]{
+		predicate: predicate,
+	})
+}
+
+type customPredicate[T client.Object] struct {
+	predicate func(T) bool
+}
+
+func (p *customPredicate[T]) Matches(object client.Object) bool {
+	return p.predicate(object.(T))
 }
 
 // WithNameThat waits for a single object with the provided name in the namespace of the awaitality that additionally


### PR DESCRIPTION
create our own ConfigMap and check that it exists to avoid any flakiness that we faced in many e2e tests before

wrt - [SANDBOX-836](https://issues.redhat.com/browse/SANDBOX-836)