### PR TITLE
Tests for AAP idler

### DIFF
--- a/deploy/crds/README.adoc
+++ b/deploy/crds/README.adoc
@@ -5,3 +5,6 @@ Copy/paste relevant definitions from https://raw.githubusercontent.com/redhat-ap
 
 == virtualmachines CRD
 Copy from a cluster with CNV operator installed
+
+== ansibleautomationplatforms CRD
+Copy from a cluster with Ansible Automation Platform operator installed

--- a/deploy/crds/aap.ansible.com_ansibleautomationplatforms.yaml
+++ b/deploy/crds/aap.ansible.com_ansibleautomationplatforms.yaml
@@ -1,0 +1,664 @@
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
+metadata:
+  name: ansibleautomationplatforms.aap.ansible.com
+  labels:
+    operators.coreos.com/ansible-automation-platform-operator.ansible-automation-platfor: ''
+spec:
+  group: aap.ansible.com
+  names:
+    plural: ansibleautomationplatforms
+    singular: ansibleautomationplatform
+    kind: AnsibleAutomationPlatform
+    listKind: AnsibleAutomationPlatformList
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: AnsibleAutomationPlatform is the Schema for the ansibleautomationplatforms API
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of AnsibleAutomationPlatform
+              type: object
+              properties:
+                eda:
+                  description: EDA defines the desired state of EDA
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                image_proxy_version:
+                  description: AAP Gateway Proxy container image version (tag)
+                  type: string
+                route_tls_termination_mechanism:
+                  description: The secure TLS termination mechanism to use
+                  type: string
+                  default: Edge
+                  enum:
+                    - Edge
+                    - edge
+                    - Passthrough
+                    - passthrough
+                service_type:
+                  description: The service type to be used on the deployed instance
+                  type: string
+                  enum:
+                    - LoadBalancer
+                    - loadbalancer
+                    - ClusterIP
+                    - clusterip
+                    - NodePort
+                    - nodeport
+                ingress_type:
+                  description: The ingress type to use to reach the deployed instance
+                  type: string
+                  enum:
+                    - none
+                    - Ingress
+                    - ingress
+                    - Route
+                    - route
+                loadbalancer_port:
+                  description: Port to use for the loadbalancer
+                  type: integer
+                admin_password_secret:
+                  description: Secret where the admin password can be found
+                  type: string
+                  maxLength: 255
+                  pattern: '^[a-zA-Z0-9][-a-zA-Z0-9]{0,253}[a-zA-Z0-9]$'
+                idle_aap:
+                  description: Scale down replicas to put AAP into an idle mode
+                  type: boolean
+                no_log:
+                  description: Configure no_log for no_log tasks
+                  type: boolean
+                  default: true
+                redis_mode:
+                  description: Redis Mode
+                  type: string
+                  default: standalone
+                  enum:
+                    - cluster
+                    - standalone
+                db_fields_encryption_secret:
+                  description: 'Secret where the DB fields encryption key can be found. If not specified, one will be generated.'
+                  type: string
+                image_pull_policy:
+                  description: The image pull policy
+                  type: string
+                  enum:
+                    - Always
+                    - always
+                    - Never
+                    - never
+                    - IfNotPresent
+                    - ifnotpresent
+                service_account_annotations:
+                  description: ServiceAccount annotations
+                  type: string
+                ingress_api_version:
+                  description: The Ingress API version to use
+                  type: string
+                ingress_path_type:
+                  description: The ingress path type for the deployed service
+                  type: string
+                route_tls_secret:
+                  description: Secret where the TLS related credentials are stored
+                  type: string
+                image_proxy:
+                  description: AAP Gateway Proxy container image
+                  type: string
+                image_pull_secrets:
+                  description: Image pull secrets for app and database containers
+                  type: array
+                  items:
+                    type: string
+                postgres_image_version:
+                  description: PostgreSQL container image version to use
+                  type: string
+                ingress_path:
+                  description: The ingress path used to reach the deployed service
+                  type: string
+                bundle_cacert_secret:
+                  description: Secret where the trusted Certificate Authority Bundle is stored
+                  type: string
+                redis_image_version:
+                  description: Redis container image version to use
+                  type: string
+                lightspeed:
+                  description: Lightspeed defines the desired state of AnsibleLightspeed
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                redhat_registry:
+                  description: Default Redhat Container Image Registry
+                  type: string
+                redhat_registry_ns:
+                  description: Default Redhat Container Image Registry Namespace
+                  type: string
+                extra_settings:
+                  description: Environment variables to configure the application-level settings
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      setting:
+                        type: string
+                      value:
+                        x-kubernetes-preserve-unknown-fields: true
+                hostname:
+                  description: Override default hostname of the Ansible Automation Platform
+                  type: string
+                image_version:
+                  description: AAP Gateway container image version (tag)
+                  type: string
+                hub:
+                  description: Hub defines the desired state of AutomationHub
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                postgres_image:
+                  description: Registry path to the PostgreSQL container to use
+                  type: string
+                public_base_url:
+                  description: Public base URL for AAP
+                  type: string
+                redis_image:
+                  description: Registry path to the redis container to use
+                  type: string
+                ingress_annotations:
+                  description: Annotations to add to the Ingress Controller
+                  type: string
+                service_annotations:
+                  description: Annotations to add to the load balancer service
+                  type: string
+                api:
+                  description: The gateway api deployment.
+                  type: object
+                  properties:
+                    log_level:
+                      description: The log level for the deployment.
+                      type: string
+                      default: INFO
+                      enum:
+                        - DEBUG
+                        - INFO
+                        - WARNING
+                        - ERROR
+                        - CRITICAL
+                    node_selector:
+                      description: NodeSelector for the gateway pods.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    replicas:
+                      description: The number of replicas for the deployment.
+                      type: integer
+                      format: int32
+                      default: 1
+                    resource_requirements:
+                      description: Resource requirements for the galaxy api container
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                            storage:
+                              type: string
+                        requests:
+                          type: object
+                          properties:
+                            cpu:
+                              type: string
+                            memory:
+                              type: string
+                            storage:
+                              type: string
+                    security_context:
+                      description: Settings to apply to the securityContext field of the api container.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    strategy:
+                      description: The deployment strategy to use to replace existing pods with new ones.
+                      type: object
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                          type: object
+                          properties:
+                            maxSurge:
+                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                          type: string
+                    tolerations:
+                      description: Node tolerations for the gateway pods.
+                      type: array
+                      items:
+                        description: 'The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.'
+                        type: object
+                        properties:
+                          effect:
+                            description: 'Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.'
+                            type: string
+                          key:
+                            description: 'Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.'
+                            type: string
+                          operator:
+                            description: 'Operator represents a key''s relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.'
+                            type: string
+                          tolerationSeconds:
+                            description: 'TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.'
+                            type: integer
+                            format: int64
+                          value:
+                            description: 'Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.'
+                            type: string
+                    topology_spread_constraints:
+                      description: Topology rule(s) for the pods.
+                      type: array
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                        type: object
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                            type: object
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                type: array
+                                items:
+                                  description: 'A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.'
+                                  type: object
+                                  required:
+                                    - key
+                                    - operator
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: 'operator represents a key''s relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.'
+                                      type: string
+                                    values:
+                                      description: 'values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.'
+                                      type: array
+                                      items:
+                                        type: string
+                              matchLabels:
+                                description: 'matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.'
+                                type: object
+                                additionalProperties:
+                                  type: string
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: 'MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don''t exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.'
+                            type: array
+                            items:
+                              type: string
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. Its a required field. Default value is 1 and 0 is not allowed.'
+                            type: integer
+                            format: int32
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. 
+                               For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. 
+                               This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            type: integer
+                            format: int32
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. 
+                               If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. 
+                               If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: 'TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It''s a required field.'
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                image:
+                  description: AAP Gateway container image
+                  type: string
+                database:
+                  description: The Gateway PostgreSQL database StatefulSet
+                  type: object
+                  properties:
+                    resource_requirements:
+                      description: Resource requirements for the database container.
+                      type: object
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+                             This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+                             This field is immutable.
+                          type: array
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                type: string
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                    postgres_keep_pvc_after_upgrade:
+                      description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                      type: boolean
+                    postgres_data_volume_init:
+                      description: Sets permissions on the /var/lib/pgdata/data for postgres container using an init container (not Openshift)
+                      type: boolean
+                      default: false
+                    postgres_storage_class:
+                      description: Storage class to use for the PostgreSQL PVC
+                      type: string
+                    postgres_init_container_commands:
+                      description: Customize the postgres init container commands (Non Openshift)
+                      type: string
+                    postgres_extra_args:
+                      description: Arguments to pass to postgres process
+                      type: array
+                      items:
+                        type: string
+                    database_secret:
+                      description: 'Secret where the database configuration can be found. Set this to use your own external PostgreSQL database. If not specified, this secret will be generated and Gateway will create a managed postgres pod.'
+                      type: string
+                    storage_requirements:
+                      description: Storage requirements for the PostgreSQL container
+                      type: object
+                      properties:
+                        limits:
+                          type: object
+                          properties:
+                            storage:
+                              type: string
+                        requests:
+                          type: object
+                          properties:
+                            storage:
+                              type: string
+                    node_selector:
+                      description: NodeSelector for the database pod.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    postgres_ssl_mode:
+                      description: 'Configure PostgreSQL connection sslmode option. Default: "prefer"'
+                      type: string
+                    tolerations:
+                      description: Node tolerations for the database pod.
+                      type: array
+                      items:
+                        description: 'The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.'
+                        type: object
+                        properties:
+                          effect:
+                            description: 'Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.'
+                            type: string
+                          key:
+                            description: 'Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.'
+                            type: string
+                          operator:
+                            description: 'Operator represents a key''s relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.'
+                            type: string
+                          tolerationSeconds:
+                            description: 'TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.'
+                            type: integer
+                            format: int64
+                          value:
+                            description: 'Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.'
+                            type: string
+                    priority_class:
+                      description: Assign a pre-existing priority class to the postgres pod
+                      type: string
+                redis:
+                  description: Defines desired state of cache resources
+                  type: object
+                  properties:
+                    eda_redis_secret:
+                      description: Secret where the EDA redis configuration can be found. Set this to use your own external redis instance for EDA.
+                      type: string
+                    node_selector:
+                      description: NodeSelector for the Redis pods.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    redis_secret:
+                      description: Secret where the redis configuration can be found. Set this to use your own external redis instance.
+                      type: string
+                    replicas:
+                      description: Defines Redis Deployment replicas
+                      type: integer
+                      format: int32
+                    resource_requirements:
+                      description: Resource requirements for the Redis container
+                      type: object
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
+                             This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
+                             This field is immutable.
+                          type: array
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                type: string
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                        requests:
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                          additionalProperties:
+                            pattern: '^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
+                    strategy:
+                      description: The deployment strategy to use to replace existing pods with new ones.
+                      type: object
+                      properties:
+                        rollingUpdate:
+                          description: 'Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate. --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be.'
+                          type: object
+                          properties:
+                            maxSurge:
+                              description: 'The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.'
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              description: 'The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.'
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                        type:
+                          description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                          type: string
+                    tolerations:
+                      description: Node tolerations for the Redis pods.
+                      type: array
+                      items:
+                        description: 'The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.'
+                        type: object
+                        properties:
+                          effect:
+                            description: 'Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.'
+                            type: string
+                          key:
+                            description: 'Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.'
+                            type: string
+                          operator:
+                            description: 'Operator represents a key''s relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.'
+                            type: string
+                          tolerationSeconds:
+                            description: 'TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.'
+                            type: integer
+                            format: int64
+                          value:
+                            description: 'Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.'
+                            type: string
+                loadbalancer_protocol:
+                  description: Protocol to use for the loadbalancer
+                  type: string
+                  enum:
+                    - http
+                    - https
+                ingress_class_name:
+                  description: The name of ingress class to use instead of the cluster default.
+                  type: string
+                controller:
+                  description: Controller defines the desired state of AutomationController
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                route_api_version:
+                  description: The route API version to use
+                  type: string
+                route_host:
+                  description: The DNS to use to points to the instance
+                  type: string
+                ingress_tls_secret:
+                  description: Secret where the Ingress TLS secret can be found
+                  type: string
+                feature_flags:
+                  description: Platform Feature Flags Dictionary
+                  type: object
+                  additionalProperties:
+                    type: boolean
+                  x-kubernetes-validations:
+                    - rule: 'self.exists(k, k.startsWith(''FEATURE_''))'
+                      message: All feature flag keys must start with 'FEATURE_'.
+            status:
+              description: Status defines the observed state of AnsibleAutomationPlatform
+              type: object
+              properties:
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                controllerDatabaseSecret:
+                  description: Controller database configuration secret
+                  type: string
+                edaDatabaseSecret:
+                  description: EDA database configuration secret
+                  type: string
+                hubDatabaseSecret:
+                  description: Hub database configuration secret
+                  type: string
+                lightspeedDatabaseSecret:
+                  description: AnsibleLightspeed database configuration secret
+                  type: string
+                upgradedFrom:
+                  description: Last gated version
+                  type: string
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: None
+status:
+  conditions:
+    - type: NamesAccepted
+      status: 'True'
+      lastTransitionTime: '2024-12-12T02:08:56Z'
+      reason: NoConflicts
+      message: no conflicts found
+    - type: Established
+      status: 'True'
+      lastTransitionTime: '2024-12-12T02:08:56Z'
+      reason: InitialNamesAccepted
+      message: the initial names have been accepted
+  acceptedNames:
+    plural: ansibleautomationplatforms
+    singular: ansibleautomationplatform
+    kind: AnsibleAutomationPlatform
+    listKind: AnsibleAutomationPlatformList
+  storedVersions:
+    - v1alpha1

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -2,7 +2,6 @@ package parallel
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -28,13 +27,6 @@ import (
 
 func TestIdlerAndPriorityClass(t *testing.T) {
 	t.Parallel()
-	os.Setenv("KUBECONFIG", "/home/mjobanek/.kube/config")
-	os.Setenv("MEMBER_NS", "toolchain-member-20122840")
-	os.Setenv("MEMBER_NS_2", "toolchain-member2-20122840")
-	os.Setenv("SECOND_MEMBER_MODE", "true")
-	os.Setenv("HOST_NS", "toolchain-host-20122840")
-	os.Setenv("REGISTRATION_SERVICE_NS", "toolchain-host-20122840")
-
 	await := WaitForDeployments(t)
 	hostAwait := await.Host()
 	memberAwait := await.Member1()

--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -2,6 +2,8 @@ package parallel
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -46,7 +49,10 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	podsToIdle := prepareWorkloads(t, await.Member1(), idler.Name, wait.WithSandboxPriorityClass())
 	podsNoise := prepareWorkloads(t, await.Member1(), idlerNoise.Name, wait.WithSandboxPriorityClass())
 
-	// Create another noise pods in non-user namespace
+	// Create an Ansible Automation Platform resource
+	prepareAAPWorkloads(t, await.Member1(), "test-idler-aap", idler.Name, wait.WithSandboxPriorityClass())
+
+	// Create more noise pods in non-user namespace
 	memberAwait.CreateNamespace(t, "workloads-noise")
 	externalNsPodsNoise := prepareWorkloads(t, await.Member1(), "workloads-noise", wait.WithOriginalPriorityClass())
 
@@ -64,6 +70,15 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 		err := memberAwait.WaitUntilPodsDeleted(t, p.Namespace, wait.WithPodName(p.Name))
 		require.NoError(t, err)
 	}
+
+	// Wait for the AAP resource to be idled.
+	// The pods which owned by this AAP are still running because there is no AAP controller to shut them down.
+	// So we just need to verify that aap.Spec.Idle_aap is set to "true" by the idler.
+	clnt, err := dynamic.NewForConfig(memberAwait.RestConfig)
+	require.NoError(t, err)
+	_, err = memberAwait.WaitForAAP(t, "test-idler-aap", idler.Name, clnt.Resource(aapRes), true)
+	require.NoError(t, err)
+
 	// check notification was created
 	_, err = hostAwait.WaitForNotificationWithName(t, "test-idler-dev-idled", toolchainv1alpha1.NotificationTypeIdled, wait.UntilNotificationHasConditions(wait.Sent()))
 	require.NoError(t, err)
@@ -81,7 +96,7 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create another pod and make sure it's deleted.
-	// In the tests above the Idler reconcile was triggered after we changed the Idler resource (to set a short timeout).
+	// In the tests above, the Idler reconcile was triggered after we changed the Idler resource (to set a short timeout).
 	// Now we want to verify that the idler reconcile is triggered without modifying the Idler resource.
 	// Notification shouldn't be created again.
 	pod := createStandalonePod(t, await.Member1(), idler.Name, "idler-test-pod-2") // create just one standalone pod. No need to create all possible pod controllers which may own pods.
@@ -96,6 +111,18 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	// There should not be any pods left in the namespace
 	err = memberAwait.WaitUntilPodsDeleted(t, idler.Name, wait.WithPodLabel("idler", "idler"))
 	require.NoError(t, err)
+}
+
+// prepareAAPWorkloads prepares an Ansible Automation Platform instance with one deployment owned by it and waits for the pods to run
+func prepareAAPWorkloads(t *testing.T, memberAwait *wait.MemberAwaitility, name, namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
+	aapDeployment := createAAP(t, memberAwait, name, namespace)
+	n := int(*aapDeployment.Spec.Replicas) // total number of created pods
+
+	pods, err := memberAwait.WaitForPods(t, namespace, n, append(additionalPodCriteria, wait.PodRunning(),
+		wait.WithPodLabel("app", name))...)
+	require.NoError(t, err)
+
+	return pods
 }
 
 func prepareWorkloads(t *testing.T, memberAwait *wait.MemberAwaitility, namespace string, additionalPodCriteria ...wait.PodWaitCriterion) []corev1.Pod {
@@ -146,6 +173,41 @@ func createDeployment(t *testing.T, memberAwait *wait.MemberAwaitility, namespac
 		},
 	}
 	err := memberAwait.Create(t, deployment)
+	require.NoError(t, err)
+
+	return deployment
+}
+
+var aapRes = schema.GroupVersionResource{Group: "aap.ansible.com", Version: "v1alpha1", Resource: "ansibleautomationplatforms"}
+
+// createAAP creates an instance of ansibleautomationplatforms.aap.ansible.com with one deployment owned by this instance
+// returns the underlying deployment
+func createAAP(t *testing.T, memberAwait *wait.MemberAwaitility, name, namespace string) *appsv1.Deployment {
+	clnt, err := dynamic.NewForConfig(memberAwait.RestConfig)
+	require.NoError(t, err)
+
+	// Create an AAP instance
+	aap := aapResource(name)
+	createdAAP, err := clnt.Resource(aapRes).Namespace(namespace).Create(context.TODO(), aap, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a Deployment with two replicas and the AAP instance as the owner
+	replicas := int32(2)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(createdAAP, createdAAP.GroupVersionKind()),
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels(name)},
+			Replicas: &replicas,
+			Template: podTemplateSpec(name),
+		},
+	}
+	err = memberAwait.Create(t, deployment)
 	require.NoError(t, err)
 
 	return deployment
@@ -294,4 +356,19 @@ func podTemplateSpec(app string) corev1.PodTemplateSpec {
 
 func selectorLabels(app string) map[string]string {
 	return map[string]string{"app": app}
+}
+
+func aapResource(name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "aap.ansible.com/v1alpha1",
+			"kind":       "AnsibleAutomationPlatform",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"spec": map[string]interface{}{
+				"idle_aap": false,
+			},
+		},
+	}
 }

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/dynamic"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -1518,6 +1519,7 @@ func (a *MemberAwaitility) WaitForSecret(t *testing.T, name string) (*corev1.Sec
 
 // WaitForAAP waits for the AAP resource to get into the expected idled state (Spec.Idle_aap)
 func (a *MemberAwaitility) WaitForAAP(t *testing.T, name, namespace string, aapRes dynamic.NamespaceableResourceInterface, expectedIdled bool) (*unstructured.Unstructured, error) {
+	t.Logf("waiting for AAP '%s' in namespace '%s'", name, a.Namespace)
 	var aap *unstructured.Unstructured
 	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (bool, error) {
 		var err error

--- a/testsupport/wait/member.go
+++ b/testsupport/wait/member.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 	"reflect"
 	"sort"
 	"strings"
@@ -1512,6 +1514,27 @@ func (a *MemberAwaitility) WaitForSecret(t *testing.T, name string) (*corev1.Sec
 		return true, nil
 	})
 	return cm, err
+}
+
+// WaitForAAP waits for the AAP resource to get into the expected idled state (Spec.Idle_aap)
+func (a *MemberAwaitility) WaitForAAP(t *testing.T, name, namespace string, aapRes dynamic.NamespaceableResourceInterface, expectedIdled bool) (*unstructured.Unstructured, error) {
+	var aap *unstructured.Unstructured
+	err := wait.PollUntilContextTimeout(context.TODO(), a.RetryInterval, a.Timeout, true, func(ctx context.Context) (bool, error) {
+		var err error
+		aap, err = aapRes.Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		idled, _, err := unstructured.NestedBool(aap.UnstructuredContent(), "spec", "idle_aap")
+		if err != nil {
+			return true, err
+		}
+		return expectedIdled == idled, nil
+	})
+	return aap, err
 }
 
 // WaitForPods waits until "n" number of pods exist in the given namespace


### PR DESCRIPTION
This is an attempt to create a simple test for the AAP idler.
- it creates an AAP instance (using a mock AAP CRD) with one Deployment owned by it
- Waits for the AAP.Spec.idler_aap to be set to "true" by the idler.
- The underlying pods are still running since there is no AAP controller to shut them down