### PR TITLE
verify skipped phone-verified accounts in tracking provisioned time

### DIFF
--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -312,6 +312,8 @@ func TestVerificationRequiredMetric(t *testing.T) {
 			require.NotEmpty(t, verificationCode)
 			// Attempt to verify with an incorrect verification code
 			NewHTTPRequest(t).InvokeEndpoint("GET", route+"/api/v1/signup/verification/invalid", token0, "", http.StatusForbidden)
+			// verify with the correct code
+			NewHTTPRequest(t).InvokeEndpoint("GET", route+fmt.Sprintf("/api/v1/signup/verification/%s", verificationCode), token0, "", http.StatusOK)
 			hostAwait.WaitForMetricDelta(t, wait.UserSignupVerificationRequiredMetric, 1)  // no change after verification initiated
 			hostAwait.WaitForHistogramInfBucketDelta(t, wait.SignupProvisionTimeMetric, 0) // no tracking of provision time for users with phone verification step
 		})

--- a/test/metrics/metrics_test.go
+++ b/test/metrics/metrics_test.go
@@ -259,7 +259,7 @@ func TestVerificationRequiredMetric(t *testing.T) {
 	memberAwait := awaitilities.Member1()
 	memberAwait2 := awaitilities.Member2()
 	route := hostAwait.RegistrationServiceURL
-	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(false)) // disable automatic approval so that users are created with verification required
+	hostAwait.UpdateToolchainConfig(t, testconfig.AutomaticApproval().Enabled(true))
 	// host metrics should be available at this point
 	hostAwait.InitMetrics(t, awaitilities.Member1().ClusterName, awaitilities.Member2().ClusterName)
 	t.Cleanup(func() {


### PR DESCRIPTION
paired with https://github.com/codeready-toolchain/host-operator/pull/1150

[SANDBOX-957](https://issues.redhat.com/browse/SANDBOX-957)