### PR TITLE
feat: cleanup revision entries from nstemplatetier

### DIFF
--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -469,6 +469,41 @@ func TestTierTemplateRevision(t *testing.T) {
 
 	})
 
+	t.Run("when updating one tiertemplate the revisions field should be cleaned up from old entries", func(t *testing.T) {
+		// given
+		// we create new NSTemplateTiers (derived from `base`)
+		updatingTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "updatingtier", baseTier)
+		// we use the advanced tier only for copying the namespace and space role resources
+		advancedTier, err := hostAwait.WaitForNSTemplateTier(t, "advanced")
+		require.NoError(t, err)
+
+		// when
+		// we verify that the new tier exists and the revisions field was populated
+		tier, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, "updatingtier",
+			wait.HasStatusTierTemplateRevisions(tiers.GetTemplateRefs(t, hostAwait, "updatingtier").Flatten()))
+		require.NoError(t, err)
+		updatingTier.NSTemplateTier = tier
+		// and we update the tier with the "advanced" template refs for namespace and space role resources
+		tiers.UpdateCustomNSTemplateTier(t, hostAwait, updatingTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
+
+		// then
+		// we ensure the new revisions are made by namespace and spaceroles from advanced tier + clusterResources from the updating tier
+		advancedRefs := tiers.GetTemplateRefs(t, hostAwait, advancedTier.Name)
+		expectedRefs := []string{updatingTier.Spec.ClusterResources.TemplateRef}
+		// the duplicated tiertemplates have a different prefix
+		for _, tierTemplateName := range advancedRefs.SpaceRolesFlatten() {
+			expectedRefs = append(expectedRefs, tiers.DuplicatedTierName(updatingTier.Name, tierTemplateName))
+		}
+		for _, tierTemplateName := range advancedRefs.Namespaces {
+			expectedRefs = append(expectedRefs, tiers.DuplicatedTierName(updatingTier.Name, tierTemplateName))
+		}
+		updatedTier, err := hostAwait.WaitForNSTemplateTierAndCheckTemplates(t, "updatingtier",
+			wait.HasStatusTierTemplateRevisions(expectedRefs))
+		require.NoError(t, err)
+		// revisions values should be different compared to the previous ones
+		assert.NotEqual(t, updatingTier.Status.Revisions, updatedTier.Status.Revisions)
+	})
+
 }
 
 func getTestCRQ(podsCount string) unstructured.Unstructured {

--- a/testsupport/tiers/templaterefs.go
+++ b/testsupport/tiers/templaterefs.go
@@ -46,6 +46,14 @@ func (r TemplateRefs) Flatten() []string {
 	return refs
 }
 
+func (r TemplateRefs) SpaceRolesFlatten() []string {
+	refs := make([]string, 0, len(r.SpaceRoles))
+	for _, ref := range r.SpaceRoles {
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
 func clusterResourcesRevision(tier toolchainv1alpha1.NSTemplateTier) *string {
 	if tier.Spec.ClusterResources != nil {
 		return &(tier.Spec.ClusterResources.TemplateRef)

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -168,7 +168,7 @@ func duplicateTierTemplate(t *testing.T, hostAwait *wait.HostAwaitility, namespa
 	newTierTemplate := &toolchainv1alpha1.TierTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      fmt.Sprintf("%sfrom%s", tierName, origTierTemplate.Name),
+			Name:      DuplicatedTierName(tierName, origTierTemplate.Name),
 			Labels:    map[string]string{"producer": "toolchain-e2e"},
 		},
 		Spec: origTierTemplate.Spec,
@@ -185,6 +185,10 @@ func duplicateTierTemplate(t *testing.T, hostAwait *wait.HostAwaitility, namespa
 		}
 	}
 	return newTierTemplate.Name, nil
+}
+
+func DuplicatedTierName(tierName, origTierTemplateName string) string {
+	return fmt.Sprintf("%sfrom%s", tierName, origTierTemplateName)
 }
 
 func MoveSpaceToTier(t *testing.T, hostAwait *wait.HostAwaitility, spacename, tierName string) {

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1154,7 +1154,7 @@ func HasStatusTierTemplateRevisions(revisions []string) NSTemplateTierWaitCriter
 				return false
 			}
 			for _, tierTemplateRef := range revisions {
-				if _, found := actual.Status.Revisions[tierTemplateRef]; !found {
+				if value, found := actual.Status.Revisions[tierTemplateRef]; !found || value == "" {
 					return false
 				}
 			}


### PR DESCRIPTION
e2e tests for : https://github.com/codeready-toolchain/host-operator/pull/1136

Jira:  https://issues.redhat.com/browse/KUBESAW-259