### PR TITLE
SANDBOX-1889: update e2e wait helper default to PhoneLookupModeDisabled

### DIFF
--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1728,14 +1728,14 @@ func UntilToolchainConfigHasVerificationEnabled(expected bool) ToolchainConfigWa
 func UntilToolchainConfigHasPhoneLookupMode(expected toolchainv1alpha1.PhoneLookupMode) ToolchainConfigWaitCriterion {
 	return ToolchainConfigWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.ToolchainConfig) bool {
-			mode := toolchainv1alpha1.PhoneLookupModeLog
+			mode := toolchainv1alpha1.PhoneLookupModeDisabled
 			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
 				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
 			}
 			return mode == expected
 		},
 		Diff: func(actual *toolchainv1alpha1.ToolchainConfig) string {
-			mode := toolchainv1alpha1.PhoneLookupModeLog
+			mode := toolchainv1alpha1.PhoneLookupModeDisabled
 			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
 				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
 			}


### PR DESCRIPTION
Update UntilToolchainConfigHasPhoneLookupMode to treat nil as PhoneLookupModeDisabled instead of PhoneLookupModeLog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of an unset phone lookup setting so it now matches the disabled default and reports differences more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->