### PR TITLE
Update ansible and cluster-logging operator versions for perf tests

### DIFF
--- a/setup/operators/installtemplates/ansible-automation-platform.yaml
+++ b/setup/operators/installtemplates/ansible-automation-platform.yaml
@@ -18,7 +18,7 @@ objects:
       name: aap-operator
       namespace: ${AAP_NAMESPACE}
     spec:
-      channel: stable-2.4-cluster-scoped
+      channel: stable-2.5-cluster-scoped
       installPlanApproval: Automatic
       name: ansible-automation-platform-operator
       source: redhat-operators

--- a/setup/operators/installtemplates/cluster-logging-operator.yaml
+++ b/setup/operators/installtemplates/cluster-logging-operator.yaml
@@ -15,7 +15,7 @@ objects:
     labels:
       operators.coreos.com/cluster-logging.openshift-logging: ""
   spec:
-    channel: stable-6.1
+    channel: stable-6.3
     installPlanApproval: Automatic
     name: cluster-logging
     source: redhat-operators


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default subscription channel for Ansible Automation Platform Operator to stable-2.5 (cluster-scoped).
  - Updated Cluster Logging Operator subscription channel to stable-6.3.
  - New installations will track these newer operator streams; existing environments are unaffected.
  - Install behavior and approvals remain unchanged (Automatic).
  - Aligns templates with current vendor-recommended channels for improved currency and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->