### PR TITLE
feat: add Twilio Lookup v2 API tests

### DIFF
--- a/deploy/host-operator/e2e-tests/toolchainconfig.yaml
+++ b/deploy/host-operator/e2e-tests/toolchainconfig.yaml
@@ -20,6 +20,7 @@ spec:
       workatoWebHookURL: https://webhooks.testwebhook
       verification:
         enabled: true
+        phoneLookupMode: 'disabled'
         excludedEmailDomains: 'redhat.com,acme.com'
         secret:
           ref: 'host-operator-secret'

--- a/go.mod
+++ b/go.mod
@@ -142,9 +142,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91
 
 go 1.24.4
 

--- a/go.mod
+++ b/go.mod
@@ -142,9 +142,9 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32
 
 go 1.24.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260603091009-6db0c02f4506
+	github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0
 	github.com/ghodss/yaml v1.0.0
@@ -141,10 +141,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91
 
 go 1.24.4
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-e2e
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174
+	github.com/codeready-toolchain/api v0.0.0-20260603082246-cfa3dd9db9cc
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0
@@ -141,6 +141,10 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8
 
 go 1.24.4
 

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174 h1:hed3ZyardxswS6yMB0ME9l3vEkO+pFouyk4dvIiAQOo=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74 h1:yxKX0m6Kk1AIWwaGpf25flTfTrYrEJ9TyLW5NEQSq0Y=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74/go.mod h1:NEnnq2R5GYoWdN0b0iaSdX7L1ndrzxl3ML0m7XLsSqk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -50,6 +46,10 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8 h1:sObsn7DQTpOV3xFUjz3CukBbV0yBbocoy7oY44lmohI=
+github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8/go.mod h1:pcEdk1XDpioLNGX3/p10q6TG+JiM1fpNGksjUGN4j+8=
+github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc h1:uqVQWx9dBBUQ63BuyinZX8UYPDPiPzUmOrinw+Luw/M=
+github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,10 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe h1:ZcRGUQ4PQ5jdklG+sjbNiRcWDWZRJTnAw7sMzhUFMcE=
-github.com/fbm3307/toolchain-common v0.0.0-20260608074508-590711573ffe/go.mod h1:qM3O9UX4HOWPYW4QT7G3cZxO91+XKQBUZaxlOIN73Uo=
-github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4 h1:iMRDRRzSq9Ie33g3WqfzDvvnLzesgTRKEnI3AhTTIfs=
-github.com/fbm3307/toolchainapi v0.0.0-20260608073802-89362d94dca4/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91 h1:ZRjnFxN8UIcmJo+BjNTiaCpyYVCj7TclarGbRRko3mE=
+github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91/go.mod h1:xcm86+meY59A4Rs62c8wVAznTuPk2QQW/yijPWZxHLw=
+github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621 h1:4Ga0w0uuWUw8Q3KgJsgMncH+1F2S048y0eCAzSSlYbA=
+github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/go.sum
+++ b/go.sum
@@ -46,10 +46,10 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8 h1:sObsn7DQTpOV3xFUjz3CukBbV0yBbocoy7oY44lmohI=
-github.com/fbm3307/toolchain-common v0.0.0-20260604083249-f7d10b0cf7f8/go.mod h1:pcEdk1XDpioLNGX3/p10q6TG+JiM1fpNGksjUGN4j+8=
-github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc h1:uqVQWx9dBBUQ63BuyinZX8UYPDPiPzUmOrinw+Luw/M=
-github.com/fbm3307/toolchainapi v0.0.0-20260604080936-f3460ab84acc/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32 h1:0hDjq6yEF3IfohFQayMKvBLHCRXfDrrfuqmA3qdkL/s=
+github.com/fbm3307/toolchain-common v0.0.0-20260604095108-e1b8464eda32/go.mod h1:oTa3Nrm18nLZoY288yT0iNK9BWYtyZiEC6kpBbQuSk0=
+github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb h1:bXPET+ypBRQzmSUdUvL963GLYFNc4eZmh7a5LyxbLBc=
+github.com/fbm3307/toolchainapi v0.0.0-20260604095004-7254759589cb/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581 h1:KE14RYWzMatSrwGa2wOB4SoVkbvpTm8hfnUH/nrpnfw=
+github.com/codeready-toolchain/api v0.0.0-20260609071155-c8f486b1a581/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579 h1:1qfOdNV6gRQSE0xOmJggqQxAiEjOpV7nZ6Xph75Mb1I=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260609073430-82d1748db579/go.mod h1:aYvTzEtTuw3O+kjWMMkH/1YgV4pgUPC3v3X2Li3ixlM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,10 +50,6 @@ github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91 h1:ZRjnFxN8UIcmJo+BjNTiaCpyYVCj7TclarGbRRko3mE=
-github.com/fbm3307/toolchain-common v0.0.0-20260608111724-c30cc73c6b91/go.mod h1:xcm86+meY59A4Rs62c8wVAznTuPk2QQW/yijPWZxHLw=
-github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621 h1:4Ga0w0uuWUw8Q3KgJsgMncH+1F2S048y0eCAzSSlYbA=
-github.com/fbm3307/toolchainapi v0.0.0-20260608110443-4e4fa9fe0621/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -30,11 +30,12 @@ const (
 )
 
 func TestPhoneLookupMode(t *testing.T) {
-	await := WaitForDeployments(t)
-	hostAwait := await.Host()
+	t.Parallel()
+	awaitilities := WaitForDeployments(t)
+	hostAwait := awaitilities.Host()
 	route := hostAwait.RegistrationServiceURL
 
-	t.Run("log mode stores phone lookup annotations when lookup succeeds", func(t *testing.T) {
+	t.Run("log mode stores annotations and user is provisioned", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
 		userSignup, token := signup(t, hostAwait)
@@ -44,7 +45,7 @@ func TestPhoneLookupMode(t *testing.T) {
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
 				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRiskBlocked), http.StatusNoContent)
 
-		// then
+		// then — verification code is set and lookup details are recorded
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
 		require.NoError(t, err)
@@ -52,6 +53,42 @@ func TestPhoneLookupMode(t *testing.T) {
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 		assert.False(t, states.Rejected(userSignup), "UserSignup should NOT be rejected in log mode")
+
+		// complete verification and confirm user is provisioned
+		NewHTTPRequest(t).InvokeEndpoint("GET", route+fmt.Sprintf("/api/v1/signup/verification/%s",
+			userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]), token, "", http.StatusOK)
+
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, hostAwait.Namespace,
+				func(instance *toolchainv1alpha1.UserSignup) {
+					states.SetApprovedManually(instance, true)
+				})
+		require.NoError(t, err)
+
+		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup)
+	})
+
+	t.Run("enabled mode rejects high-risk phone number", func(t *testing.T) {
+		// given
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().
+			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled).
+			Verification().PhoneLookupExcludedCountries([]string{"US", "CA"}))
+		userSignup, token := signup(t, hostAwait)
+
+		// when
+		responseMap := NewHTTPRequest(t).
+			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRiskBlocked), http.StatusForbidden).
+			UnmarshalMap()
+
+		// then
+		require.NotEmpty(t, responseMap)
+		assert.Equal(t, "Forbidden", responseMap["status"])
+
+		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name)
+		require.NoError(t, err)
+		assert.True(t, states.Rejected(userSignup), "UserSignup should be rejected in enabled mode with high-risk phone")
+		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 
 	t.Run("enabled mode blocks verification for previously rejected signup", func(t *testing.T) {
@@ -82,7 +119,7 @@ func TestPhoneLookupMode(t *testing.T) {
 		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 
-	t.Run("enabled mode skips lookup for US numbers", func(t *testing.T) {
+	t.Run("enabled mode skips lookup for US numbers and user is provisioned", func(t *testing.T) {
 		// given
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().
 			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled).
@@ -101,5 +138,19 @@ func TestPhoneLookupMode(t *testing.T) {
 
 		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(t, states.Rejected(userSignup), "UserSignup should NOT be rejected for excluded country")
+
+		// complete verification and confirm user is provisioned
+		NewHTTPRequest(t).InvokeEndpoint("GET", route+fmt.Sprintf("/api/v1/signup/verification/%s",
+			userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]), token, "", http.StatusOK)
+
+		userSignup, err = wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, hostAwait.Namespace,
+				func(instance *toolchainv1alpha1.UserSignup) {
+					states.SetApprovedManually(instance, true)
+				})
+		require.NoError(t, err)
+
+		VerifyResourcesProvisionedForSignup(t, awaitilities, userSignup)
 	})
 }

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -15,6 +15,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Twilio test credentials with magic lookup numbers return deterministic SMS Pumping Risk
+// responses at no cost. The API takes country_code and phone_number separately.
+// See: https://www.twilio.com/docs/lookup/magic-numbers-for-lookup/testing-sms-pumping-risk-with-magic-numbers
+//
+// Magic numbers used:
+//
+//	+441234567890 → high risk, not blocked, score 2
+//	+441234567891 → high risk, blocked, score 34
+//	+911234567890 → low risk, not blocked, score 2
+const (
+	twilioMagicPhoneHighRisk        = "1234567890" // +44 prefix → high risk, not blocked
+	twilioMagicPhoneHighRiskBlocked = "1234567891" // +44 prefix → high risk, blocked
+)
+
 func TestPhoneLookupMode(t *testing.T) {
 	await := WaitForDeployments(t)
 	hostAwait := await.Host()
@@ -30,11 +44,9 @@ func TestPhoneLookupMode(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled))
 
 		userSignup, token := signup(t, hostAwait)
-		phoneNumber := uniqueUKPhoneNumber()
-
 		NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusNoContent)
 
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
@@ -48,27 +60,19 @@ func TestPhoneLookupMode(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
 
 		userSignup, token := signup(t, hostAwait)
-		phoneNumber := uniqueUKPhoneNumber()
-
 		NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRiskBlocked), http.StatusNoContent)
 
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
 		require.NoError(t, err)
 
-		lookupResult := userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey]
-		if lookupResult == "" {
-			t.Log("Twilio Lookup did not return a result (fail-open); skipping lookup annotation assertions")
-			return
-		}
-
-		assert.Contains(t, []string{"allowed", "rejected"}, lookupResult)
+		assert.Equal(t, "rejected", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
-		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey])
-		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey])
-		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupRiskScoreAnnotationKey])
+		assert.Equal(t, "high", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey])
+		assert.Equal(t, "true", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey])
+		assert.Equal(t, "34", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupRiskScoreAnnotationKey])
 		// verification must proceed in log mode even when lookup result is rejected
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
@@ -77,8 +81,6 @@ func TestPhoneLookupMode(t *testing.T) {
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
 
 		userSignup, token := signup(t, hostAwait)
-		phoneNumber := uniqueUKPhoneNumber()
-
 		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
 			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
@@ -91,7 +93,7 @@ func TestPhoneLookupMode(t *testing.T) {
 
 		responseMap := NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusForbidden).
+				fmt.Sprintf(`{ "country_code":"+91", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusForbidden).
 			UnmarshalMap()
 
 		require.NotEmpty(t, responseMap)
@@ -120,10 +122,4 @@ func TestPhoneLookupMode(t *testing.T) {
 		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
-}
-
-func uniqueUKPhoneNumber() string {
-	// UK mobile numbers are 10 digits after country code; use a unique suffix to avoid phone-in-use conflicts
-	suffix := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")[:10]
-	return "77009" + suffix[len(suffix)-5:]
 }

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -1,0 +1,132 @@
+package parallel
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
+	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPhoneLookupMode(t *testing.T) {
+	await := WaitForDeployments(t)
+	hostAwait := await.Host()
+	route := hostAwait.RegistrationServiceURL
+
+	t.Run("phoneLookupMode can be set on ToolchainConfig", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("log"))
+		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode("log"))
+
+		config := hostAwait.GetToolchainConfig(t)
+		require.NotNil(t, config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
+		assert.Equal(t, "log", *config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
+	})
+
+	t.Run("disabled mode skips phone lookup annotations", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("disabled"))
+
+		userSignup, token := signup(t, hostAwait)
+		phoneNumber := uniqueUKPhoneNumber()
+
+		NewHTTPRequest(t).
+			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+
+		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
+			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
+		require.NoError(t, err)
+
+		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+	})
+
+	t.Run("log mode stores phone lookup annotations when lookup succeeds", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("log"))
+
+		userSignup, token := signup(t, hostAwait)
+		phoneNumber := uniqueUKPhoneNumber()
+
+		NewHTTPRequest(t).
+			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+
+		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
+			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
+		require.NoError(t, err)
+
+		lookupResult := userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey]
+		if lookupResult == "" {
+			t.Log("Twilio Lookup did not return a result (fail-open); skipping lookup annotation assertions")
+			return
+		}
+
+		assert.Contains(t, []string{"allowed", "rejected"}, lookupResult)
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupPhoneHashAnnotationKey])
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey])
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey])
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupRiskScoreAnnotationKey])
+		// verification must proceed in log mode even when lookup result is rejected
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	t.Run("enabled mode blocks verification for previously rejected signup", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("enabled"))
+
+		userSignup, token := signup(t, hostAwait)
+		phoneNumber := uniqueUKPhoneNumber()
+
+		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
+			Update(userSignup.Name, hostAwait.Namespace,
+				func(us *toolchainv1alpha1.UserSignup) {
+					if us.Annotations == nil {
+						us.Annotations = map[string]string{}
+					}
+					us.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey] = "rejected"
+				})
+		require.NoError(t, err)
+
+		responseMap := NewHTTPRequest(t).
+			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
+				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, phoneNumber), http.StatusForbidden).
+			UnmarshalMap()
+
+		require.NotEmpty(t, responseMap)
+		assert.Equal(t, "Forbidden", responseMap["status"])
+
+		userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name)
+		require.NoError(t, err)
+		assert.Equal(t, "rejected", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+
+	t.Run("enabled mode skips lookup for US numbers", func(t *testing.T) {
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("enabled"))
+
+		userSignup, token := signup(t, hostAwait)
+		phoneNumber := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")[:10]
+
+		NewHTTPRequest(t).
+			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
+				fmt.Sprintf(`{ "country_code":"+1", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+
+		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
+			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
+		require.NoError(t, err)
+
+		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupResultAnnotationKey])
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+	})
+}
+
+func uniqueUKPhoneNumber() string {
+	// UK mobile numbers are 10 digits after country code; use a unique suffix to avoid phone-in-use conflicts
+	suffix := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")[:10]
+	return "77009" + suffix[len(suffix)-5:]
+}

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -21,12 +21,9 @@ func TestPhoneLookupMode(t *testing.T) {
 	route := hostAwait.RegistrationServiceURL
 
 	t.Run("phoneLookupMode can be set on ToolchainConfig", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
-		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
-
-		config := hostAwait.GetToolchainConfig(t)
-		require.NotNil(t, config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
-		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, *config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
+		// Non-default value: CRD default "log" is omitted in spec when set explicitly, so use "enabled" to verify persistence.
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
+		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
 	})
 
 	t.Run("disabled mode skips phone lookup annotations", func(t *testing.T) {

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -21,16 +21,16 @@ func TestPhoneLookupMode(t *testing.T) {
 	route := hostAwait.RegistrationServiceURL
 
 	t.Run("phoneLookupMode can be set on ToolchainConfig", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("log"))
-		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode("log"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
+		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
 
 		config := hostAwait.GetToolchainConfig(t)
 		require.NotNil(t, config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
-		assert.Equal(t, "log", *config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
+		assert.Equal(t, toolchainv1alpha1.PhoneLookupModeLog, *config.Spec.Host.RegistrationService.Verification.PhoneLookupMode)
 	})
 
 	t.Run("disabled mode skips phone lookup annotations", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("disabled"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled))
 
 		userSignup, token := signup(t, hostAwait)
 		phoneNumber := uniqueUKPhoneNumber()
@@ -48,7 +48,7 @@ func TestPhoneLookupMode(t *testing.T) {
 	})
 
 	t.Run("log mode stores phone lookup annotations when lookup succeeds", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("log"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
 
 		userSignup, token := signup(t, hostAwait)
 		phoneNumber := uniqueUKPhoneNumber()
@@ -77,7 +77,7 @@ func TestPhoneLookupMode(t *testing.T) {
 	})
 
 	t.Run("enabled mode blocks verification for previously rejected signup", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("enabled"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
 
 		userSignup, token := signup(t, hostAwait)
 		phoneNumber := uniqueUKPhoneNumber()
@@ -107,7 +107,7 @@ func TestPhoneLookupMode(t *testing.T) {
 	})
 
 	t.Run("enabled mode skips lookup for US numbers", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode("enabled"))
+		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
 
 		userSignup, token := signup(t, hostAwait)
 		phoneNumber := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")[:10]

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -26,6 +26,7 @@ import (
 const (
 	twilioMagicPhoneHighRisk        = "1234567890" // +44 prefix → high risk, not blocked
 	twilioMagicPhoneHighRiskBlocked = "1234567891" // +44 prefix → high risk, blocked
+	usTestPhone                     = "2025550123" // +1 prefix → fictional NANPA 555-01XX range, safe with test credentials
 )
 
 func TestPhoneLookupMode(t *testing.T) {
@@ -88,10 +89,10 @@ func TestPhoneLookupMode(t *testing.T) {
 			Verification().PhoneLookupExcludedCountries([]string{"US", "CA"}))
 		userSignup, token := signup(t, hostAwait)
 
-		// when — use the magic number; US is excluded so lookup is never called
+		// when — US is excluded so lookup is never called
 		NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+1", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusNoContent)
+				fmt.Sprintf(`{ "country_code":"+1", "phone_number":"%s" }`, usTestPhone), http.StatusNoContent)
 
 		// then
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -95,7 +95,7 @@ func TestPhoneLookupMode(t *testing.T) {
 					if us.Annotations == nil {
 						us.Annotations = map[string]string{}
 					}
-					us.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = `{"result":"rejected","phone_hash":"abc123"}`
+					us.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = `{"result":"rejected"}`
 				})
 		require.NoError(t, err)
 

--- a/test/e2e/parallel/phone_lookup_test.go
+++ b/test/e2e/parallel/phone_lookup_test.go
@@ -1,17 +1,15 @@
 package parallel
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	. "github.com/codeready-toolchain/toolchain-e2e/testsupport"
 	"github.com/codeready-toolchain/toolchain-e2e/testsupport/wait"
-	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,101 +28,72 @@ const (
 	twilioMagicPhoneHighRiskBlocked = "1234567891" // +44 prefix → high risk, blocked
 )
 
-func phoneLookupDetailsResult(t *testing.T, signup *toolchainv1alpha1.UserSignup) string {
-	t.Helper()
-	raw := signup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey]
-	if raw == "" {
-		return ""
-	}
-	var details map[string]string
-	require.NoError(t, json.Unmarshal([]byte(raw), &details))
-	return details["result"]
-}
-
 func TestPhoneLookupMode(t *testing.T) {
 	await := WaitForDeployments(t)
 	hostAwait := await.Host()
 	route := hostAwait.RegistrationServiceURL
 
-	t.Run("phoneLookupMode can be set on ToolchainConfig", func(t *testing.T) {
-		// Non-default value: CRD default "log" is omitted in spec when set explicitly, so use "enabled" to verify persistence.
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
-		VerifyToolchainConfig(t, hostAwait, wait.UntilToolchainConfigHasPhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
-	})
-
-	t.Run("disabled mode skips phone lookup annotations", func(t *testing.T) {
-		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeDisabled))
-
-		userSignup, token := signup(t, hostAwait)
-		NewHTTPRequest(t).
-			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusNoContent)
-
-		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
-			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
-		require.NoError(t, err)
-
-		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
-	})
-
 	t.Run("log mode stores phone lookup annotations when lookup succeeds", func(t *testing.T) {
+		// given
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeLog))
-
 		userSignup, token := signup(t, hostAwait)
+
+		// when
 		NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
 				fmt.Sprintf(`{ "country_code":"+44", "phone_number":"%s" }`, twilioMagicPhoneHighRiskBlocked), http.StatusNoContent)
 
+		// then
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
 		require.NoError(t, err)
 
-		assert.Equal(t, "rejected", phoneLookupDetailsResult(t, userSignup))
-		assert.Equal(t, "high", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupCarrierRiskAnnotationKey])
-		assert.Equal(t, "true", userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupNumberBlockedAnnotationKey])
+		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey])
 		assert.NotEmpty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
+		assert.False(t, states.Rejected(userSignup), "UserSignup should NOT be rejected in log mode")
 	})
 
 	t.Run("enabled mode blocks verification for previously rejected signup", func(t *testing.T) {
+		// given
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled))
-
 		userSignup, token := signup(t, hostAwait)
+
 		_, err := wait.For(t, hostAwait.Awaitility, &toolchainv1alpha1.UserSignup{}).
 			Update(userSignup.Name, hostAwait.Namespace,
 				func(us *toolchainv1alpha1.UserSignup) {
-					if us.Annotations == nil {
-						us.Annotations = map[string]string{}
-					}
-					us.Annotations[toolchainv1alpha1.UserSignupPhoneLookupDetailsAnnotationKey] = `{"result":"rejected"}`
+					states.SetRejected(us, true)
 				})
 		require.NoError(t, err)
 
+		// when
 		responseMap := NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
 				fmt.Sprintf(`{ "country_code":"+91", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusForbidden).
 			UnmarshalMap()
 
+		// then
 		require.NotEmpty(t, responseMap)
 		assert.Equal(t, "Forbidden", responseMap["status"])
 
 		userSignup, err = hostAwait.WaitForUserSignup(t, userSignup.Name)
 		require.NoError(t, err)
-		assert.Equal(t, "rejected", phoneLookupDetailsResult(t, userSignup))
+		assert.True(t, states.Rejected(userSignup), "UserSignup should remain rejected")
 		assert.Empty(t, userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey])
 	})
 
 	t.Run("enabled mode skips lookup for US numbers", func(t *testing.T) {
+		// given
 		hostAwait.UpdateToolchainConfig(t, testconfig.RegistrationService().
 			Verification().PhoneLookupMode(toolchainv1alpha1.PhoneLookupModeEnabled).
 			Verification().PhoneLookupExcludedCountries([]string{"US", "CA"}))
-
 		userSignup, token := signup(t, hostAwait)
-		phoneNumber := strings.ReplaceAll(uuid.Must(uuid.NewV4()).String(), "-", "")[:10]
 
+		// when — use the magic number; US is excluded so lookup is never called
 		NewHTTPRequest(t).
 			InvokeEndpoint("PUT", route+"/api/v1/signup/verification", token,
-				fmt.Sprintf(`{ "country_code":"+1", "phone_number":"%s" }`, phoneNumber), http.StatusNoContent)
+				fmt.Sprintf(`{ "country_code":"+1", "phone_number":"%s" }`, twilioMagicPhoneHighRisk), http.StatusNoContent)
 
+		// then
 		userSignup, err := hostAwait.WaitForUserSignup(t, userSignup.Name,
 			wait.UntilUserSignupHasAnnotationNotEmpty(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey))
 		require.NoError(t, err)

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -480,6 +481,34 @@ func ContainsCondition(expected toolchainv1alpha1.Condition) UserSignupWaitCrite
 			e, _ := yaml.Marshal(expected)
 			a, _ := yaml.Marshal(actual.Status.Conditions)
 			return fmt.Sprintf("expected conditions to contain: %s.\n\tactual: %s", e, a)
+		},
+	}
+}
+
+// UntilUserSignupHasAnnotation returns a `UserSignupWaitCriterion` which checks that the given
+// UserSignup has an annotation with the expected key and value
+func UntilUserSignupHasAnnotation(key, value string) UserSignupWaitCriterion {
+	return UserSignupWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.UserSignup) bool {
+			actualValue, exist := actual.Annotations[key]
+			return exist && actualValue == value
+		},
+		Diff: func(actual *toolchainv1alpha1.UserSignup) string {
+			return fmt.Sprintf("expected UserSignup annotation '%s' to be '%s'\nbut it was '%s'", key, value, actual.Annotations[key])
+		},
+	}
+}
+
+// UntilUserSignupHasAnnotationNotEmpty returns a `UserSignupWaitCriterion` which checks that the given
+// UserSignup has a non-empty annotation for the expected key
+func UntilUserSignupHasAnnotationNotEmpty(key string) UserSignupWaitCriterion {
+	return UserSignupWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.UserSignup) bool {
+			actualValue, exist := actual.Annotations[key]
+			return exist && actualValue != ""
+		},
+		Diff: func(actual *toolchainv1alpha1.UserSignup) string {
+			return fmt.Sprintf("expected UserSignup annotation '%s' to be non-empty\nbut it was '%s'", key, actual.Annotations[key])
 		},
 	}
 }
@@ -1693,6 +1722,19 @@ func UntilToolchainConfigHasVerificationEnabled(expected bool) ToolchainConfigWa
 			e, _ := yaml.Marshal(expected)
 			a, _ := yaml.Marshal(actual.Spec.Host.RegistrationService.Verification.Enabled)
 			return fmt.Sprintf("expected approval domains to contain: %s.\n\tactual: %s", e, a)
+		},
+	}
+}
+
+func UntilToolchainConfigHasPhoneLookupMode(expected string) ToolchainConfigWaitCriterion {
+	return ToolchainConfigWaitCriterion{
+		Match: func(actual *toolchainv1alpha1.ToolchainConfig) bool {
+			mode := configuration.GetString(actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode, "log")
+			return mode == expected
+		},
+		Diff: func(actual *toolchainv1alpha1.ToolchainConfig) string {
+			mode := configuration.GetString(actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode, "log")
+			return fmt.Sprintf("expected phoneLookupMode to be '%s'.\n\tactual: '%s'", expected, mode)
 		},
 	}
 }

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"

--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -13,7 +13,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
-	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
@@ -1726,14 +1725,20 @@ func UntilToolchainConfigHasVerificationEnabled(expected bool) ToolchainConfigWa
 	}
 }
 
-func UntilToolchainConfigHasPhoneLookupMode(expected string) ToolchainConfigWaitCriterion {
+func UntilToolchainConfigHasPhoneLookupMode(expected toolchainv1alpha1.PhoneLookupMode) ToolchainConfigWaitCriterion {
 	return ToolchainConfigWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.ToolchainConfig) bool {
-			mode := configuration.GetString(actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode, "log")
+			mode := toolchainv1alpha1.PhoneLookupModeLog
+			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
+				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
+			}
 			return mode == expected
 		},
 		Diff: func(actual *toolchainv1alpha1.ToolchainConfig) string {
-			mode := configuration.GetString(actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode, "log")
+			mode := toolchainv1alpha1.PhoneLookupModeLog
+			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
+				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
+			}
 			return fmt.Sprintf("expected phoneLookupMode to be '%s'.\n\tactual: '%s'", expected, mode)
 		},
 	}


### PR DESCRIPTION
Add twilio v2 lookup api and test related to it . 

related Prs:
Registration-Service: https://github.com/codeready-toolchain/registration-service/pull/595
toolchain-Common: https://github.com/codeready-toolchain/toolchain-common/pull/532
host operator: https://github.com/codeready-toolchain/host-operator/pull/1268
API: https://github.com/codeready-toolchain/api/pull/509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable phone lookup mode (disabled, enabled, log) affecting signup verification: disabled skips lookups, log records lookup results, enabled can block rejected numbers while skipping lookups for US numbers.

* **Tests**
  * Added end-to-end tests covering phone lookup modes and signup verification outcomes.
  * Added test utilities to wait for signup annotations and validate phone-lookup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->