### PR TITLE
SANDBOX-1889: update e2e wait helper default to PhoneLookupModeDisabled

### DIFF
--- a/testsupport/wait/host.go
+++ b/testsupport/wait/host.go
@@ -1728,14 +1728,14 @@ func UntilToolchainConfigHasVerificationEnabled(expected bool) ToolchainConfigWa
 func UntilToolchainConfigHasPhoneLookupMode(expected toolchainv1alpha1.PhoneLookupMode) ToolchainConfigWaitCriterion {
 	return ToolchainConfigWaitCriterion{
 		Match: func(actual *toolchainv1alpha1.ToolchainConfig) bool {
-			mode := toolchainv1alpha1.PhoneLookupModeLog
+			mode := toolchainv1alpha1.PhoneLookupModeDisabled
 			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
 				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
 			}
 			return mode == expected
 		},
 		Diff: func(actual *toolchainv1alpha1.ToolchainConfig) string {
-			mode := toolchainv1alpha1.PhoneLookupModeLog
+			mode := toolchainv1alpha1.PhoneLookupModeDisabled
 			if actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode != nil {
 				mode = *actual.Spec.Host.RegistrationService.Verification.PhoneLookupMode
 			}


### PR DESCRIPTION
Update UntilToolchainConfigHasPhoneLookupMode to treat nil as PhoneLookupModeDisabled instead of PhoneLookupModeLog.

Related Prs
API: https://github.com/codeready-toolchain/api/pull/515
host-operator: https://github.com/codeready-toolchain/host-operator/pull/1274

registration service: https://github.com/codeready-toolchain/registration-service/pull/604



Assisted By : Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated phone lookup mode checks to treat an unset value as disabled by default.
  * Improved the reported differences when the current setting does not match the expected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->