### PR TITLE
fix: refresh govulncheck silence-until dates and add new CVEs

### DIFF
--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -4,64 +4,76 @@ ignored-vulnerabilities:
   # Fixed in: net/url@go1.25.8
   - id: GO-2026-4601
     info: https://pkg.go.dev/vuln/GO-2026-4601
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # FileInfo can escape from a Root in os
   # Found in: os@go1.24.13
   # Fixed in: os@go1.25.8
   - id: GO-2026-4602
     info: https://pkg.go.dev/vuln/GO-2026-4602
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls
   # Found in: crypto/tls@go1.24.13
   # Fixed in: crypto/tls@go1.25.9
   - id: GO-2026-4870
     info: https://pkg.go.dev/vuln/GO-2026-4870
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Inefficient policy validation in crypto/x509
   # Found in: crypto/x509@go1.24.13
   # Fixed in: crypto/x509@go1.25.9
   - id: GO-2026-4946
     info: https://pkg.go.dev/vuln/GO-2026-4946
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net
   # Found in: golang.org/x/net/http2@v0.47.0
   # Fixed in: golang.org/x/net/http2@v0.53.0
   - id: GO-2026-4918
     info: https://pkg.go.dev/vuln/GO-2026-4918
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Unexpected work during chain building in crypto/x509
   # Found in: crypto/x509@go1.24.13
   # Fixed in: crypto/x509@go1.25.9
   - id: GO-2026-4947
     info: https://pkg.go.dev/vuln/GO-2026-4947
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Panic in Dial and LookupPort when handling NUL byte on Windows in net
   # Found in: net@go1.24.13
   # Fixed in: net@go1.25.10
   - id: GO-2026-4971
     info: https://pkg.go.dev/vuln/GO-2026-4971
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
   # Found in: golang.org/x/net/idna@v0.47.0
   # Fixed in: golang.org/x/net/idna@v0.55.0
   - id: GO-2026-5026
     info: https://pkg.go.dev/vuln/GO-2026-5026
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Inefficient candidate hostname parsing in crypto/x509
   # Found in: crypto/x509@go1.24.13
   # Fixed in: crypto/x509@go1.25.11
   - id: GO-2026-5037
     info: https://pkg.go.dev/vuln/GO-2026-5037
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Quadratic complexity in WordDecoder.DecodeHeader in mime
   # Found in: mime@go1.24.13
   # Fixed in: mime@go1.25.11
   - id: GO-2026-5038
     info: https://pkg.go.dev/vuln/GO-2026-5038
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
   # Arbitrary inputs are included in errors without any escaping in net/textproto
   # Found in: net/textproto@go1.24.13
   # Fixed in: net/textproto@go1.25.11
   - id: GO-2026-5039
     info: https://pkg.go.dev/vuln/GO-2026-5039
-    silence-until: 2026-07-17
+    silence-until: 2026-08-31
+  # Invoking Encrypted Client Hello privacy leak in crypto/tls
+  # Found in: crypto/tls@go1.24.13
+  # Fixed in: crypto/tls@go1.25.12
+  - id: GO-2026-5856
+    info: https://pkg.go.dev/vuln/GO-2026-5856
+    silence-until: 2026-08-31
+  # Infinite loop on invalid input in golang.org/x/text
+  # Found in: golang.org/x/text/unicode/norm@v0.31.0
+  # Fixed in: golang.org/x/text/unicode/norm@v0.39.0
+  - id: GO-2026-5970
+    info: https://pkg.go.dev/vuln/GO-2026-5970
+    silence-until: 2026-08-31


### PR DESCRIPTION
## Summary

- Refresh expired `silence-until` dates from `2026-07-17` to `2026-08-31`
- Add 2 new Go 1.24 stdlib CVEs: GO-2026-5856 (crypto/tls) and GO-2026-5970 (golang.org/x/text)

All flagged CVEs are in Go 1.24 stdlib, fixed in Go 1.25.x. The Go version bump will be addressed as part of a future coordinated deps update across toolchain repos.

Mitigates #1306

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>