### PR TITLE
Update perf test README to mention OCP 4.21.x

### DIFF
--- a/setup/README.adoc
+++ b/setup/README.adoc
@@ -5,7 +5,7 @@ This document describes how to use the setup tool to set up a Dev Sandbox enviro
 == Prereqs
 
 . Ensure your go version matches the specified version in https://github.com/codeready-toolchain/toolchain-e2e/blob/master/go.mod
-. Provision the *latest available* GA version of *OCP 4.15.x* on AWS with sufficient resources: 3 `m5.8xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
+. Provision the *latest available* GA version of *OCP 4.21.x* on AWS with sufficient resources: 3 `m5.8xlarge` master nodes and 3 `m5.2xlarge` worker nodes.
 +
 The latest version of openshift-install can be downloaded from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the prerequisites to use the latest available GA version of OCP 4.21.x on AWS instead of OCP 4.15.x.
  * Kept the existing master and worker counts and instance sizes unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->