### PR TITLE
reduce amount of logs during cleanup

### DIFF
--- a/testsupport/cleanup/clean.go
+++ b/testsupport/cleanup/clean.go
@@ -202,7 +202,7 @@ func (c *cleanTask) verifyMurDeleted(isUserSignup bool, userSignup *toolchainv1a
 			if err := c.client.Get(context.TODO(), test.NamespacedName(userSignup.GetNamespace(), userSignup.Status.CompliantUsername), mur); err != nil {
 				// if MUR is not found then we are good
 				if errors.IsNotFound(err) {
-					c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
+					// c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
 					return true, nil
 				}
 				c.t.Logf("problem with getting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)
@@ -212,7 +212,7 @@ func (c *cleanTask) verifyMurDeleted(isUserSignup bool, userSignup *toolchainv1a
 				c.t.Logf("deleting also the related MasterUserRecord: %s", userSignup.Status.CompliantUsername)
 				if err := c.client.Delete(context.TODO(), mur, propagationPolicyOpts); err != nil {
 					if errors.IsNotFound(err) {
-						c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
+						// c.t.Logf("the related MasterUserRecord: %s is deleted as well", userSignup.Status.CompliantUsername)
 						return true, nil
 					}
 					c.t.Logf("problem with deleting the related MasterUserRecord %s: %s", userSignup.Status.CompliantUsername, err)

--- a/testsupport/metrics/metrics.go
+++ b/testsupport/metrics/metrics.go
@@ -30,7 +30,9 @@ func GetMetricValue(restConfig *rest.Config, url string, family string, expected
 	if err != nil {
 		return -1, err
 	}
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", restConfig.BearerToken))
+	if restConfig.BearerToken != "" {
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", restConfig.BearerToken))
+	}
 	resp, err := client.Do(request)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
no need for dozens of logs such as:
```
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
clean.go:205: the related MasterUserRecord: foo is deleted as well
...
```

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
