### PR TITLE
feat: no idling for Claw namespaces

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -590,7 +590,7 @@ func (a *clawTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return clusterObjectsChecks(
 		clusterResourceQuotaClaw(),
 		numberOfClusterResourceQuotas(1),
-		idlers(43200, "claw"))
+		idlers(0, "claw"))
 }
 
 func clusterResourceQuotaClaw() clusterObjectsCheckCreator {


### PR DESCRIPTION
e2e tests for https://github.com/codeready-toolchain/host-operator/pull/1280

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated expected idle timeout behavior for the Claw tier to reflect immediate idling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->