### PR TITLE
wait for updates of revisions in NSTemplateTier.Status

### DIFF
--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -453,10 +453,6 @@ func TestTierTemplateRevision(t *testing.T) {
 			require.NoError(t, err)
 
 			// then
-			// an additional TTR will be created
-			// TODO check for exact match or remove the +1 once we implement the cleanup controller
-			ttrsWithNewParams, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(2*len(ttrs)+1))
-			require.NoError(t, err)
 			// retrieve new tier once the ttrs were created and the revision field updated
 			customTier.NSTemplateTier, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 				WithNameMatching(customTier.Name, func(actual *toolchainv1alpha1.NSTemplateTier) bool {
@@ -469,6 +465,10 @@ func TestTierTemplateRevision(t *testing.T) {
 					}
 					return true
 				})
+			require.NoError(t, err)
+			// an additional TTRs will be created
+			// TODO check for exact match or remove the +1 once we implement the cleanup controller
+			ttrsWithNewParams, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(2*len(ttrs)+1))
 			require.NoError(t, err)
 			// and the parameter is updated in all the ttrs
 			checkThatTTRsHaveParameter(t, customTier, ttrsWithNewParams, toolchainv1alpha1.Parameter{

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -467,7 +467,7 @@ func TestTierTemplateRevision(t *testing.T) {
 				})
 			require.NoError(t, err)
 			// an additional TTRs will be created
-			// TODO check for exact match or remove the +1 once we implement the cleanup controller
+			// TODO check for exact match and remove the 2*len(ttrs)+1 once we implement the cleanup controller
 			ttrsWithNewParams, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(2*len(ttrs)+1))
 			require.NoError(t, err)
 			// and the parameter is updated in all the ttrs

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -455,10 +455,20 @@ func TestTierTemplateRevision(t *testing.T) {
 			// then
 			// an additional TTR will be created
 			// TODO check for exact match or remove the +1 once we implement the cleanup controller
-			ttrsWithNewParams, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(len(updatedTTRs)+1))
+			ttrsWithNewParams, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(2*len(ttrs)+1))
 			require.NoError(t, err)
 			// retrieve new tier once the ttrs were created and the revision field updated
-			customTier.NSTemplateTier, err = hostAwait.WaitForNSTemplateTier(t, customTier.Name)
+			customTier.NSTemplateTier, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
+				WithNameMatching(customTier.Name, func(actual *toolchainv1alpha1.NSTemplateTier) bool {
+					for _, oldValue := range updatedCustomTier.Status.Revisions {
+						for _, actualValue := range actual.Status.Revisions {
+							if oldValue == actualValue {
+								return false
+							}
+						}
+					}
+					return true
+				})
 			require.NoError(t, err)
 			// and the parameter is updated in all the ttrs
 			checkThatTTRsHaveParameter(t, customTier, ttrsWithNewParams, toolchainv1alpha1.Parameter{


### PR DESCRIPTION
to fix flakiness 
https://storage.googleapis.com/test-platform-results/pr-logs/pull/codeready-toolchain_registration-service/506/pull-ci-codeready-toolchain-registration-service-master-e2e/1889236061419212800/build-log.txt
```
    nstemplatetier_test.go:570: 
        	Error Trace:	/tmp/toolchain-e2e/test/e2e/parallel/nstemplatetier_test.go:570
        	            				/tmp/toolchain-e2e/test/e2e/parallel/nstemplatetier_test.go:464
        	Error:      	[]v1alpha1.Parameter{v1alpha1.Parameter{Name:"DEPLOYMENT_QUOTA", Value:"60"}} does not contain v1alpha1.Parameter{Name:"DEPLOYMENT_QUOTA", Value:"100"}
        	Test:       	TestTierTemplateRevision/update_of_tiertemplate_should_trigger_creation_of_new_TTR/update_of_the_NSTemplateTier_parameters_should_trigger_creation_of_new_TTR
        	Messages:   	Unable to find required parameters:{Name:DEPLOYMENT_QUOTA Value:100} in the TTR:ttr-ttrfrombase1ns-admin-88b275d-88b275d-lwsn6
```