### PR TITLE
test: handle "Cookie Preferences and Opt-Out Rights" modal

### DIFF
--- a/testsupport/devsandbox-dashboard/setup.go
+++ b/testsupport/devsandbox-dashboard/setup.go
@@ -131,12 +131,18 @@ func handleCookiesConsent(t *testing.T, page playwright.Page) {
 	contentFrame := iframe.ContentFrame()
 	require.NotNil(t, contentFrame)
 
-	// find the agree button
-	agreeButton := contentFrame.GetByRole("button", playwright.FrameLocatorGetByRoleOptions{
+	// TrustArc can show different modals (e.g. full consent vs. simplified); accept whichever button is present.
+	agreeProceed := contentFrame.GetByRole("button", playwright.FrameLocatorGetByRoleOptions{
 		Name: "Agree and proceed with",
 	})
 
-	err = agreeButton.Click()
+	// to some us states, like texas, it appears the "Cookie Preferences and Opt-Out Rights" modal
+	acceptDefault := contentFrame.GetByRole("button", playwright.FrameLocatorGetByRoleOptions{
+		Name: "Accept default",
+	})
+	consentButton := agreeProceed.Or(acceptDefault)
+
+	err = consentButton.Click()
 	require.NoError(t, err)
 
 	// wait for iframe to disappear (indicates cookie acceptance complete)


### PR DESCRIPTION
The "Cookie Preferences and Opt-Out Rights Your Choices About Cookies on this Site" modal appears depending on the country/state (for example, it appears for us texas), which breaks the current Developer Sandbox E2E tests against prod (pls, check this [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/78335/rehearse-78335-periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod/2049474170013618176/artifacts/ci-daily-prod/codeready-toolchain-devsandbox-dashboard-prod/artifacts/devsandbox-dashboard/trace/test-activities-page.webm)). So, we should handle it.

## Issue ticket number and link
[SANDBOX-1630](https://issues.redhat.com/browse/SANDBOX-1630)



<img width="1040" height="923" alt="image" src="https://github.com/user-attachments/assets/bd8ac0f1-7117-4d24-a7ae-1637dedd9cde" />


Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cookie consent handling to support multiple modal variants, ensuring consistent functionality across different consent dialog implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->