### PR TITLE
SANDBOX-1282 | refactor: replace "wrapf" calls with stdlib wrap calls

### DIFF
--- a/setup/metrics/gather.go
+++ b/setup/metrics/gather.go
@@ -11,7 +11,6 @@ import (
 	cfg "github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/metrics/queries"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	k8sutil "k8s.io/apimachinery/pkg/util/wait"
@@ -124,13 +123,13 @@ func (g *Gatherer) sample(q queries.Query) error {
 		if strings.Contains(err.Error(), "client error: 403") {
 			url, tokenErr := auth.GetTokenRequestURI(g.k8sClient)
 			if tokenErr != nil {
-				return errors.Wrapf(err, "metrics query failed with 403 (Forbidden)")
+				return fmt.Errorf("metrics query failed with 403 (Forbidden): %w", err)
 			}
-			return errors.Wrapf(err, "metrics query failed with 403 (Forbidden) - retrieve a new token from %s", url)
+			return fmt.Errorf("metrics query failed with 403 (Forbidden) - retrieve a new token from %s: %w", url, err)
 		}
-		return errors.Wrapf(err, "metrics query failed - check whether prometheus is still healthy in the cluster")
+		return fmt.Errorf("metrics query failed - check whether prometheus is still healthy in the cluster: %w", err)
 	} else if len(warnings) > 0 {
-		return errors.Wrapf(fmt.Errorf("warnings: %v", warnings), "metrics query had unexpected warnings")
+		return fmt.Errorf("metrics query had unexpected warnings: %w", fmt.Errorf("warnings: %v", warnings))
 	}
 
 	vector := val.(model.Vector)

--- a/setup/operators/operators.go
+++ b/setup/operators/operators.go
@@ -12,7 +12,6 @@ import (
 
 	ctemplate "github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -68,7 +67,7 @@ func EnsureOperatorsInstalled(ctx context.Context, cl client.Client, s *runtime.
 	for _, templatePath := range templatePaths {
 		tmpl, err := templates.GetTemplateFromFile(templatePath)
 		if err != nil {
-			return errors.Wrapf(err, "invalid template file: '%s'", templatePath)
+			return fmt.Errorf("invalid template file: '%s': %w", templatePath, err)
 		}
 
 		processor := ctemplate.NewProcessor(s)
@@ -135,10 +134,10 @@ func EnsureOperatorsInstalled(ctx context.Context, cl client.Client, s *runtime.
 		}
 		installDuration := time.Since(startTime)
 		if csverr != nil {
-			return errors.Wrapf(csverr, "failed to find CSV '%s' with Phase 'Succeeded'", currentCSV)
+			return fmt.Errorf("failed to find CSV '%s' with Phase 'Succeeded': %w", currentCSV, csverr)
 		}
 		if err != nil {
-			return errors.Wrapf(err, "failed to verify installation of operator with subscription '%s' after %s", subscriptionResource.GetName(), installDuration.String())
+			return fmt.Errorf("failed to verify installation of operator with subscription '%s' after %s: %w", subscriptionResource.GetName(), installDuration.String(), err)
 		}
 
 		fmt.Printf("Verified installation of operator with subscription '%s' completed in %s\n\n", subscriptionResource.GetName(), installDuration.String())

--- a/setup/resources/create_resources.go
+++ b/setup/resources/create_resources.go
@@ -7,7 +7,6 @@ import (
 	ctemplate "github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/templates"
 	"github.com/codeready-toolchain/toolchain-e2e/setup/wait"
-	"github.com/pkg/errors"
 
 	templatev1 "github.com/openshift/api/template/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,7 +25,7 @@ func CreateUserResourcesFromTemplateFiles(ctx context.Context, cl runtimeclient.
 		if _, ok := tmpls[templatePath]; !ok {
 			var err error
 			if tmpls[templatePath], err = templates.GetTemplateFromFile(templatePath); err != nil {
-				return errors.Wrapf(err, "invalid template file: '%s'", templatePath)
+				return fmt.Errorf("invalid template file: '%s': %w", templatePath, err)
 			}
 		}
 		tmpl := tmpls[templatePath]

--- a/setup/templates/template.go
+++ b/setup/templates/template.go
@@ -12,7 +12,6 @@ import (
 	cfg "github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
 	multierror "github.com/hashicorp/go-multierror"
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	k8swait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubectl/pkg/scheme"
@@ -148,7 +147,7 @@ func applyObject(ctx context.Context, applycl *applyclientlib.SSAApplyClient, ob
 		}
 		return true, nil
 	}); err != nil {
-		return errors.Wrapf(err, "could not apply resource '%s' in namespace '%s'", obj.GetName(), obj.GetNamespace())
+		return fmt.Errorf("could not apply resource '%s' in namespace '%s': %w", obj.GetName(), obj.GetNamespace(), err)
 	}
 	return nil
 }

--- a/setup/wait/wait.go
+++ b/setup/wait/wait.go
@@ -2,6 +2,7 @@ package wait
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -9,7 +10,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +41,7 @@ func ForSpace(cl client.Client, space string) error {
 		}
 		return true, nil
 	}); err != nil {
-		return errors.Wrapf(err, "space '%s' is not ready yet", space)
+		return fmt.Errorf("space '%s' is not ready yet: %w", space, err)
 	}
 	return nil
 }
@@ -67,7 +67,7 @@ func ForSubscriptionWithCriteria(cl client.Client, name, namespace string, timeo
 	if err := k8swait.PollUntilContextTimeout(context.TODO(), configuration.DefaultRetryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		return HasSubscriptionWithCriteria(cl, name, namespace, criteria...)
 	}); err != nil {
-		return errors.Wrapf(err, "could not find a Subscription with name '%s' in namespace '%s' that meets the expected criteria", name, namespace)
+		return fmt.Errorf("could not find a Subscription with name '%s' in namespace '%s' that meets the expected criteria: %w", name, namespace, err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func ForCSVWithCriteria(cl client.Client, name, namespace string, timeout time.D
 	if err := k8swait.PollUntilContextTimeout(context.TODO(), configuration.DefaultRetryInterval, timeout, true, func(ctx context.Context) (bool, error) {
 		return HasCSVWithCriteria(cl, name, namespace, criteria...)
 	}); err != nil {
-		return errors.Wrapf(err, "could not find a CSV with name '%s' in namespace '%s' that meets the expected criteria", name, namespace)
+		return fmt.Errorf("could not find a CSV with name '%s' in namespace '%s' that meets the expected criteria: %w", name, namespace, err)
 	}
 	return nil
 }


### PR DESCRIPTION
There is no need to keep the legacy "wrapf" calls to wrap errors anymore, so the idea is to remove them in favor of the wrapping calls of the stdlib.

## Related PRs

- https://github.com/codeready-toolchain/host-operator/pull/1257
- https://github.com/codeready-toolchain/member-operator/pull/744
- https://github.com/codeready-toolchain/toolchain-common/pull/526
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1275

## Jira ticket
[[SANDBOX-1282]](https://redhat.atlassian.net/browse/SANDBOX-1282)