### PR TITLE
update Golanci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-#service:
-#  project-path: github.com/codeready-toolchain/toolchain-e2e
-
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
-service:
-  project-path: github.com/codeready-toolchain/toolchain-e2e
+#service:
+#  project-path: github.com/codeready-toolchain/toolchain-e2e
 
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m


### PR DESCRIPTION
The Golanci-lint action recently changed the `golangci-lint verify` command to by default be true. [Change](https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0)

This broke our Golanci-lint CI [errorrepo1](https://github.com/codeready-toolchain/toolchain-common/actions/runs/13364924316/job/37328247752?pr=454#step:4:37).

The fix is to remove the additional parameter which the verify doesn't allow

Similar Prs
- Member-operator - https://github.com/codeready-toolchain/member-operator/pull/626
- Host Operator - https://github.com/codeready-toolchain/host-operator/pull/1143
- Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1120
- Toolchain - common - https://github.com/codeready-toolchain/toolchain-common/pull/458
- Api - https://github.com/codeready-toolchain/api/pull/461 
- Registration Service - https://github.com/codeready-toolchain/registration-service/pull/511