### PR TITLE
fix publish-sandbox-ui-for-ui-e2e-tests

### DIFF
--- a/.github/workflows/publish-sandbox-ui-for-ui-e2e-tests.yml
+++ b/.github/workflows/publish-sandbox-ui-for-ui-e2e-tests.yml
@@ -70,9 +70,7 @@ jobs:
       - name: Prepare tools
         uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
 
-      # Login to quay for PR events
-      - name: Login to quay (PR event)
-        if: ${{ github.event_name == 'pull_request_target' }}
+      - name: Login to quay
         run: |
           set -e
           export XDG_RUNTIME_DIR=/run/user/${UID}


### PR DESCRIPTION
Currently, `publish-sandbox-ui-for-ui-e2e-tests` workflow is failing with

```
Getting image source signatures
Copying blob sha256:a63fa69e305c8c24409a2f5a906dbdfc35fe0f898a8a27d7283291dd54a218ec
Error: trying to reuse blob sha256:a63fa69e305c8c24409a2f5a906dbdfc35fe0f898a8a27d7283291dd54a218ec at destination: checking whether a blob sha256:a63fa69e305c8c24409a2f5a906dbdfc35fe0f898a8a27d7283291dd54a218ec exists in quay.io/codeready-toolchain-test/sandbox-rhdh-plugin: authentication required
make: *** [make/sandbox-ui.mk:141: push-sandbox-plugin] Error 125
```

I am guessing because I wrongly set the login just if it is PR event target, but should also cover comment event. Sorry!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized container registry authentication across all workflow events to ensure consistent publishing of the sandbox UI used in end-to-end tests.
  * Reduced conditional logic in the CI pipeline, minimizing the risk of skipped authentication on comment-triggered runs.
  * No user-facing changes; improves reliability of internal automation.

* **Tests**
  * Enhances stability of E2E test artifact publishing by ensuring authentication is always performed before publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->