### PR TITLE
fix: get ttrs after tier update

### DIFF
--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -462,9 +462,6 @@ func TestTierTemplateRevision(t *testing.T) {
 		require.NoError(t, err)
 
 		// then
-		// a new TTR was created
-		updatedTTRs, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(len(ttrs))) //there is already a cleanup controller
-		require.NoError(t, err)
 		// get the updated nstemplatetier
 		updatedCustomTier, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.NSTemplateTier{}).
 			WithNameMatching(customTier.Name, func(actual *toolchainv1alpha1.NSTemplateTier) bool {
@@ -474,6 +471,9 @@ func TestTierTemplateRevision(t *testing.T) {
 		newTTR := updatedCustomTier.Status.Revisions[updatedCustomTier.Spec.ClusterResources.TemplateRef]
 
 		// check that it has the updated crq
+		// a new TTR was created
+		updatedTTRs, err := hostAwait.WaitForTTRs(t, customTier.Name, wait.GreaterOrEqual(len(ttrs))) //there is already a cleanup controller
+		require.NoError(t, err)
 		checkThatTTRContainsCRQ(t, newTTR, updatedTTRs, updatedCRQ)
 
 		t.Run("update of the NSTemplateTier parameters should trigger creation of new TTR", func(t *testing.T) {

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -476,7 +476,6 @@ func TestTierTemplateRevision(t *testing.T) {
 		updatedTTRs, err := hostAwait.WaitForTTRs(
 			t,
 			customTier.Name,
-			wait.GreaterOrEqual(len(ttrs)), // count must not regress
 			wait.TierTemplateRevisionWaitCriterion{
 				Match: func(actual []toolchainv1alpha1.TierTemplateRevision) bool {
 					for _, tr := range actual {

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -488,7 +488,6 @@ func TestTierTemplateRevision(t *testing.T) {
 			// when
 			// we increase the parameter for the deployment quota
 			customTier = tiers.UpdateCustomNSTemplateTier(t, hostAwait, customTier, tiers.WithParameter("DEPLOYMENT_QUOTA", "100"))
-			require.NoError(t, err)
 
 			// then
 			// retrieve new tier once the ttrs were created and the revision field updated

--- a/test/e2e/parallel/nstemplatetier_test.go
+++ b/test/e2e/parallel/nstemplatetier_test.go
@@ -468,6 +468,7 @@ func TestTierTemplateRevision(t *testing.T) {
 				newTTR, found := actual.Status.Revisions[actual.Spec.ClusterResources.TemplateRef]
 				return found && newTTR != "" && newTTR != ttrToBeModified
 			})
+		require.NoError(t, err)
 		newTTR := updatedCustomTier.Status.Revisions[updatedCustomTier.Spec.ClusterResources.TemplateRef]
 
 		// check that it has the updated crq


### PR DESCRIPTION
for flaky failure:
```
=== NAME  TestTierTemplateRevision/update_of_tiertemplate_should_trigger_creation_of_new_TTR
    host.go:1092: waiting for ttrs to match criteria for tier 'ttr'
    awaitility.go:780: waiting for object of GVK 'toolchain.dev.openshift.com/v1alpha1, Kind=NSTemplateTier' with name 'ttr' in namespace 'toolchain-host-26094943' to match additional criteria
    nstemplatetier_test.go:643: 
        	Error Trace:	/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/nstemplatetier_test.go:643
        	            				/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/parallel/nstemplatetier_test.go:477
        	Error:      	Unable to find a TTR with required crq
        	Test:       	TestTierTemplateRevision/update_of_tiertemplate_should_trigger_creation_of_new_TTR
        	Messages:   	ttr:ttr-ttrfrombase1ns-clusterresources-5b0d541-5b0d541-dh5vx CRQ:{Object:map[kind:ClusterResourceQuota metadata:map[name:for-{{.SPACE_NAME}}-deployments] spec:map[quota:map[hard:map[count/deploymentconfigs.apps:{{.DEPLOYMENT_QUOTA}} count/deployments.apps:{{.DEPLOYMENT_QUOTA}} count/pods:100]] selector:map[annotations:map[] labels:map[matchLabels:map[toolchain.dev.openshift.com/space:{{.SPACE_NAME}}]]]]]}
```

It looks like the TTRs are being retrieved before the NStemplateTier revisions are being updated, thus we are getting an old list of ttrs, let's retrieve those only once the NSTemplateTier revision is up to date.


see: https://redhat-internal.slack.com/archives/C09430LK7QE/p1756203780905619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked end-to-end tests to wait for and verify updated tier resources before validating revisions, improving determinism and reducing flakiness.
  * Added waits and checks to ensure new revision resources appear and include updated parameters, confirming parameter propagation to newly created revisions.
  * Added clearer error checks after fetching updated tiers and removed an incorrect immediate check that could cause false failures.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->