### PR TITLE
test: handle cookies

### DIFF
--- a/test/e2e/devsandbox-dashboard/activities_page_test.go
+++ b/test/e2e/devsandbox-dashboard/activities_page_test.go
@@ -61,7 +61,7 @@ func TestActivitiesPage(t *testing.T) {
 		require.NoError(t, err)
 
 		// assert the popup heading matches the expected article title
-		h1 := popup.Locator("h1")
+		h1 := popup.Locator("h1").First()
 		h1Text, err := h1.TextContent()
 		require.NoError(t, err)
 		// clean text since it returns this format: Overview:\n\t\t\t\t\t\t

--- a/test/e2e/devsandbox-dashboard/header_test.go
+++ b/test/e2e/devsandbox-dashboard/header_test.go
@@ -24,7 +24,7 @@ func TestHeader(t *testing.T) {
 	rhdhPage, err := sandboxui.ClickAndWaitForPopup(t, page, rhdhLink, testName)
 	require.NoError(t, err)
 
-	h1Text, err := rhdhPage.Locator("h1").TextContent()
+	h1Text, err := rhdhPage.Locator("h1").First().TextContent()
 	require.NoError(t, err)
 	require.Contains(t, h1Text, "Red Hat Developer Hub")
 
@@ -37,7 +37,7 @@ func TestHeader(t *testing.T) {
 	salesPage, err := sandboxui.ClickAndWaitForPopup(t, page, salesBtn, testName)
 	require.NoError(t, err)
 
-	h1Text, err = salesPage.Locator("h1").TextContent()
+	h1Text, err = salesPage.Locator("h1").First().TextContent()
 	require.NoError(t, err)
 	// replace non-breaking space with regular space
 	h1Text = strings.ReplaceAll(h1Text, "\u00a0", " ")

--- a/testsupport/devsandbox-dashboard/setup.go
+++ b/testsupport/devsandbox-dashboard/setup.go
@@ -114,11 +114,10 @@ func launchBrowser(t *testing.T, pw *playwright.Playwright) playwright.Browser {
 }
 
 func handleCookiesConsent(t *testing.T, page playwright.Page) {
-	// wait for the iframe to appear
-	iframe := page.Locator("iframe[name=\"trustarc_cm\"]")
+	// TrustArc renders as a div with a declarative shadow DOM, not a real iframe.
+	consent := page.Locator("div[name=\"trustarc_cm\"]")
 
-	// check if iframe exists
-	err := iframe.WaitFor(playwright.LocatorWaitForOptions{
+	err := consent.WaitFor(playwright.LocatorWaitForOptions{
 		State: playwright.WaitForSelectorStateVisible,
 	})
 
@@ -127,26 +126,24 @@ func handleCookiesConsent(t *testing.T, page playwright.Page) {
 		return
 	}
 
-	// get the content frame
-	contentFrame := iframe.ContentFrame()
-	require.NotNil(t, contentFrame)
-
 	// TrustArc can show different modals (e.g. full consent vs. simplified); accept whichever button is present.
-	agreeProceed := contentFrame.GetByRole("button", playwright.FrameLocatorGetByRoleOptions{
+	agreeProceed := consent.GetByRole("button", playwright.LocatorGetByRoleOptions{
 		Name: "Agree and proceed with",
 	})
 
 	// to some us states, like texas, it appears the "Cookie Preferences and Opt-Out Rights" modal
-	acceptDefault := contentFrame.GetByRole("button", playwright.FrameLocatorGetByRoleOptions{
+	acceptDefault := consent.GetByRole("button", playwright.LocatorGetByRoleOptions{
 		Name: "Accept default",
 	})
 	consentButton := agreeProceed.Or(acceptDefault)
 
+	IsVisible(t, consentButton)
+
 	err = consentButton.Click()
 	require.NoError(t, err)
 
-	// wait for iframe to disappear (indicates cookie acceptance complete)
-	err = iframe.WaitFor(playwright.LocatorWaitForOptions{
+	// wait for the consent banner to disappear
+	err = consent.WaitFor(playwright.LocatorWaitForOptions{
 		State: playwright.WaitForSelectorStateDetached,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
# Description
Today's `periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod` failed due to a change in the cookies consent popup. They are no longer using `iframe`, but `div` instead ([job example](https://redhat-internal.slack.com/archives/C09430LK7QE/p1780479026602439))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent dialog handling to reliably detect TrustArc’s rendered consent container, interact with the appropriate consent option shown, and confirm dismissal before continuing.

* **Tests**
  * Tightened end-to-end popup verification to scope heading lookup more precisely, making assertions for activity and header popups more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->