### PR TITLE
fix: increase SSO login password field timeout to 60s

### DIFF
--- a/testsupport/devsandbox-dashboard/login.go
+++ b/testsupport/devsandbox-dashboard/login.go
@@ -72,6 +72,15 @@ func (lp *LoginPage) Login(t *testing.T, loginUsername, loginPw string) {
 	if lp.Env == DevEnv || lp.Env == ProdEnv {
 		err := lp.NextBtn.Click()
 		require.NoError(t, err)
+
+		// After "Next", the SSO server validates the username before rendering the
+		// password form. This server-side call can be slow under load, so wait with
+		// a longer timeout than the default 30s to avoid intermittent failures.
+		err = lp.LoginPwLoc.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateVisible,
+			Timeout: playwright.Float(60000),
+		})
+		require.NoError(t, err)
 	}
 
 	err = lp.LoginPwLoc.Fill(loginPw)


### PR DESCRIPTION
The ci-jobs have been failing intermittently with a Playwright timeout at `login.go:78` when filling the password field after clicking "Next" on the Red Hat SSO login page.

After clicking "Next", the SSO server validates the username server-side before rendering the password form. This call can be intermittently slow, exceeding the default 30s Playwright timeout.

- [June 12 failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod/2065358477227724800) — `TestActivitiesPage` failed at `login.go:78`
- [June 14 failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily-prod/2066083259632062464) — `TestActivitiesPage` passed but `TestFreshSignup` failed at the same `login.go:78`


**Fix:** Add an explicit `WaitFor(visible)` with a 60s timeout on the password field locator after the "Next" click, matching the timeout already used for `Navigate()`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced login test synchronization to improve reliability during the authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->