### PR TITLE
The advanced ns template tier was removed

### DIFF
--- a/test/e2e/default_tier_test.go
+++ b/test/e2e/default_tier_test.go
@@ -26,8 +26,8 @@ func TestSetDefaultTier(t *testing.T) {
 	})
 
 	t.Run("changed default tier configuration", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("advanced"))
-		// Create and approve a new user that should be provisioned to the advanced tier
+		hostAwait.UpdateToolchainConfig(t, testconfig.Tiers().DefaultUserTier("deactivate30").DefaultSpaceTier("base1nsnoidling"))
+		// Create and approve a new user that should be provisioned to the base1nsnoidling tier
 		NewSignupRequest(awaitilities).
 			Username("defaulttierchanged").
 			ManuallyApprove().

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -90,7 +90,7 @@ func TestNSTemplateTiers(t *testing.T) {
 func TestUpdateNSTemplateTier(t *testing.T) {
 	t.Parallel()
 	// in this test, we have 2 groups of users, configured with their own tier (both using the "base1ns" tier templates)
-	// then, the first tier is updated with the "advanced" templates, whereas the second one is updated using the "baseextendedidling" templates
+	// then, the first tier is updated with the "base1nsnoidling" templates, whereas the second one is updated using the "baseextendedidling" templates
 	// finally, all user namespaces are verified.
 	// So, in this test, we verify that namespace resources and cluster resources are updated, on 2 groups of users with different tiers ;)
 
@@ -106,7 +106,7 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 
 	baseTier, err := hostAwait.WaitForNSTemplateTier(t, "base1ns")
 	require.NoError(t, err)
-	advancedTier, err := hostAwait.WaitForNSTemplateTier(t, "advanced")
+	base1nsnoidlingTier, err := hostAwait.WaitForNSTemplateTier(t, "base1nsnoidling")
 	require.NoError(t, err)
 	baseextendedidlingTier, err := hostAwait.WaitForNSTemplateTier(t, "baseextendedidling")
 	require.NoError(t, err)
@@ -129,12 +129,12 @@ func TestUpdateNSTemplateTier(t *testing.T) {
 	verifyResourceUpdatesForSpaces(t, hostAwait, memberAwait, spaces, chocolateTier)
 
 	t.Log("updating tiers")
-	// when updating the "cheesecakeTier" tier with the "advanced" template refs for namespace resources and spaceroles
-	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
+	// when updating the "cheesecakeTier" tier with the "base1nsnoidling" template refs for namespace resources and spaceroles
+	cheesecakeTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cheesecakeTier, tiers.WithNamespaceResources(t, base1nsnoidlingTier), tiers.WithSpaceRoles(t, base1nsnoidlingTier))
 	// and when updating the "cookie" tier with the "baseextendedidling" template refs for both namespace resources and cluster-wide resources
 	cookieTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, cookieTier, tiers.WithNamespaceResources(t, baseextendedidlingTier), tiers.WithClusterResources(t, baseextendedidlingTier))
-	// and when updating the "chocolate" tier to the "advanced" template refs for namespace resources
-	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, advancedTier))
+	// and when updating the "chocolate" tier to the "base1nsnoidling" template refs for namespace resources
+	chocolateTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, chocolateTier, tiers.WithNamespaceResources(t, base1nsnoidlingTier))
 
 	// then
 	t.Log("verifying users and spaces after tier updates")
@@ -485,8 +485,8 @@ func TestTierTemplateRevision(t *testing.T) {
 		// given
 		// we create new NSTemplateTiers (derived from `base`)
 		updatingTier := tiers.CreateCustomNSTemplateTier(t, hostAwait, "updatingtier", baseTier)
-		// we use the advanced tier only for copying the namespace and space role resources
-		advancedTier, err := hostAwait.WaitForNSTemplateTier(t, "advanced")
+		// we use the base1nsnoidling tier only for copying the namespace and space role resources
+		base1nsnoidlingTier, err := hostAwait.WaitForNSTemplateTier(t, "base1nsnoidling")
 		require.NoError(t, err)
 
 		// when
@@ -496,12 +496,12 @@ func TestTierTemplateRevision(t *testing.T) {
 		require.NoError(t, err)
 		updatingTier.NSTemplateTier = tier
 		revisionsBeforeUpdate := updatingTier.Status.Revisions
-		// and we update the tier with the "advanced" template refs for namespace and space role resources
-		tiers.UpdateCustomNSTemplateTier(t, hostAwait, updatingTier, tiers.WithNamespaceResources(t, advancedTier), tiers.WithSpaceRoles(t, advancedTier))
+		// and we update the tier with the "base1nsnoidling" template refs for namespace and space role resources
+		tiers.UpdateCustomNSTemplateTier(t, hostAwait, updatingTier, tiers.WithNamespaceResources(t, base1nsnoidlingTier), tiers.WithSpaceRoles(t, base1nsnoidlingTier))
 
 		// then
 		// we ensure the new revisions are made by namespace and spaceroles from advanced tier + clusterResources from the updating tier
-		advancedRefs := tiers.GetTemplateRefs(t, hostAwait, advancedTier.Name)
+		advancedRefs := tiers.GetTemplateRefs(t, hostAwait, base1nsnoidlingTier.Name)
 		expectedRefs := []string{updatingTier.Spec.ClusterResources.TemplateRef}
 		// the duplicated tiertemplates have a different prefix
 		for _, tierTemplateName := range advancedRefs.SpaceRolesFlatten() {

--- a/test/e2e/parallel/space_test.go
+++ b/test/e2e/parallel/space_test.go
@@ -271,9 +271,9 @@ func TestPromoteSpace(t *testing.T) {
 		Execute(t)
 	spaceName := user.Space.Name
 
-	t.Run("to advanced tier", func(t *testing.T) {
+	t.Run("to base1nsnoidling tier", func(t *testing.T) {
 		// when
-		tiers.MoveSpaceToTier(t, hostAwait, spaceName, "advanced")
+		tiers.MoveSpaceToTier(t, hostAwait, spaceName, "base1nsnoidling")
 
 		// then
 		VerifyResourcesProvisionedForSpace(t, awaitilities, spaceName)

--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	// tier names
-	advanced           = "advanced"
 	appstudio          = "appstudio"
 	appstudiolarge     = "appstudiolarge"
 	appstudioEnv       = "appstudio-env"
@@ -44,9 +43,7 @@ const (
 	baseCPULimit = "40000m"
 )
 
-var (
-	providerMatchingLabels = client.MatchingLabels(map[string]string{toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue})
-)
+var providerMatchingLabels = client.MatchingLabels(map[string]string{toolchainv1alpha1.ProviderLabelKey: toolchainv1alpha1.ProviderLabelValue})
 
 type TierChecks interface {
 	GetClusterObjectChecks() []clusterObjectsCheck
@@ -69,8 +66,6 @@ func NewChecksForTier(tier *toolchainv1alpha1.NSTemplateTier) (TierChecks, error
 		return &baselargeTierChecks{baseTierChecks{tierName: baselarge}}, nil
 	case baseextendedidling:
 		return &baseextendedidlingTierChecks{baseTierChecks{tierName: baseextendedidling}}, nil
-	case advanced:
-		return &advancedTierChecks{baseTierChecks{tierName: advanced}}, nil
 	case appstudio:
 		return &appstudioTierChecks{tierName: appstudio}, nil
 	case appstudiolarge:
@@ -389,31 +384,6 @@ func commonNetworkPolicyChecks() []namespaceObjectsCheck {
 	}
 }
 
-type advancedTierChecks struct {
-	baseTierChecks
-}
-
-func (a *advancedTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
-	return clusterObjectsChecks(
-		clusterResourceQuotaCompute(baseCPULimit, "6000m", "32Gi", "60Gi"),
-		clusterResourceQuotaDeployments(),
-		clusterResourceQuotaReplicas(),
-		clusterResourceQuotaRoutes(),
-		clusterResourceQuotaJobs(),
-		clusterResourceQuotaServicesNoLoadBalancers(),
-		clusterResourceQuotaBuildConfig(),
-		clusterResourceQuotaSecrets(),
-		clusterResourceQuotaConfigMap(),
-		numberOfClusterResourceQuotas(9),
-		idlers(0, "dev", "stage"))
-}
-
-func (a *advancedTierChecks) GetExpectedTemplateRefs(t *testing.T, hostAwait *wait.HostAwaitility) TemplateRefs {
-	templateRefs := GetTemplateRefs(t, hostAwait, a.tierName)
-	verifyNsTypes(t, a.tierName, templateRefs, "dev", "stage")
-	return templateRefs
-}
-
 // testTierChecks checks only that the "test" tier exists and has correct template references.
 // It does not check the test tier resources
 type testTierChecks struct {
@@ -611,7 +581,7 @@ func (a *appstudioEnvTierChecks) GetSpaceRoleChecks(spaceRoles map[string][]stri
 		case "maintainer":
 			// no permissions granted
 		case "contributor":
-			//no permissions granted
+			// no permissions granted
 		default:
 			return nil, fmt.Errorf("unexpected template name: '%s'", role)
 		}
@@ -1705,7 +1675,6 @@ func gitOpsServiceLabel() namespaceObjectsCheck {
 
 func appstudioWorkSpaceNameLabel() namespaceObjectsCheck {
 	return func(t *testing.T, ns *corev1.Namespace, memberAwait *wait.MemberAwaitility, owner string) {
-
 		labelWaitCriterion := []wait.LabelWaitCriterion{}
 		labelWaitCriterion = append(labelWaitCriterion, wait.UntilObjectHasLabel("appstudio.redhat.com/workspace_name", owner))
 

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -50,7 +50,7 @@ import (
 )
 
 var (
-	BundledNSTemplateTiers []string = []string{"advanced", "baseextendedidling", "baselarge", "test", "base1ns", "base1nsnoidling", "base1ns6didler", "intelmedium", "intellarge", "intelxlarge", "base"}
+	BundledNSTemplateTiers []string = []string{"baseextendedidling", "baselarge", "test", "base1ns", "base1nsnoidling", "base1ns6didler", "intelmedium", "intellarge", "intelxlarge", "base"}
 	CustomNSTemplateTiers  []string = []string{"appstudio", "appstudiolarge", "appstudio-env"}
 	AllE2eNSTemplateTiers  []string = append(BundledNSTemplateTiers, CustomNSTemplateTiers...)
 )

--- a/testsupport/wait/stringify_test.go
+++ b/testsupport/wait/stringify_test.go
@@ -89,7 +89,7 @@ func TestStringifyObjects(t *testing.T) {
 					},
 				},
 				Spec: toolchainv1alpha1.SpaceSpec{
-					TierName: "advanced",
+					TierName: "base1nsnoidling",
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestStringifyObjects(t *testing.T) {
     creationTimestamp: "2021-12-16T10:45:30Z"
     name: oddity-2
   spec:
-    tierName: advanced
+    tierName: base1nsnoidling
   status: {}
 `, string(result))
 }


### PR DESCRIPTION
This updates the e2e tests to not rely on the `advanced` tier to be present.

Related PRs:
* host-operator: https://github.com/codeready-toolchain/host-operator/pull/1177
* ksctl: https://github.com/kubesaw/ksctl/pull/120