### PR TITLE
fix: panic for concurrent writing in parallel test (scheme)

### DIFF
--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -23,6 +23,7 @@ import (
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -279,6 +280,7 @@ func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
 		userv1.AddToScheme,
 		netv1.AddToScheme,
 		admv1.AddToScheme,
+		batchv1.AddToScheme,
 	)
 	require.NoError(t, builder.AddToScheme(s))
 	return s

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -20,6 +20,7 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -259,7 +260,7 @@ func getMemberAwaitility(t *testing.T, hostAwait *wait.HostAwaitility, restconfi
 }
 
 func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	builder := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme,
 		userv1.Install,
 		templatev1.Install,
@@ -270,6 +271,7 @@ func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
 		metrics.AddToScheme,
 		appstudiov1.AddToScheme,
 		rbacv1.AddToScheme,
+		appsv1.AddToScheme,
 	)
 	require.NoError(t, builder.AddToScheme(s))
 	return s

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -259,7 +259,7 @@ func getMemberAwaitility(t *testing.T, hostAwait *wait.HostAwaitility, restconfi
 }
 
 func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	builder := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme,
 		userv1.Install,
 		templatev1.Install,

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -20,10 +20,13 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -272,6 +275,10 @@ func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
 		appstudiov1.AddToScheme,
 		rbacv1.AddToScheme,
 		appsv1.AddToScheme,
+		schedulingv1.AddToScheme,
+		userv1.AddToScheme,
+		netv1.AddToScheme,
+		admv1.AddToScheme,
 	)
 	require.NoError(t, builder.AddToScheme(s))
 	return s

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -18,6 +18,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 	userv1 "github.com/openshift/api/user/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admv1 "k8s.io/api/admissionregistration/v1"
@@ -281,6 +282,7 @@ func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
 		netv1.AddToScheme,
 		admv1.AddToScheme,
 		batchv1.AddToScheme,
+		operatorsv1alpha1.AddToScheme,
 	)
 	require.NoError(t, builder.AddToScheme(s))
 	return s

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -259,7 +259,7 @@ func getMemberAwaitility(t *testing.T, hostAwait *wait.HostAwaitility, restconfi
 }
 
 func schemeWithAllAPIs(t *testing.T) *runtime.Scheme {
-	s := runtime.NewScheme()
+	s := scheme.Scheme
 	builder := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme,
 		userv1.Install,
 		templatev1.Install,

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1734,7 +1733,7 @@ func (a *HostAwaitility) CreateAPIProxyConfig(t *testing.T, usertoken, proxyURL 
 func (a *HostAwaitility) CreateAPIProxyClient(t *testing.T, userToken, proxyURL string) (client.Client, error) {
 	proxyKubeConfig := a.CreateAPIProxyConfig(t, userToken, proxyURL)
 
-	s := scheme.Scheme
+	s := runtime.NewScheme()
 	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme)
 	require.NoError(t, builder.AddToScheme(s))
 

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -24,6 +24,7 @@ import (
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1828,7 +1829,7 @@ func (a *HostAwaitility) CreateAPIProxyClient(t *testing.T, userToken, proxyURL 
 	proxyKubeConfig := a.CreateAPIProxyConfig(t, userToken, proxyURL)
 
 	s := runtime.NewScheme()
-	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme, appsv1.AddToScheme)
 	require.NoError(t, builder.AddToScheme(s))
 
 	// Getting the proxy client can fail from time to time if the proxy's informer cache has not been

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -16,17 +16,28 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	appstudiov1 "github.com/codeready-toolchain/toolchain-e2e/testsupport/appstudio/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/cleanup"
 	testutil "github.com/codeready-toolchain/toolchain-e2e/testsupport/util"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	quotav1 "github.com/openshift/api/quota/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	templatev1 "github.com/openshift/api/template/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	goerr "github.com/pkg/errors"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/metrics/pkg/apis/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1829,7 +1841,26 @@ func (a *HostAwaitility) CreateAPIProxyClient(t *testing.T, userToken, proxyURL 
 	proxyKubeConfig := a.CreateAPIProxyConfig(t, userToken, proxyURL)
 
 	s := runtime.NewScheme()
-	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme, appsv1.AddToScheme)
+	builder := append(runtime.SchemeBuilder{}, corev1.AddToScheme,
+		appsv1.AddToScheme,
+		toolchainv1alpha1.AddToScheme,
+		userv1.Install,
+		templatev1.Install,
+		routev1.Install,
+		quotav1.Install,
+		openshiftappsv1.Install,
+		corev1.AddToScheme,
+		metrics.AddToScheme,
+		appstudiov1.AddToScheme,
+		v1.AddToScheme,
+		appsv1.AddToScheme,
+		schedulingv1.AddToScheme,
+		userv1.AddToScheme,
+		netv1.AddToScheme,
+		admv1.AddToScheme,
+		batchv1.AddToScheme,
+		operatorsv1alpha1.AddToScheme,
+	)
 	require.NoError(t, builder.AddToScheme(s))
 
 	// Getting the proxy client can fail from time to time if the proxy's informer cache has not been


### PR DESCRIPTION
This PR is for the fix of e2e [Failures](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/codeready-toolchain_host-operator/1130/pull-ci-codeready-toolchain-host-operator-master-e2e/1887805053301952512/build-log.txt) .

The parallel e2e test are making concurrent writes to the global `Scheme` variable, used in the package `testsupport/wait` .

This PR ensures that a new Scheme is always used instead of the global one.
