### PR TITLE
fix: remove invalid inputs from govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -16,6 +16,4 @@ jobs:
     - name: Run govulncheck
       uses: codeready-toolchain/toolchain-cicd/govulncheck-action@master
       with:
-        go-version-file: go.mod
-        cache: false
         config: .govulncheck.yaml


### PR DESCRIPTION
## Summary
- The upstream `govulncheck-action` switched to a Docker-based action that no longer accepts `go-version-file` and `cache` inputs
- Removes the invalid inputs, keeping only `config` which is still supported

## Test plan
- [ ] Verify `govulncheck` CI check passes on this PR

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning configuration to use the project’s dedicated settings file.
  * Simplified the scanning workflow configuration by removing obsolete options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->