### PR TITLE
revert go-version-file usage in govulncheck gh action

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -18,7 +18,6 @@ jobs:
       with:
         go-version-file: go.mod
 
-
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,9 +13,18 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Generate Assets
+      run: |
+        make generate-assets
+
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-file: go.mod
+        go-version-input: ${{ steps.install-go.outputs.go-version }}
         go-package: ./...
         repo-checkout: false

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -18,9 +18,6 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Generate Assets
-      run: |
-        make generate-assets
 
     - name: Run govulncheck
       uses: golang/govulncheck-action@v1


### PR DESCRIPTION
# Description
There is a bug when using `go-version-file`: https://github.com/golang/go/issues/70036, which leads to pick go 1.24 as the go version. Reverting to the first approach of using `go-version-input`. Slack thread: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1741939607080469?thread_ts=1741889746.719249&cid=CHK0J6HT6