### PR TITLE
chore(build): migrate to golangci-lint@v2 and golangci-lint-action@v7

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,9 +23,9 @@ jobs:
         go-version-file: go.mod
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.63.1
+        version: v2.0.2
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,65 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
+version: "2"
 linters:
   enable:
-    - megacheck
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - gocyclo
-    - gofmt
-    - revive
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
     - misspell
-  presets: # groups of linters. See https://golangci-lint.run/usage/linters/
-    - bugs
-    - unused
-  disable: 
-    - golint # deprecated, use 'revive'
-    - scopelint # deprecated, use 'exportloopref'
-    - contextcheck # too many false-positives
-    - noctx # not needed
-
-# all available settings of specific linters
-linters-settings:
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: true
-  testifylint:
-    disable:
-      - suite-dont-use-pkg
-  revive:
-    rules:
-      - name: dot-imports
-        disabled: true # we allow for dot-import
+    - musttag
+    - nilerr
+    - nilnesserr
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unparam
+    - zerologlint
+  disable:
+    - contextcheck
+    - noctx
+  settings:
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    testifylint:
+      disable:
+        - suite-dont-use-pkg
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/setup/metrics/client.go
+++ b/setup/metrics/client.go
@@ -51,7 +51,7 @@ func (c *httpClient) URL(ep string, args map[string]string) *url.URL {
 
 	for arg, val := range args {
 		arg = ":" + arg
-		p = strings.Replace(p, arg, val, -1)
+		p = strings.ReplaceAll(p, arg, val)
 	}
 
 	u := *c.endpoint

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -1380,10 +1380,10 @@ func verifyHasExpectedWorkspace(t *testing.T, expectedWorkspace toolchainv1alpha
 	for _, actualWorkspace := range actualWorkspaces {
 		if actualWorkspace.Name == expectedWorkspace.Name {
 			assert.Equal(t, expectedWorkspace.Status, actualWorkspace.Status)
-			assert.NotEmpty(t, actualWorkspace.ObjectMeta.ResourceVersion, "Workspace.ObjectMeta.ResourceVersion field is empty: %#v", actualWorkspace)
-			assert.NotEmpty(t, actualWorkspace.ObjectMeta.Generation, "Workspace.ObjectMeta.Generation field is empty: %#v", actualWorkspace)
-			assert.NotEmpty(t, actualWorkspace.ObjectMeta.CreationTimestamp, "Workspace.ObjectMeta.CreationTimestamp field is empty: %#v", actualWorkspace)
-			assert.NotEmpty(t, actualWorkspace.ObjectMeta.UID, "Workspace.ObjectMeta.UID field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.ResourceVersion, "Workspace.ResourceVersion field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.Generation, "Workspace.Generation field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.CreationTimestamp, "Workspace.CreationTimestamp field is empty: %#v", actualWorkspace)
+			assert.NotEmpty(t, actualWorkspace.UID, "Workspace.UID field is empty: %#v", actualWorkspace)
 			return
 		}
 	}

--- a/test/e2e/parallel/registration_service_test.go
+++ b/test/e2e/parallel/registration_service_test.go
@@ -501,7 +501,7 @@ func TestUserSignupFoundWhenNamedWithEncodedUsername(t *testing.T) {
 		authsupport.WithPreferredUsername("arnold"))
 	require.NoError(t, err)
 	mp, mpStatus := ParseSignupResponse(t, NewHTTPRequest(t).InvokeEndpoint("GET", route+"/api/v1/signup", token0, "", http.StatusOK).UnmarshalMap())
-	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Empty(t, mp["compliantUsername"])
 	assert.Equal(t, "arnold", mp["username"], "got response %+v", mp)
 	require.IsType(t, false, mpStatus["ready"])
 	assert.False(t, mpStatus["ready"].(bool))
@@ -536,7 +536,7 @@ func TestPhoneVerification(t *testing.T) {
 
 	// Call get signup endpoint with a valid token and make sure verificationRequired is true
 	mp, mpStatus := ParseSignupResponse(t, NewHTTPRequest(t).InvokeEndpoint("GET", route+"/api/v1/signup", token0, "", http.StatusOK).UnmarshalMap())
-	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Empty(t, mp["compliantUsername"])
 	assert.Equal(t, identity0.Username, mp["username"])
 	require.IsType(t, false, mpStatus["ready"])
 	assert.False(t, mpStatus["ready"].(bool))
@@ -602,7 +602,7 @@ func TestPhoneVerification(t *testing.T) {
 
 	// Call get signup endpoint with a valid token and make sure it's pending approval
 	mp, mpStatus = ParseSignupResponse(t, NewHTTPRequest(t).InvokeEndpoint("GET", route+"/api/v1/signup", token0, "", http.StatusOK).UnmarshalMap())
-	assert.Equal(t, "", mp["compliantUsername"])
+	assert.Empty(t, mp["compliantUsername"])
 	assert.Empty(t, mp["defaultUserNamespace"])
 	assert.Empty(t, mp["rhodsMemberURL"])
 	assert.Equal(t, identity0.Username, mp["username"])

--- a/test/e2e/user_management_test.go
+++ b/test/e2e/user_management_test.go
@@ -819,7 +819,7 @@ func (s *userManagementTestSuite) TestReturningUsersProvisionedToLastCluster() {
 
 // TODO remove once UserTier migration is completed
 func (s *userManagementTestSuite) promoteToDefaultUserTier(mur *toolchainv1alpha1.MasterUserRecord) {
-	hostAwait := s.Awaitilities.Host()
+	hostAwait := s.Host()
 	_, err := wait.For(s.T(), hostAwait.Awaitility, &toolchainv1alpha1.MasterUserRecord{}).
 		Update(mur.Name, hostAwait.Namespace, func(m *toolchainv1alpha1.MasterUserRecord) {
 			m.Spec.TierName = "deactivate30"

--- a/testsupport/space/spacerequest.go
+++ b/testsupport/space/spacerequest.go
@@ -36,14 +36,14 @@ func WithSpecDisableInheritance(disableInheritance bool) SpaceRequestOption {
 
 func WithNamespace(namespace string) SpaceRequestOption {
 	return func(s *toolchainv1alpha1.SpaceRequest) {
-		s.ObjectMeta.Namespace = namespace
+		s.Namespace = namespace
 	}
 }
 
 func WithName(name string) SpaceRequestOption {
 	return func(s *toolchainv1alpha1.SpaceRequest) {
-		s.ObjectMeta.GenerateName = ""
-		s.ObjectMeta.Name = name
+		s.GenerateName = ""
+		s.Name = name
 	}
 }
 

--- a/testsupport/spacebinding/spacebindingrequest.go
+++ b/testsupport/spacebinding/spacebindingrequest.go
@@ -27,7 +27,7 @@ func WithSpecMasterUserRecord(mur string) SpaceBindingRequestOption {
 
 func WithNamespace(ns string) SpaceBindingRequestOption {
 	return func(s *toolchainv1alpha1.SpaceBindingRequest) {
-		s.ObjectMeta.Namespace = ns
+		s.Namespace = ns
 	}
 }
 

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -127,15 +127,15 @@ func (c *customTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 
 func (c *customTierChecks) GetExpectedTemplateRefs(_ *testing.T, _ *wait.HostAwaitility) TemplateRefs {
 	var clusterResourcesTmplRef *string
-	if c.tier.NSTemplateTier.Spec.ClusterResources != nil {
-		clusterResourcesTmplRef = &c.tier.NSTemplateTier.Spec.ClusterResources.TemplateRef
+	if c.tier.Spec.ClusterResources != nil {
+		clusterResourcesTmplRef = &c.tier.Spec.ClusterResources.TemplateRef
 	}
-	namespaceTmplRefs := make([]string, len(c.tier.NSTemplateTier.Spec.Namespaces))
-	for i, ns := range c.tier.NSTemplateTier.Spec.Namespaces {
+	namespaceTmplRefs := make([]string, len(c.tier.Spec.Namespaces))
+	for i, ns := range c.tier.Spec.Namespaces {
 		namespaceTmplRefs[i] = ns.TemplateRef
 	}
 	spaceRolesTmplRefs := make(map[string]string)
-	for i, ns := range c.tier.NSTemplateTier.Spec.SpaceRoles {
+	for i, ns := range c.tier.Spec.SpaceRoles {
 		spaceRolesTmplRefs[i] = ns.TemplateRef
 	}
 
@@ -1107,7 +1107,7 @@ func limitRange(cpuLimit, memoryLimit, cpuRequest, memoryRequest string) namespa
 		require.NoError(t, err)
 		defReq[corev1.ResourceMemory], err = resource.ParseQuantity(memoryRequest)
 		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, lr.ObjectMeta.Labels[toolchainv1alpha1.ProviderLabelKey])
+		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, lr.Labels[toolchainv1alpha1.ProviderLabelKey])
 		expected := &corev1.LimitRange{
 			Spec: corev1.LimitRangeSpec{
 				Limits: []corev1.LimitRangeItem{
@@ -1128,7 +1128,7 @@ func networkPolicySameNamespace() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
 		np, err := memberAwait.WaitForNetworkPolicy(t, ns, "allow-same-namespace")
 		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.ObjectMeta.Labels[toolchainv1alpha1.ProviderLabelKey])
+		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.Labels[toolchainv1alpha1.ProviderLabelKey])
 		expected := &netv1.NetworkPolicy{
 			Spec: netv1.NetworkPolicySpec{
 				Ingress: []netv1.NetworkPolicyIngressRule{
@@ -1199,7 +1199,7 @@ func networkPolicyAllowFromRedHatODSNamespaceToMariaDB() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, userName string) {
 		np, err := memberAwait.WaitForNetworkPolicy(t, ns, "allow-from-redhat-ods-app-to-mariadb")
 		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.ObjectMeta.Labels[toolchainv1alpha1.ProviderLabelKey])
+		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.Labels[toolchainv1alpha1.ProviderLabelKey])
 
 		tcpProtocol := corev1.ProtocolTCP
 		port := intstr.FromInt(3306)
@@ -1257,7 +1257,7 @@ func assertNetworkPolicyIngressForNamespaces(name string, podSelector metav1.Lab
 		require.Equal(t, 0, len(labelNameValuePairs)%2, "labelNameValuePairs must be a list of key-value pairs")
 		np, err := memberAwait.WaitForNetworkPolicy(t, ns, name)
 		require.NoError(t, err)
-		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.ObjectMeta.Labels[toolchainv1alpha1.ProviderLabelKey])
+		assert.Equal(t, toolchainv1alpha1.ProviderLabelValue, np.Labels[toolchainv1alpha1.ProviderLabelKey])
 
 		ingressRules := []netv1.NetworkPolicyIngressRule{}
 		for labelNameValuePairsIndex := 0; labelNameValuePairsIndex < len(labelNameValuePairs); labelNameValuePairsIndex += 2 {

--- a/testsupport/tiers/tier_setup.go
+++ b/testsupport/tiers/tier_setup.go
@@ -157,8 +157,8 @@ func UpdateCustomNSTemplateTier(t *testing.T, hostAwait *wait.HostAwaitility, ti
 		require.NoError(t, err)
 	}
 	tier.NSTemplateTier, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
-		Update(tier.NSTemplateTier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
-			nstt.Spec = tier.NSTemplateTier.Spec
+		Update(tier.Name, hostAwait.Namespace, func(nstt *toolchainv1alpha1.NSTemplateTier) {
+			nstt.Spec = tier.Spec
 		})
 	require.NoError(t, err)
 	newTTier, err := hostAwait.WaitForNSTemplateTier(t, tier.Name,

--- a/testsupport/wait/diff.go
+++ b/testsupport/wait/diff.go
@@ -10,17 +10,16 @@ import (
 func Diff(expected, actual interface{}) string {
 	msg := &strings.Builder{}
 
-	msg.WriteString("\nexpected:\n")
-	msg.WriteString("----\n")
-	msg.WriteString(fmt.Sprintf("%s", expected))
-	msg.WriteString("----\n")
-	msg.WriteString("actual:\n")
-	msg.WriteString("----\n")
-	msg.WriteString(fmt.Sprintf("%s", actual))
-	msg.WriteString("----\n")
-
-	msg.WriteString("-expected\n")
-	msg.WriteString("+actual\n")
+	fmt.Fprintln(msg, "\nexpected:")
+	fmt.Fprintln(msg, "----")
+	fmt.Fprintf(msg, "%s", expected)
+	fmt.Fprintln(msg, "----")
+	fmt.Fprintln(msg, "\nactual:")
+	fmt.Fprintln(msg, "----")
+	fmt.Fprintf(msg, "%s", actual)
+	fmt.Fprintln(msg, "----")
+	fmt.Fprintln(msg, "-expected")
+	fmt.Fprintln(msg, "+actual")
 	msg.WriteString(cmp.Diff(expected, actual))
 	return msg.String()
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -208,19 +208,18 @@ func matchMasterUserRecordWaitCriterion(actual *toolchainv1alpha1.MasterUserReco
 func (a *HostAwaitility) printMasterUserRecordWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.MasterUserRecord, criteria ...MasterUserRecordWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
-		buf.WriteString("failed to find MasterUserRecord\n")
+		fmt.Fprintln(buf, "failed to find MasterUserRecord")
 	} else {
-		buf.WriteString("failed to find MasterUserRecord with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "failed to find MasterUserRecord with matching criteria:")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) && c.Diff != nil {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -383,15 +382,14 @@ func (a *HostAwaitility) printUserSignupWaitCriterionDiffs(t *testing.T, actual 
 		buf.WriteString("failed to find UserSignup\n")
 	} else {
 		buf.WriteString("failed to find UserSignup with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) && c.Diff != nil {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -863,15 +861,14 @@ func (a *HostAwaitility) printUserTierWaitCriterionDiffs(t *testing.T, actual *t
 		buf.WriteString("failed to find UserTier\n")
 	} else {
 		buf.WriteString("failed to find UserTier with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1035,17 +1032,16 @@ func (a *HostAwaitility) printTierTemplateRevisionWaitCriterionDiffs(t *testing.
 		buf.WriteString("no ttrs found\n")
 	} else {
 		buf.WriteString("failed to find ttrs with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		for _, obj := range actual {
 			y, _ := StringifyObject(&obj) // nolint:gosec
-			buf.Write(y)
+			fmt.Fprintln(buf, string(y))
 		}
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1129,15 +1125,14 @@ func (a *HostAwaitility) printNSTemplateTierWaitCriterionDiffs(t *testing.T, act
 		buf.WriteString("failed to find NSTemplateTier\n")
 	} else {
 		buf.WriteString("failed to find NSTemplateTier with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1241,18 +1236,17 @@ func (a *HostAwaitility) printNotificationWaitCriterionDiffs(t *testing.T, actua
 		buf.WriteString("no notification found\n")
 	} else {
 		buf.WriteString("failed to find notifications with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		for _, obj := range actual {
 			y, _ := StringifyObject(&obj) // nolint:gosec
-			buf.Write(y)
+			fmt.Fprintln(buf, string(y))
 		}
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, n := range actual {
 			for _, c := range criteria {
 				if !c.Match(n) {
 					buf.WriteString(c.Diff(n))
-					buf.WriteString("\n")
 				}
 			}
 		}
@@ -1399,15 +1393,14 @@ func (a *HostAwaitility) printToolchainStatusWaitCriterionDiffs(t *testing.T, ac
 		buf.WriteString("failed to find Toolchainstatus\n")
 	} else {
 		buf.WriteString("failed to find ToolchainStatus with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1651,15 +1644,14 @@ func (a *HostAwaitility) printToolchainConfigWaitCriterionDiffs(t *testing.T, ac
 		buf.WriteString("failed to find ToolchainConfig\n")
 	} else {
 		buf.WriteString("failed to find ToolchainConfig with matching criteria:\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1961,16 +1953,15 @@ func (a *HostAwaitility) printSpaceWaitCriterionDiffs(t *testing.T, actual *tool
 		buf.WriteString("failed to find Space\n")
 	} else {
 		buf.WriteString("failed to find Space with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -2020,7 +2011,7 @@ func UntilSpaceHasCreationTimestampOlderThan(expectedElapsedTime time.Duration) 
 func UntilSpaceHasCreationTimestampGreaterThan(creationTimestamp time.Time) SpaceWaitCriterion {
 	return SpaceWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.Space) bool {
-			return actual.CreationTimestamp.Time.After(creationTimestamp)
+			return actual.CreationTimestamp.After(creationTimestamp)
 		},
 		Diff: func(actual *toolchainv1alpha1.Space) string {
 			return fmt.Sprintf("expected space to be created after %s; Actual creation timestamp %s", creationTimestamp.String(), actual.CreationTimestamp.String())
@@ -2249,11 +2240,10 @@ func (a *HostAwaitility) WaitUntilSpaceBindingsWithLabelDeleted(t *testing.T, ke
 	// print the listed spacebindings
 	if err != nil {
 		buf := &strings.Builder{}
-		buf.WriteString(fmt.Sprintf("spacebindings still found with labels %v:\n", labels))
+		fmt.Fprintf(buf, "spacebindings still found with labels %v:\n", labels)
 		for _, sb := range spaceBindingList.Items {
 			y, _ := yaml.Marshal(sb)
-			buf.Write(y)
-			buf.WriteString("\n")
+			fmt.Fprintln(buf, string(y))
 		}
 	}
 	return err
@@ -2352,16 +2342,15 @@ func (a *HostAwaitility) printSpaceBindingWaitCriterionDiffs(t *testing.T, actua
 		buf.WriteString("failed to find SpaceBinding\n")
 	} else {
 		buf.WriteString("failed to find SpaceBinding with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -2437,7 +2426,7 @@ func UntilSpaceBindingHasDifferentUID(uid types.UID) SpaceBindingWaitCriterion {
 func UntilSpaceBindingHasCreationTimestampGreaterThan(creationTimestamp time.Time) SpaceBindingWaitCriterion {
 	return SpaceBindingWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.SpaceBinding) bool {
-			return actual.CreationTimestamp.Time.After(creationTimestamp)
+			return actual.CreationTimestamp.After(creationTimestamp)
 		},
 		Diff: func(actual *toolchainv1alpha1.SpaceBinding) string {
 			return fmt.Sprintf("expected SpaceBinding to be created after %s; Actual creation timestamp %s", creationTimestamp.String(), actual.CreationTimestamp.String())
@@ -2531,19 +2520,18 @@ func UntilSocialEventHasConditions(expected ...toolchainv1alpha1.Condition) Soci
 func (a *HostAwaitility) printSocialEventWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.SocialEvent, criteria ...SocialEventWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
-		buf.WriteString("failed to find SocialEvent\n")
+		fmt.Fprintln(buf, "failed to find SocialEvent")
 	} else {
-		buf.WriteString("failed to find SocialEvent with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "failed to find SocialEvent with matching criteria:")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -115,16 +115,15 @@ func (a *MemberAwaitility) printUserAccountWaitCriterionDiffs(t *testing.T, actu
 		buf.WriteString(a.listAndReturnContent("UserAccount", a.Namespace, &toolchainv1alpha1.UserAccountList{}))
 	} else {
 		buf.WriteString("failed to find UserAccount with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) && c.Diff != nil {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -435,16 +434,15 @@ func (a *MemberAwaitility) printSpaceRequestWaitCriterionDiffs(t *testing.T, act
 		buf.WriteString(a.listAndReturnContent("SpaceRequest", a.Namespace, &toolchainv1alpha1.SpaceRequestList{}))
 	} else {
 		buf.WriteString("failed to find SpaceRequest with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) && c.Diff != nil {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -533,16 +531,15 @@ func (a *MemberAwaitility) printSpaceBindingRequestWaitCriterionDiffs(t *testing
 		buf.WriteString(a.listAndReturnContent("SpaceBindingRequest", a.Namespace, &toolchainv1alpha1.SpaceBindingRequestList{}))
 	} else {
 		buf.WriteString("failed to find SpaceBindingRequest with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) && c.Diff != nil {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -575,20 +572,19 @@ func matchNSTemplateSetWaitCriterion(actual *toolchainv1alpha1.NSTemplateSet, cr
 func (a *MemberAwaitility) printNSTemplateSetWaitCriterionDiffs(t *testing.T, actual *toolchainv1alpha1.NSTemplateSet, criteria ...NSTemplateSetWaitCriterion) {
 	buf := &strings.Builder{}
 	if actual == nil {
-		buf.WriteString("failed to find NSTemplateSet at all\n")
-		buf.WriteString(a.listAndReturnContent("NSTemplateSet", a.Namespace, &toolchainv1alpha1.NSTemplateSetList{}))
+		fmt.Fprintln(buf, "failed to find NSTemplateSet at all")
+		fmt.Fprint(buf, a.listAndReturnContent("NSTemplateSet", a.Namespace, &toolchainv1alpha1.NSTemplateSetList{}))
 	} else {
-		buf.WriteString(fmt.Sprintf("failed to find NSTemplateSet with matching criteria after %fs:\n", a.Timeout.Seconds()))
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintf(buf, "failed to find NSTemplateSet with matching criteria after %fs:\n", a.Timeout.Seconds())
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -905,16 +901,15 @@ func (a *MemberAwaitility) printNamespaceLabelCriterionDiffs(t *testing.T, actua
 		buf.WriteString(a.listAndReturnContent("Namespace", "", &corev1.NamespaceList{}))
 	} else {
 		buf.WriteString("failed to find Namespace with matching label criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual.ObjectMeta) {
 				buf.WriteString(c.Diff(actual.ObjectMeta))
-				buf.WriteString("\n")
 			}
 		}
 	}
@@ -949,16 +944,15 @@ func (a *MemberAwaitility) printRoleBindingWaitCriterionDiffs(t *testing.T, actu
 		buf.WriteString(a.listAndReturnContent("RoleBinding", "", &rbacv1.RoleBindingList{}))
 	} else {
 		buf.WriteString("failed to find RoleBinding with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual.ObjectMeta) {
 				buf.WriteString(c.Diff(actual.ObjectMeta))
-				buf.WriteString("\n")
 			}
 		}
 	}
@@ -1119,16 +1113,15 @@ func (a *MemberAwaitility) printRoleWaitCriterionDiffs(t *testing.T, actual *rba
 		buf.WriteString(a.listAndReturnContent("Role", "", &rbacv1.RoleList{}))
 	} else {
 		buf.WriteString("failed to find Role with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual.ObjectMeta) {
 				buf.WriteString(c.Diff(actual.ObjectMeta))
-				buf.WriteString("\n")
 			}
 		}
 	}
@@ -1157,16 +1150,15 @@ func (a *MemberAwaitility) printClusterResourceQuotaWaitCriterionDiffs(t *testin
 		buf.WriteString(a.listAndReturnContent("ClusterResourceQuota", "", &quotav1.ClusterResourceQuotaList{}))
 	} else {
 		buf.WriteString("failed to find ClusterResourceQuota with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1222,16 +1214,15 @@ func (a *MemberAwaitility) printResourceQuotaWaitCriterionDiffs(t *testing.T, ac
 		buf.WriteString(a.listAndReturnContent("ResourceQuota", "", &corev1.ResourceQuotaList{}))
 	} else {
 		buf.WriteString("failed to find ResourceQuota with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1284,17 +1275,16 @@ func (a *MemberAwaitility) printIdlerWaitCriteriaDiffs(t *testing.T, actual *too
 		buf.WriteString(a.listAndReturnContent("Idler", "", &toolchainv1alpha1.IdlerList{}))
 	} else {
 		buf.WriteString("failed to find Idler with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			// if at least one criteria does not match, keep waiting
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1444,8 +1434,7 @@ func (a *MemberAwaitility) printPodWaitCriterionDiffs(t *testing.T, actual *core
 		buf.WriteString("failed to find Pod with matching criteria:\n")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1733,8 +1722,7 @@ func (a *MemberAwaitility) printUserWaitCriterionDiffs(t *testing.T, actual *use
 		buf.WriteString("failed to find User with matching criteria:\n")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -1835,8 +1823,8 @@ func (a *MemberAwaitility) WaitForIdentity(t *testing.T, name string, criteria .
 
 func (a *MemberAwaitility) printIdentities(t *testing.T, expectedName string) {
 	buf := &strings.Builder{}
-	buf.WriteString(fmt.Sprintf("failed to find Identity '%s'\n", expectedName))
-	buf.WriteString(a.listAndReturnContent("Identity", "", &userv1.IdentityList{}))
+	fmt.Fprintf(buf, "failed to find Identity '%s'\n", expectedName)
+	fmt.Fprint(buf, a.listAndReturnContent("Identity", "", &userv1.IdentityList{}))
 	t.Log(buf.String())
 }
 
@@ -1954,16 +1942,15 @@ func (a *MemberAwaitility) printMemberStatusWaitCriterionDiffs(t *testing.T, act
 		buf.WriteString(a.listAndReturnContent("ToolchainCluster", "", &toolchainv1alpha1.ToolchainClusterList{}))
 	} else {
 		buf.WriteString("failed to find MemberStatus with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual) {
-				buf.WriteString(c.Diff(actual))
-				buf.WriteString("\n")
+				fmt.Fprintln(buf, c.Diff(actual))
 			}
 		}
 	}
@@ -2179,8 +2166,8 @@ func (a *MemberAwaitility) waitForWebhookDeployment(t *testing.T, image string) 
 	assert.Equal(t, appMemberOperatorWebhookLabel, actualDeployment.Spec.Selector.MatchLabels)
 
 	template := actualDeployment.Spec.Template
-	assert.Equal(t, "member-operator-webhook", template.ObjectMeta.Name)
-	assert.Equal(t, appMemberOperatorWebhookLabel, template.ObjectMeta.Labels)
+	assert.Equal(t, "member-operator-webhook", template.Name)
+	assert.Equal(t, appMemberOperatorWebhookLabel, template.Labels)
 	require.Len(t, template.Spec.Volumes, 1)
 	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Name)
 	assert.Equal(t, "webhook-certs", template.Spec.Volumes[0].Secret.SecretName)
@@ -2425,7 +2412,7 @@ func (a *MemberAwaitility) verifyAutoscalingBufferDeployment(t *testing.T) {
 	}, func(d *appsv1.Deployment) bool {
 		return d.Spec.Selector != nil && len(d.Spec.Selector.MatchLabels) == 1 && d.Spec.Selector.MatchLabels["app"] == "autoscaling-buffer"
 	}, func(d *appsv1.Deployment) bool {
-		return len(d.Spec.Template.ObjectMeta.Labels) == 1 && d.Spec.Template.ObjectMeta.Labels["app"] == "autoscaling-buffer"
+		return len(d.Spec.Template.Labels) == 1 && d.Spec.Template.Labels["app"] == "autoscaling-buffer"
 	}, func(d *appsv1.Deployment) bool {
 		return d.Spec.Template.Spec.PriorityClassName == "member-operator-autoscaling-buffer"
 	}, func(d *appsv1.Deployment) bool {
@@ -2513,16 +2500,15 @@ func (a *MemberAwaitility) printEnvironmentWaitCriterionDiffs(t *testing.T, actu
 		buf.WriteString(a.listAndReturnContent("Environment", "", &appstudiov1.EnvironmentList{}))
 	} else {
 		buf.WriteString("failed to find Environment with matching criteria:\n")
-		buf.WriteString("----\n")
-		buf.WriteString("actual:\n")
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "actual:")
 		y, _ := StringifyObject(actual)
-		buf.Write(y)
-		buf.WriteString("\n----\n")
-		buf.WriteString("diffs:\n")
+		fmt.Fprintln(buf, string(y))
+		fmt.Fprintln(buf, "----")
+		fmt.Fprintln(buf, "diffs:")
 		for _, c := range criteria {
 			if !c.Match(actual.ObjectMeta) {
 				buf.WriteString(c.Diff(actual.ObjectMeta))
-				buf.WriteString("\n")
 			}
 		}
 	}


### PR DESCRIPTION
upgraded `.golangci.yml` with `golangci-lint migrate`

include fixes suggested by `golangci-lint run -c ./.golangci.yml`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
