### PR TITLE
SANDBOX-799 SANDBOX-800: clean only when test passed + add timestamp when test fails

### DIFF
--- a/testsupport/cleanup/clean.go
+++ b/testsupport/cleanup/clean.go
@@ -100,87 +100,96 @@ func newCleanTask(t *testing.T, cl client.Client, obj client.Object) *cleanTask 
 }
 
 func (c *cleanTask) cleanObject() {
-	if c.objToClean == nil {
-		return
-	}
-	objToClean, ok := c.objToClean.DeepCopyObject().(client.Object)
-	require.True(c.t, ok)
-	userSignup, isUserSignup := c.objToClean.(*toolchainv1alpha1.UserSignup)
-	nsTemplateTier, isNsTemplateTier := c.objToClean.(*toolchainv1alpha1.NSTemplateTier)
-	kind := objToClean.GetObjectKind().GroupVersionKind().Kind
-	if kind == "" {
-		kind = reflect.TypeOf(c.objToClean).Elem().Name()
-	}
-	c.t.Logf("deleting %s: %s ...", kind, objToClean.GetName())
-	if err := c.client.Delete(context.TODO(), objToClean, propagationPolicyOpts); err != nil {
-		if errors.IsNotFound(err) {
-			// if the object was UserSignup, then let's check that the MUR was deleted as well
-			murDeleted, err := c.verifyMurDeleted(isUserSignup, userSignup, true)
-			require.NoError(c.t, err)
-			// if the object was UserSignup, then let's check that the Space was deleted as well
-			spaceDeleted, err := c.verifySpaceDeleted(isUserSignup, userSignup, true)
-			require.NoError(c.t, err)
-			// either if it was deleted or if it wasn't UserSignup, then return here
-			if murDeleted && spaceDeleted {
-				c.t.Logf("%s: %s was already deleted", kind, objToClean.GetName())
-				return
-			}
+	// only clean if test passed
+	if !c.t.Failed() {
+		if c.objToClean == nil {
+			return
 		}
-	}
-	// if the object was NSTemplateTier, then let's check that the TierTemplateRevisions were deleted as well
-	_, err := c.verifyTierTemplateRevisionsDeleted(isNsTemplateTier, nsTemplateTier, true)
-	require.NoError(c.t, err)
-
-	// wait until deletion is done
-	c.t.Logf("waiting until %s: %s is completely deleted", kind, objToClean.GetName())
-	err = wait.PollUntilContextTimeout(context.TODO(), defaultRetryInterval, defaultTimeout, true, func(ctx context.Context) (done bool, err error) {
-		if err := c.client.Get(context.TODO(), test.NamespacedName(objToClean.GetNamespace(), objToClean.GetName()), objToClean); err != nil {
+		objToClean, ok := c.objToClean.DeepCopyObject().(client.Object)
+		require.True(c.t, ok)
+		userSignup, isUserSignup := c.objToClean.(*toolchainv1alpha1.UserSignup)
+		nsTemplateTier, isNsTemplateTier := c.objToClean.(*toolchainv1alpha1.NSTemplateTier)
+		kind := objToClean.GetObjectKind().GroupVersionKind().Kind
+		if kind == "" {
+			kind = reflect.TypeOf(c.objToClean).Elem().Name()
+		}
+		c.t.Logf("deleting %s: %s ...", kind, objToClean.GetName())
+		if err := c.client.Delete(context.TODO(), objToClean, propagationPolicyOpts); err != nil {
 			if errors.IsNotFound(err) {
-				// if the object was UserSignup, then let's check that the MUR is deleted as well
-				if murDeleted, err := c.verifyMurDeleted(isUserSignup, userSignup, false); !murDeleted || err != nil {
-					return false, err
+				// if the object was UserSignup, then let's check that the MUR was deleted as well
+				murDeleted, err := c.verifyMurDeleted(isUserSignup, userSignup, true)
+				require.NoError(c.t, err)
+				// if the object was UserSignup, then let's check that the Space was deleted as well
+				spaceDeleted, err := c.verifySpaceDeleted(isUserSignup, userSignup, true)
+				require.NoError(c.t, err)
+				// either if it was deleted or if it wasn't UserSignup, then return here
+				if murDeleted && spaceDeleted {
+					c.t.Logf("%s: %s was already deleted", kind, objToClean.GetName())
+					return
 				}
-				// if the object was UserSignup, then let's check that the Space is deleted as well
-				if spaceDeleted, err := c.verifySpaceDeleted(isUserSignup, userSignup, false); !spaceDeleted || err != nil {
-					return false, err
-				}
-				// if the object was NSTemplateTier, then let's check that the TTRs were deleted as well
-				if ttrsDeleted, err := c.verifyTierTemplateRevisionsDeleted(isNsTemplateTier, nsTemplateTier, false); !ttrsDeleted || err != nil {
-					return false, err
-				}
-				return true, nil
 			}
-			c.t.Logf("problem with getting the related %s '%s': %s", kind, objToClean.GetName(), err)
-			return false, err
 		}
-		return false, nil
-	})
-	if err != nil {
-		if isUserSignup {
-			message := spew.Sprintf("The proper cleanup of the UserSignup '%s' and related resources wasn't finished within the given timeout\n", objToClean.GetName())
+		// if the object was NSTemplateTier, then let's check that the TierTemplateRevisions were deleted as well
+		_, err := c.verifyTierTemplateRevisionsDeleted(isNsTemplateTier, nsTemplateTier, true)
+		require.NoError(c.t, err)
 
-			message += c.checkIfStillPresent(&toolchainv1alpha1.UserSignup{}, "UserSignup", userSignup.GetNamespace(), userSignup.Name)
-			if userSignup.Status.CompliantUsername != "" {
-				message += c.checkIfStillPresent(&toolchainv1alpha1.MasterUserRecord{}, "MasterUserRecord", userSignup.GetNamespace(), userSignup.Status.CompliantUsername)
-				message += c.checkIfStillPresent(&toolchainv1alpha1.Space{}, "Space", userSignup.GetNamespace(), userSignup.Status.CompliantUsername)
+		// wait until deletion is done
+		c.t.Logf("waiting until %s: %s is completely deleted", kind, objToClean.GetName())
+		err = wait.PollUntilContextTimeout(context.TODO(), defaultRetryInterval, defaultTimeout, true, func(ctx context.Context) (done bool, err error) {
+			if err := c.client.Get(context.TODO(), test.NamespacedName(objToClean.GetNamespace(), objToClean.GetName()), objToClean); err != nil {
+				if errors.IsNotFound(err) {
+					// if the object was UserSignup, then let's check that the MUR is deleted as well
+					if murDeleted, err := c.verifyMurDeleted(isUserSignup, userSignup, false); !murDeleted || err != nil {
+						return false, err
+					}
+					// if the object was UserSignup, then let's check that the Space is deleted as well
+					if spaceDeleted, err := c.verifySpaceDeleted(isUserSignup, userSignup, false); !spaceDeleted || err != nil {
+						return false, err
+					}
+					// if the object was NSTemplateTier, then let's check that the TTRs were deleted as well
+					if ttrsDeleted, err := c.verifyTierTemplateRevisionsDeleted(isNsTemplateTier, nsTemplateTier, false); !ttrsDeleted || err != nil {
+						return false, err
+					}
+					return true, nil
+				}
+				c.t.Logf("problem with getting the related %s '%s': %s", kind, objToClean.GetName(), err)
+				return false, err
 			}
-			require.NoError(c.t, err, message)
-		} else if isNsTemplateTier {
-			message := spew.Sprintf("The proper cleanup of the NSTemplateTier '%s' and related resources wasn't finished within the given timeout\n", objToClean.GetName())
-			message += c.checkIfStillPresent(&toolchainv1alpha1.NSTemplateTier{}, "NSTemplateTier", nsTemplateTier.GetNamespace(), nsTemplateTier.Name)
-			ttrs := &toolchainv1alpha1.TierTemplateRevisionList{}
-			if err := c.client.List(context.TODO(), ttrs,
-				client.InNamespace(nsTemplateTier.GetNamespace()),
-				client.MatchingLabels{toolchainv1alpha1.TierLabelKey: nsTemplateTier.GetName()}); err != nil {
-				message += fmt.Sprintf("unexpected error when getting the TTR CRs: %s \n", err.Error())
+			return false, nil
+		})
+		if err != nil {
+			if isUserSignup {
+				message := spew.Sprintf("The proper cleanup of the UserSignup '%s' and related resources wasn't finished within the given timeout\n", objToClean.GetName())
+
+				message += c.checkIfStillPresent(&toolchainv1alpha1.UserSignup{}, "UserSignup", userSignup.GetNamespace(), userSignup.Name)
+				if userSignup.Status.CompliantUsername != "" {
+					message += c.checkIfStillPresent(&toolchainv1alpha1.MasterUserRecord{}, "MasterUserRecord", userSignup.GetNamespace(), userSignup.Status.CompliantUsername)
+					message += c.checkIfStillPresent(&toolchainv1alpha1.Space{}, "Space", userSignup.GetNamespace(), userSignup.Status.CompliantUsername)
+				}
+				require.NoError(c.t, err, message)
+			} else if isNsTemplateTier {
+				message := spew.Sprintf("The proper cleanup of the NSTemplateTier '%s' and related resources wasn't finished within the given timeout\n", objToClean.GetName())
+				message += c.checkIfStillPresent(&toolchainv1alpha1.NSTemplateTier{}, "NSTemplateTier", nsTemplateTier.GetNamespace(), nsTemplateTier.Name)
+				ttrs := &toolchainv1alpha1.TierTemplateRevisionList{}
+				if err := c.client.List(context.TODO(), ttrs,
+					client.InNamespace(nsTemplateTier.GetNamespace()),
+					client.MatchingLabels{toolchainv1alpha1.TierLabelKey: nsTemplateTier.GetName()}); err != nil {
+					message += fmt.Sprintf("unexpected error when getting the TTR CRs: %s \n", err.Error())
+				}
+				for _, ttr := range ttrs.Items {
+					message += fmt.Sprintf("the TTR CR '%s' is still present in the cluster: %+v \n", ttr.Name, ttr)
+				}
+				require.NoError(c.t, err, message)
+			} else {
+				require.NoError(c.t, err, "The object still exists after the time out expired: %s", spew.Sdump(objToClean))
 			}
-			for _, ttr := range ttrs.Items {
-				message += fmt.Sprintf("the TTR CR '%s' is still present in the cluster: %+v \n", ttr.Name, ttr)
-			}
-			require.NoError(c.t, err, message)
-		} else {
-			require.NoError(c.t, err, "The object still exists after the time out expired: %s", spew.Sdump(objToClean))
 		}
+		// if test failed, print time
+	} else {
+		c.t.Logf("test %s failed at %s",
+			c.t.Name(),
+			time.Now().Format("2006-01-02_15:04:05"),
+		)
 	}
 }
 


### PR DESCRIPTION
# Description
- Just clean resources when test passes
- Add timestamp when test fails

## Issue ticket number and link
[SANDBOX-799](https://issues.redhat.com/browse/SANDBOX-799)
[SANDBOX-800](https://issues.redhat.com/browse/SANDBOX-800)