### PR TITLE
env(dev): enable SpaceRequestController

### DIFF
--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -4,40 +4,64 @@ ignored-vulnerabilities:
   # Fixed in: net/url@go1.25.8
   - id: GO-2026-4601
     info: https://pkg.go.dev/vuln/GO-2026-4601
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # FileInfo can escape from a Root in os
   # Found in: os@go1.24.13
   # Fixed in: os@go1.25.8
   - id: GO-2026-4602
     info: https://pkg.go.dev/vuln/GO-2026-4602
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls
   # Found in: crypto/tls@go1.24.13
   # Fixed in: crypto/tls@go1.25.9
   - id: GO-2026-4870
     info: https://pkg.go.dev/vuln/GO-2026-4870
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # Inefficient policy validation in crypto/x509
   # Found in: crypto/x509@go1.24.13
   # Fixed in: crypto/x509@go1.25.9
   - id: GO-2026-4946
     info: https://pkg.go.dev/vuln/GO-2026-4946
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net
   # Found in: golang.org/x/net/http2@v0.47.0
   # Fixed in: golang.org/x/net/http2@v0.53.0
   - id: GO-2026-4918
     info: https://pkg.go.dev/vuln/GO-2026-4918
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # Unexpected work during chain building in crypto/x509
   # Found in: crypto/x509@go1.24.13
   # Fixed in: crypto/x509@go1.25.9
   - id: GO-2026-4947
     info: https://pkg.go.dev/vuln/GO-2026-4947
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
   # Panic in Dial and LookupPort when handling NUL byte on Windows in net
   # Found in: net@go1.24.13
   # Fixed in: net@go1.25.10
   - id: GO-2026-4971
     info: https://pkg.go.dev/vuln/GO-2026-4971
-    silence-until: 2026-06-18
+    silence-until: 2026-07-17
+  # Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
+  # Found in: golang.org/x/net/idna@v0.47.0
+  # Fixed in: golang.org/x/net/idna@v0.55.0
+  - id: GO-2026-5026
+    info: https://pkg.go.dev/vuln/GO-2026-5026
+    silence-until: 2026-07-17
+  # Inefficient candidate hostname parsing in crypto/x509
+  # Found in: crypto/x509@go1.24.13
+  # Fixed in: crypto/x509@go1.25.11
+  - id: GO-2026-5037
+    info: https://pkg.go.dev/vuln/GO-2026-5037
+    silence-until: 2026-07-17
+  # Quadratic complexity in WordDecoder.DecodeHeader in mime
+  # Found in: mime@go1.24.13
+  # Fixed in: mime@go1.25.11
+  - id: GO-2026-5038
+    info: https://pkg.go.dev/vuln/GO-2026-5038
+    silence-until: 2026-07-17
+  # Arbitrary inputs are included in errors without any escaping in net/textproto
+  # Found in: net/textproto@go1.24.13
+  # Fixed in: net/textproto@go1.25.11
+  - id: GO-2026-5039
+    info: https://pkg.go.dev/vuln/GO-2026-5039
+    silence-until: 2026-07-17

--- a/deploy/host-operator/dev/toolchainconfig.yaml
+++ b/deploy/host-operator/dev/toolchainconfig.yaml
@@ -10,6 +10,9 @@ spec:
       deactivationDomainsExcluded: '@redhat.com'
     registrationService:
       environment: 'dev'
+    spaceConfig:
+      spaceBindingRequestEnabled: false
+      spaceRequestEnabled: true
     tiers:
       defaultSpaceTier: 'base1ns'
   members:


### PR DESCRIPTION
Enabled by default since we now support SpaceRequests on staging and prod for OpenClaw

so I don't have to patch the config on my temp cluster everytime I need to do some testing ;)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added space configuration controls to enable space requests by default while disabling space binding request functionality.
* **Security / Maintenance**
  * Updated vulnerability scanning suppression settings to extend the silence window and include additional known issues with reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->