### PR TITLE
test: SANDBOX-1826 - fix race condition in CreateSpaceRequest

### DIFF
--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -195,8 +195,10 @@ func (s *userSignupIntegrationTest) TestAutomaticApproval() {
 		domains := "anotherdomain.edu"
 		// when
 		hostAwait.UpdateToolchainConfig(s.T(), testconfig.AutomaticApproval().Enabled(true).Domains(domains), testconfig.RegistrationService().Verification().Enabled(false))
-		VerifyToolchainConfig(s.T(), hostAwait, wait.UntilToolchainConfigHasAutoApprovalDomains(domains), wait.UntilToolchainConfigHasVerificationEnabled(false))
-
+		VerifyToolchainConfig(s.T(), hostAwait,
+			wait.UntilToolchainConfigHasAutoApprovalDomains(domains),
+			wait.UntilToolchainConfigHasVerificationEnabled(false),
+			wait.UntilToolchainConfigHasSyncedStatus(wait.ToolchainConfigSyncComplete()))
 		// and
 		waitingListUser3 := NewSignupRequest(s.Awaitilities).
 			Username("waitinglist3").


### PR DESCRIPTION
# Description
Last Saturday (May 2), [periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily/2050500619004809216) failed in the test `TestRunUserSignupIntegrationTest/TestAutomaticApproval`. We are likely facing flakiness in this test due to a race condition between ToolchainConfig CR update and the in-memory config cache refresh in the host-operator process.

The test updates ToolchainConfig to restrict auto-approval domains to [anotherdomain.edu](http://anotherdomain.edu/), then immediately creates a [waitinglist3@redhat.com](mailto:waitinglist3@redhat.com) signup expecting PendingApproval. However, the UserSignup controller reads config from an in-memory cache (toolchain-common/pkg/configuration/cache.go), which is only refreshed when the ToolchainConfig controller reconciles.

If the UserSignup is reconciled before the cache is refreshed, the controller still sees the old config (all domains approved), auto-approves the user, and the test hangs forever waiting for PendingApproval conditions.

We can see in the [UserSignup list](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily/2050500619004809216/artifacts/ci-daily/codeready-toolchain-gather/artifacts/usersignups.toolchain.dev.openshift.com.json) that `waitinglist3` was approved.

Assisted-by: Cursor

## Issue ticket number and link
[SANDBOX-1826](https://issues.redhat.com/browse/SANDBOX-1826)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced user signup test to include additional verification for toolchain configuration synchronization completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->