### PR TITLE
SANDBOX-1239: add retry when connecting to websocket

### DIFF
--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -1279,6 +1279,8 @@ func (w *wsWatcher) Start() func() {
 					w.t.Logf("rate limited, retrying: %s", string(r))
 					return false, nil
 				}
+				w.t.Logf("handshake failed with status %d / response %s", resp.StatusCode, string(r))
+				return false, err
 			} else {
 				w.t.Logf("connection failed with status %d / response %s", resp.StatusCode, string(r))
 				return false, err

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -1260,15 +1260,15 @@ func (w *wsWatcher) Start() func() {
 
 	var conn *websocket.Conn
 	var resp *http.Response
-	var err error
 
 	// Retry websocket connection to handle rate limiting issues
 	// From OpenShift 4.19+ (using k8s 1.32), the ResilientWatchCacheInitialization feature is enabled
 	// which can cause 429 rate limiting responses when watchcache is still under initialization
-	err = kubewait.PollUntilContextTimeout(context.TODO(), wait.DefaultRetryInterval, wait.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
+	err := kubewait.PollUntilContextTimeout(context.TODO(), wait.DefaultRetryInterval, wait.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
 		extraHeaders := make(http.Header, 1)
 		extraHeaders.Add("Origin", "http://localhost")
 
+		var err error
 		conn, resp, err = dialer.Dial(socketURL, extraHeaders) // nolint:bodyclose // see `return func() {...}`
 
 		if err != nil {

--- a/test/e2e/parallel/proxy_test.go
+++ b/test/e2e/parallel/proxy_test.go
@@ -198,7 +198,7 @@ func TestProxyFlow(t *testing.T) {
 		t.Run(user.username, func(t *testing.T) {
 			// Start a new websocket watcher
 			w := newWsWatcher(t, *user, user.compliantUsername, hostAwait.APIProxyURL)
-			closeConnection := w.Start(t)
+			closeConnection := w.Start()
 			defer closeConnection()
 			proxyCl := user.createProxyClient(t, hostAwait)
 			applicationList := &appstudiov1.ApplicationList{}
@@ -449,7 +449,7 @@ func TestProxyFlow(t *testing.T) {
 				proxyWorkspaceURL := hostAwait.ProxyURLWithWorkspaceContext(user.compliantUsername)
 				// Start a new websocket watcher which watches for Application CRs in the user's namespace
 				w := newWsWatcher(t, *user, user.compliantUsername, proxyWorkspaceURL)
-				closeConnection := w.Start(t)
+				closeConnection := w.Start()
 				defer closeConnection()
 				workspaceCl, err := hostAwait.CreateAPIProxyClient(t, user.token, proxyWorkspaceURL) // proxy client with workspace context
 				require.NoError(t, err)
@@ -615,7 +615,7 @@ func TestProxyFlow(t *testing.T) {
 
 			// Start a new websocket watcher which watches for Application CRs in the user's namespace
 			w := newWsWatcher(t, *guestUser, primaryUser.compliantUsername, primaryUserWorkspaceURL)
-			closeConnection := w.Start(t)
+			closeConnection := w.Start()
 			defer closeConnection()
 			guestUserPrimaryWsCl, err := hostAwait.CreateAPIProxyClient(t, guestUser.token, primaryUserWorkspaceURL)
 			require.NoError(t, err)
@@ -1239,7 +1239,7 @@ type wsWatcher struct {
 }
 
 // start creates a new WebSocket connection. The method returns a function which is to be used to close the connection when done.
-func (w *wsWatcher) Start(t *testing.T) func() {
+func (w *wsWatcher) Start() func() {
 	w.done = make(chan interface{})    // Channel to indicate that the receiverHandler is done
 	w.interrupt = make(chan os.Signal) // Channel to listen for interrupt signal to terminate gracefully
 
@@ -1287,7 +1287,7 @@ func (w *wsWatcher) Start(t *testing.T) func() {
 		w.connection = conn
 		return true, nil
 	})
-	require.NoError(t, err)
+	require.NoError(w.t, err)
 
 	w.connection = conn
 	w.receivedApps = make(map[string]*appstudiov1.Application)


### PR DESCRIPTION
## Description
We started to see flakiness in TestProxyFlow on the PR to [upgrade the cluster to version 4.19 on the release side](https://github.com/openshift/release/pull/66283). Openshift 4.19 uses Kubernetes 1.32, which has now ResilientWatchCacheInitialization feature enabled. For more info: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1751015099622649

## Issue ticket number and link
[SANDBOX-1239](https://issues.redhat.com/browse/SANDBOX-1239)