### PR TITLE
Add allow-unsafe-pr-checkout: true for fork PR checkouts

### DIFF
--- a/.github/workflows/publish-components-for-e2e-tests.yml
+++ b/.github/workflows/publish-components-for-e2e-tests.yml
@@ -31,6 +31,7 @@ jobs:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
+        allow-unsafe-pr-checkout: true
 
     # If the workflow was triggered based on comment, then we need to get the information about the PR
     - name: Send Github API Request to get PR data
@@ -51,6 +52,7 @@ jobs:
         repository: ${{ fromJson(steps.request.outputs.data).head.repo.full_name }}
         ref: ${{ fromJson(steps.request.outputs.data).head.ref }}
         fetch-depth: 0
+        allow-unsafe-pr-checkout: true
 
     - name: Install Go
       uses: actions/setup-go@v6


### PR DESCRIPTION
actions/checkout@v7 refuses to check out fork PR code from a pull_request_target workflow without this flag. This mirrors the fix applied to registration-service in codeready-toolchain/registration-service#600.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the automated workflow used to publish components for end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->