### PR TITLE
manage AAP and KServe pods as standard workloads

### DIFF
--- a/test/e2e/parallel/user_workloads_test.go
+++ b/test/e2e/parallel/user_workloads_test.go
@@ -90,8 +90,8 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for the AAP resource to be idled.
-	// The pods are idled already as well (verified in the previous  - after some time, the idler idles the
-	// second-top-parent when the pod is still running
+	// The pods are idled as well, which is verified in the previous step - after some time,
+	// the idler idles the second-top-owner when the pod is still running
 	clnt, err := dynamic.NewForConfig(memberAwait.RestConfig)
 	require.NoError(t, err)
 	_, err = memberAwait.WaitForAAP(t, "test-idler-aap", idler.Name, clnt.Resource(aapRes), true)
@@ -99,8 +99,8 @@ func TestIdlerAndPriorityClass(t *testing.T) {
 
 	// Wait for the InferenceService to be deleted - the expected action to idle
 	// the workload is by deleting the InferenceService that is old enough.
-	// The pods are idled already as well (verified in the previous  - after some time, the idler idles the
-	// second-top-parent when the pod is still running
+	// The pods are idled as well, which is verified in the previous step - after some time,
+	// the idler idles the second-top-owner when the pod is still running
 	err = memberAwait.WaitUntilInferenceServiceDeleted(t, "test-idler-kserve", idler.Name, clnt.Resource(inferenceServiceRes))
 	require.NoError(t, err)
 }


### PR DESCRIPTION
We don't need any special handling for AAP & KServe pods - they will be idled (when running for really too long) anyway
for more info see https://github.com/codeready-toolchain/member-operator/commit/9a77538ead5165d6e50e0627b9e2178caba807db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Consolidated end-to-end user workload scenarios by creating all resources within the main preparation flow, improving clarity and reducing flakiness.

- Refactor
  - Inlined test setup logic to simplify flows and remove unnecessary indirection.

- Chores
  - Updated test comments and documentation to reflect the unified setup.

- Note
  - No changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->