### PR TITLE
KUBESAW-147: Space controller updates tier-hash label based on the NSTemplateTier.Status.Revisions field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1

--- a/go.mod
+++ b/go.mod
@@ -130,4 +130,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd
+
 go 1.21

--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,6 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd
-
 go 1.21
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1

--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,4 @@ require (
 
 go 1.21
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20250131223755-a9c24d874b32
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20250225125153-139ef30bbd6d
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.15.0
 	github.com/ghodss/yaml v1.0.0
@@ -131,5 +131,3 @@ require (
 )
 
 go 1.21
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1 h1:MeSRqFQY4U7tdPOpyHM4NUEaDiWovCxsmlvDZk6Yc5s=
-github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d h1:JFp6ZpoQNteTULtSZU97SkAYt7yUyiAR6QlXO/F40Sw=
+github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429 h1:I7xzHRmstvzucH9NqF54xvsM/yYuWOp/G5+BUr5j4tY=
 github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250131223755-a9c24d874b32 h1:mX8aMYw9yPCSZuRNeZwShOPQDl0aTKV9FcEfb1Sdhiw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250131223755-a9c24d874b32/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -177,6 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd h1:J7+2CJOdD0zNEoKiLsogmQ6sgi4enS+KgBk4ZmJm5Wc=
+github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429 h1:I7xzHRmstvzucH9NqF54xvsM/yYuWOp/G5+BUr5j4tY=
 github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250225125153-139ef30bbd6d h1:iEUmJ9XB7Q6BUWG76ocuECZBPIY2wDxQhAXTAW3CM8g=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250225125153-139ef30bbd6d/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -175,8 +177,6 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1 h1:GKf+ilZj/yuzerN92EXYv0CY2Pm4t2Ny4lBvCX2BVMU=
-github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e h1:/q2mG9f+aRTW1L3K8wpVrrlF8dmvDX9JXEVhoAoZjLA=
-github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1 h1:GKf+ilZj/yuzerN92EXYv0CY2Pm4t2Ny4lBvCX2BVMU=
+github.com/fbm3307/toolchain-common v0.0.0-20250220120644-6801b14609a1/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d h1:JFp6ZpoQNteTULtSZU97SkAYt7yUyiAR6QlXO/F40Sw=
-github.com/fbm3307/toolchain-common v0.0.0-20250218092615-904368a04d1d/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e h1:/q2mG9f+aRTW1L3K8wpVrrlF8dmvDX9JXEVhoAoZjLA=
+github.com/fbm3307/toolchain-common v0.0.0-20250219102514-e40790d4c60e/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8 h1:7TZ8mMJ8cJp9XiYoI1F6LS+1WWcaZbvdIsi/iT231q0=
-github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1 h1:MeSRqFQY4U7tdPOpyHM4NUEaDiWovCxsmlvDZk6Yc5s=
+github.com/fbm3307/toolchain-common v0.0.0-20250213115635-08fe47f6bea1/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d h1:/qkmS/0KJrowFfMHCqgZjeiY5aErTuyp7ut2Qi+Sdpo=
-github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8 h1:7TZ8mMJ8cJp9XiYoI1F6LS+1WWcaZbvdIsi/iT231q0=
+github.com/fbm3307/toolchain-common v0.0.0-20250210091950-b4f865b966e8/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd h1:J7+2CJOdD0zNEoKiLsogmQ6sgi4enS+KgBk4ZmJm5Wc=
-github.com/fbm3307/toolchain-common v0.0.0-20250204103153-96b3936ca3dd/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451 h1:CgBh6BucjNdwUpGocGxEoXmWJjmsYfL2nQWdbA6yxwM=
+github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451 h1:CgBh6BucjNdwUpGocGxEoXmWJjmsYfL2nQWdbA6yxwM=
-github.com/fbm3307/toolchain-common v0.0.0-20250206071242-14a81cf9b451/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
+github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d h1:/qkmS/0KJrowFfMHCqgZjeiY5aErTuyp7ut2Qi+Sdpo=
+github.com/fbm3307/toolchain-common v0.0.0-20250207061421-f27914eef71d/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -113,20 +113,8 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	// create new NSTemplateTiers (derived from `base`)
 	cheesecakeTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cheesecake", baseTier)
-	newCheese, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
-	cheesecakeTier.NSTemplateTier = newCheese
-	require.NoError(t, err)
 	cookieTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cookie", baseTier)
-	newCookie, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
-	cookieTier.NSTemplateTier = newCookie
-	require.NoError(t, err)
 	chocolateTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "chocolate", baseTier)
-	newChocolate, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
-	chocolateTier.NSTemplateTier = newChocolate
-	require.NoError(t, err)
 
 	// first group of users: the "cheesecake users"
 	cheesecakeUsers := setupAccounts(t, awaitilities, cheesecakeTier, "cheesecakeuser%02d", memberAwait, count)
@@ -142,31 +130,17 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	t.Log("updating tiers")
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources and spaceroles
-	cheesecakeTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
-	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier1.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
-	require.NoError(t, err)
-	cheesecakeTier1.NSTemplateTier = newCheeseCake
-
+	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
-	cookieTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
-	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier1.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
-	require.NoError(t, err)
-	cookieTier1.NSTemplateTier = newCookieTier
-
+	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
 	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
-	chocolateTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
-	newChocoTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier1.Name,
-		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
-	require.NoError(t, err)
-	chocolateTier1.NSTemplateTier = newChocoTier
+	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
 
 	// then
 	t.Log("verifying users and spaces after tier updates")
-	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cheesecakeUsers, cheesecakeTier1)
-	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cookieUsers, cookieTier1)
-	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier1)
+	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cheesecakeUsers, cheesecakeTier)
+	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cookieUsers, cookieTier)
+	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier)
 }
 
 func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -142,31 +142,31 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	t.Log("updating tiers")
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources and spaceroles
-	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
-	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name,
+	cheesecakeTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
+	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier1.Name,
 		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
 	require.NoError(t, err)
-	cheesecakeTier.NSTemplateTier = newCheeseCake
+	cheesecakeTier1.NSTemplateTier = newCheeseCake
 
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
-	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
-	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name,
+	cookieTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
+	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier1.Name,
 		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
 	require.NoError(t, err)
-	cookieTier.NSTemplateTier = newCookieTier
+	cookieTier1.NSTemplateTier = newCookieTier
 
 	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
-	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
-	newChocoTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name,
+	chocolateTier1 := tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
+	newChocoTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier1.Name,
 		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
 	require.NoError(t, err)
-	chocolateTier.NSTemplateTier = newChocoTier
+	chocolateTier1.NSTemplateTier = newChocoTier
 
 	// then
 	t.Log("verifying users and spaces after tier updates")
-	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cheesecakeUsers, cheesecakeTier)
-	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cookieUsers, cookieTier)
-	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier)
+	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cheesecakeUsers, cheesecakeTier1)
+	verifyResourceUpdatesForUserSignups(t, hostAwait, memberAwait, cookieUsers, cookieTier1)
+	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier1)
 }
 
 func TestResetDeactivatingStateWhenPromotingUser(t *testing.T) {

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -117,7 +117,6 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	cookieTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cookie", baseTier)
 	chocolateTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "chocolate", baseTier)
 
-	cheesecakeTier.Status.Revisions = map[string]string{}
 	// first group of users: the "cheesecake users"
 	cheesecakeUsers := setupAccounts(t, awaitilities, cheesecakeTier, "cheesecakeuser%02d", memberAwait, count)
 	// second group of users: the "cookie users"

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -138,12 +138,21 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier)
 
 	t.Log("updating tiers")
-	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources
+	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources and spaceroles
 	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
+	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, cheesecakeTier.Name).Flatten()))
+	cheesecakeTier.NSTemplateTier = newCheeseCake
+	require.NoError(t, err)
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
 	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
+	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, cookieTier.Name).Flatten()))
+	cookieTier.NSTemplateTier = newCookieTier
+	require.NoError(t, err)
 	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
 	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
+	newChocolateTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, chocolateTier.Name).Flatten()))
+	chocolateTier.NSTemplateTier = newChocolateTier
+	require.NoError(t, err)
 
 	// then
 	t.Log("verifying users and spaces after tier updates")

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -495,6 +495,7 @@ func TestTierTemplateRevision(t *testing.T) {
 			wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "updatingtier").Flatten()))
 		require.NoError(t, err)
 		updatingTier.NSTemplateTier = tier
+		revisionsBeforeUpdate := updatingTier.Status.Revisions
 		// and we update the tier with the "advanced" template refs for namespace and space role resources
 		tiers.UpdateCustomNSTemplateTier(t, hostAwait, updatingTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
 
@@ -513,7 +514,7 @@ func TestTierTemplateRevision(t *testing.T) {
 			wait.HasStatusTierTemplateRevisions(expectedRefs))
 		require.NoError(t, err)
 		// revisions values should be different compared to the previous ones
-		assert.NotEqual(t, updatingTier.Status.Revisions, updatedTier.Status.Revisions)
+		assert.NotEqual(t, revisionsBeforeUpdate, updatedTier.Status.Revisions)
 	})
 
 }

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -288,11 +288,8 @@ func TestFeatureToggles(t *testing.T) {
 			withClusterRoleBindings(t, base1nsTier, "test-feature"),
 			tiers.WithNamespaceResources(t, base1nsTier),
 			tiers.WithSpaceRoles(t, base1nsTier))
-		newTierRv, err := hostAwait.WaitForNSTemplateTier(t, tier.Name,
-			wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "ftier").Flatten()))
+		_, err := hostAwait.WaitForNSTemplateTier(t, tier.Name)
 		require.NoError(t, err)
-		tier.NSTemplateTier = newTierRv
-
 		// when
 
 		// Now let's create a Space

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -117,6 +117,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	cookieTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cookie", baseTier)
 	chocolateTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "chocolate", baseTier)
 
+	cheesecakeTier.Status.Revisions = map[string]string{}
 	// first group of users: the "cheesecake users"
 	cheesecakeUsers := setupAccounts(t, awaitilities, cheesecakeTier, "cheesecakeuser%02d", memberAwait, count)
 	// second group of users: the "cookie users"

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -113,15 +113,18 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	// create new NSTemplateTiers (derived from `base`)
 	cheesecakeTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cheesecake", baseTier)
-	newCheese, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
+	newCheese, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
 	cheesecakeTier.NSTemplateTier = newCheese
 	require.NoError(t, err)
 	cookieTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cookie", baseTier)
-	newCookie, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
+	newCookie, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
 	cookieTier.NSTemplateTier = newCookie
 	require.NoError(t, err)
 	chocolateTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "chocolate", baseTier)
-	newChocolate, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
+	newChocolate, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
 	chocolateTier.NSTemplateTier = newChocolate
 	require.NoError(t, err)
 
@@ -140,19 +143,24 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	t.Log("updating tiers")
 	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources and spaceroles
 	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
-	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, cheesecakeTier.Name).Flatten()))
-	cheesecakeTier.NSTemplateTier = newCheeseCake
+	newCheeseCake, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
 	require.NoError(t, err)
+	cheesecakeTier.NSTemplateTier = newCheeseCake
+
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
 	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
-	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, cookieTier.Name).Flatten()))
-	cookieTier.NSTemplateTier = newCookieTier
+	newCookieTier, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
 	require.NoError(t, err)
+	cookieTier.NSTemplateTier = newCookieTier
+
 	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
 	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
-	newChocolateTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, chocolateTier.Name).Flatten()))
-	chocolateTier.NSTemplateTier = newChocolateTier
+	newChocoTier, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name,
+		wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
 	require.NoError(t, err)
+	chocolateTier.NSTemplateTier = newChocoTier
 
 	// then
 	t.Log("verifying users and spaces after tier updates")
@@ -306,9 +314,10 @@ func TestFeatureToggles(t *testing.T) {
 			withClusterRoleBindings(t, base1nsTier, "test-feature"),
 			tiers.WithNamespaceResources(t, base1nsTier),
 			tiers.WithSpaceRoles(t, base1nsTier))
-		newTierRv, err := hostAwait.WaitForNSTemplateTier(t, tier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "ftier").Flatten()))
-		tier.NSTemplateTier = newTierRv
+		newTierRv, err := hostAwait.WaitForNSTemplateTier(t, tier.Name,
+			wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "ftier").Flatten()))
 		require.NoError(t, err)
+		tier.NSTemplateTier = newTierRv
 
 		// when
 

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -113,8 +113,17 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	// create new NSTemplateTiers (derived from `base`)
 	cheesecakeTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cheesecake", baseTier)
+	newCheese, err := hostAwait.WaitForNSTemplateTier(t, cheesecakeTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cheesecake").Flatten()))
+	cheesecakeTier.NSTemplateTier = newCheese
+	require.NoError(t, err)
 	cookieTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "cookie", baseTier)
+	newCookie, err := hostAwait.WaitForNSTemplateTier(t, cookieTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "cookie").Flatten()))
+	cookieTier.NSTemplateTier = newCookie
+	require.NoError(t, err)
 	chocolateTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "chocolate", baseTier)
+	newChocolate, err := hostAwait.WaitForNSTemplateTier(t, chocolateTier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "chocolate").Flatten()))
+	chocolateTier.NSTemplateTier = newChocolate
+	require.NoError(t, err)
 
 	// first group of users: the "cheesecake users"
 	cheesecakeUsers := setupAccounts(t, awaitilities, cheesecakeTier, "cheesecakeuser%02d", memberAwait, count)
@@ -288,7 +297,8 @@ func TestFeatureToggles(t *testing.T) {
 			withClusterRoleBindings(t, base1nsTier, "test-feature"),
 			tiers.WithNamespaceResources(t, base1nsTier),
 			tiers.WithSpaceRoles(t, base1nsTier))
-		_, err := hostAwait.WaitForNSTemplateTier(t, tier.Name)
+		newTierRv, err := hostAwait.WaitForNSTemplateTier(t, tier.Name, wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "ftier").Flatten()))
+		tier.NSTemplateTier = newTierRv
 		require.NoError(t, err)
 
 		// when

--- a/testsupport/space/space.go
+++ b/testsupport/space/space.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	testspace "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
-	testtier "github.com/codeready-toolchain/toolchain-common/pkg/test/tier"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	testsupportsb "github.com/codeready-toolchain/toolchain-e2e/testsupport/spacebinding"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,7 +122,7 @@ func VerifyResourcesProvisionedForSpaceWithCustomTier(t *testing.T, hostAwait *w
 }
 
 func verifyResourcesProvisionedForSpace(t *testing.T, hostAwait *wait.HostAwaitility, targetCluster *wait.MemberAwaitility, spaceName string, tier *toolchainv1alpha1.NSTemplateTier, checks tiers.TierChecks) (*toolchainv1alpha1.Space, *toolchainv1alpha1.NSTemplateSet) {
-	hash, err := testtier.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
+	hash, err := hash.ComputeHashForNSTemplateTier(tier)
 	require.NoError(t, err)
 
 	// wait for space to be fully provisioned

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -41,7 +41,7 @@ func WithClusterResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateT
 			return err
 		}
 		tier.Spec.ClusterResources = &toolchainv1alpha1.NSTemplateTierClusterResources{
-			TemplateRef: tmplRef,
+			TemplateRef: tier.Status.Revisions[tmplRef],
 		}
 		return nil
 	}
@@ -57,7 +57,7 @@ func WithNamespaceResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplat
 			if err != nil {
 				return err
 			}
-			tier.Spec.Namespaces[i].TemplateRef = tmplRef
+			tier.Spec.Namespaces[i].TemplateRef = tier.Status.Revisions[tmplRef]
 		}
 		return nil
 	}
@@ -74,7 +74,7 @@ func WithSpaceRoles(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier, m
 				return err
 			}
 			tier.Spec.SpaceRoles[name] = toolchainv1alpha1.NSTemplateTierSpaceRole{
-				TemplateRef: tmplRef,
+				TemplateRef: tier.Status.Revisions[tmplRef],
 			}
 		}
 		return nil
@@ -109,6 +109,9 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, na
 			},
 			Spec: toolchainv1alpha1.NSTemplateTierSpec{
 				// default values
+			},
+			Status: toolchainv1alpha1.NSTemplateTierStatus{
+				//default values
 			},
 		},
 	}
@@ -146,6 +149,7 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, ti
 	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
+			nstt.Status.Revisions = tier.Status.Revisions
 		})
 	require.NoError(t, err)
 	return tier

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -110,9 +110,6 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, na
 			Spec: toolchainv1alpha1.NSTemplateTierSpec{
 				// default values
 			},
-			Status: toolchainv1alpha1.NSTemplateTierStatus{
-				//default values
-			},
 		},
 	}
 	if len(modifiers) == 0 {
@@ -149,7 +146,7 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, ti
 	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
-			nstt.Status.Revisions = tier.Status.Revisions
+
 		})
 	require.NoError(t, err)
 	return tier

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -146,7 +146,6 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, ti
 	_, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
 			nstt.Spec = tier.NSTemplateTier.Spec
-
 		})
 	require.NoError(t, err)
 	return tier

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -41,7 +41,7 @@ func WithClusterResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateT
 			return err
 		}
 		tier.Spec.ClusterResources = &toolchainv1alpha1.NSTemplateTierClusterResources{
-			TemplateRef: tier.Status.Revisions[tmplRef],
+			TemplateRef: tmplRef,
 		}
 		return nil
 	}
@@ -57,7 +57,7 @@ func WithNamespaceResources(t *testing.T, otherTier *toolchainv1alpha1.NSTemplat
 			if err != nil {
 				return err
 			}
-			tier.Spec.Namespaces[i].TemplateRef = tier.Status.Revisions[tmplRef]
+			tier.Spec.Namespaces[i].TemplateRef = tmplRef
 		}
 		return nil
 	}
@@ -74,7 +74,7 @@ func WithSpaceRoles(t *testing.T, otherTier *toolchainv1alpha1.NSTemplateTier, m
 				return err
 			}
 			tier.Spec.SpaceRoles[name] = toolchainv1alpha1.NSTemplateTierSpaceRole{
-				TemplateRef: tier.Status.Revisions[tmplRef],
+				TemplateRef: tmplRef,
 			}
 		}
 		return nil

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -137,6 +137,10 @@ func CreateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, na
 	}
 	err := hostAwait.CreateWithCleanup(t, tier.NSTemplateTier)
 	require.NoError(t, err)
+	newTTier, err := hostAwait.WaitForNSTemplateTier(t, tier.Name,
+		wait.HasStatusTierTemplateRevisions(GetTemplateRefs(t, hostAwait, tier.Name).Flatten()))
+	require.NoError(t, err)
+	tier.NSTemplateTier = newTTier
 	return tier
 }
 
@@ -157,6 +161,10 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, ti
 			nstt.Spec = tier.NSTemplateTier.Spec
 		})
 	require.NoError(t, err)
+	newTTier, err := hostAwait.WaitForNSTemplateTier(t, tier.Name,
+		wait.HasStatusTierTemplateRevisions(GetTemplateRefs(t, hostAwait, tier.Name).Flatten()))
+	require.NoError(t, err)
+	tier.NSTemplateTier = newTTier
 	return tier
 }
 

--- a/testsupport/user_assertions.go
+++ b/testsupport/user_assertions.go
@@ -11,8 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	identitypkg "github.com/codeready-toolchain/toolchain-common/pkg/identity"
-	testtier "github.com/codeready-toolchain/toolchain-common/pkg/test/tier"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/tiers"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
 
@@ -237,7 +237,7 @@ func VerifySpaceRelatedResources(t *testing.T, awaitilities wait.Awaitilities, u
 
 	tier, err := hostAwait.WaitForNSTemplateTier(t, spaceTierName)
 	require.NoError(t, err)
-	hash, err := testtier.ComputeTemplateRefsHash(tier) // we can assume the JSON marshalling will always work
+	hash, err := hash.ComputeHashForNSTemplateTier(tier) // we can assume the JSON marshalling will always work
 	require.NoError(t, err)
 
 	space, err := hostAwait.WaitForSpace(t, userSignup.Status.CompliantUsername,


### PR DESCRIPTION
This PR is to update the space controller to compute the tier-hash label value using the NSTemplateTier.Status.Revisions field so that it can match outdated spaces using the new revisions mechanism.

Jira-Link - [KUBESAW-147](https://issues.redhat.com/browse/KUBESAW-147)

Related PR
- Toolchain-commmon - https://github.com/codeready-toolchain/toolchain-common/pull/454

Paired with 
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1135