### PR TITLE
wait until ToolchainStatus is updated and in sync with counter

### DIFF
--- a/test/migration/setup_runner.go
+++ b/test/migration/setup_runner.go
@@ -62,6 +62,10 @@ func (r *SetupMigrationRunner) Run(t *testing.T) {
 	}
 
 	wg.Wait()
+
+	// wait until the ToolchainStatus is updated to make sure that all counters are in sync
+	_, err := r.Awaitilities.Host().WaitForToolchainStatus(t, wait.UntilToolchainStatusUpdatedAfter(time.Now()))
+	require.NoError(t, err)
 }
 
 func (r *SetupMigrationRunner) prepareAppStudioProvisionedSpace(t *testing.T) {

--- a/test/migration/verify/verify_migration_test.go
+++ b/test/migration/verify/verify_migration_test.go
@@ -106,6 +106,10 @@ func runVerifyFunctions(t *testing.T, awaitilities wait.Awaitilities) {
 	wg.Wait()
 
 	cleanup.ExecuteAllCleanTasks(t)
+
+	// wait until the ToolchainStatus is updated to make sure that all counters are in sync
+	_, err := awaitilities.Host().WaitForToolchainStatus(t, wait.UntilToolchainStatusUpdatedAfter(time.Now()))
+	require.NoError(t, err)
 }
 
 func verifyAppStudioProvisionedSpace(t *testing.T, awaitilities wait.Awaitilities) {

--- a/testsupport/init.go
+++ b/testsupport/init.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	toolchaincommon "github.com/codeready-toolchain/toolchain-common/pkg/client"
@@ -238,6 +239,12 @@ func WaitForDeployments(t *testing.T) wait.Awaitilities {
 		// check that the default user tier exists and is updated to the current version, an outdated version is applied from deploy/e2e-tests/usertier-base.yaml as
 		// part of the e2e test setup make target for the purpose of verifying the user tier update mechanism on startup of the host operator
 		err = initHostAwait.WaitUntilBaseUserTierIsUpdated(t)
+		require.NoError(t, err)
+
+		// wait until the controller has started, counter is initialized, and ToolchainStatus is updated & ready
+		_, err = initHostAwait.WaitForToolchainStatus(t,
+			wait.UntilToolchainStatusHasConditions(wait.ToolchainStatusReadyAndUnreadyNotificationNotCreated()...),
+			wait.UntilToolchainStatusUpdatedAfter(time.Now()))
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
This could minimize the test flakiness. It waits at the beginning of each test suite (and at the end of the migration test suites) until the ToolchainStatus is ready and updated, this means that the client-cache is initialized, the controller has started, and ToolchainStatus in sync with the counter. 
