### PR TITLE
Handle compliant username prefix in Space/Idler lookups

### DIFF
--- a/setup/configuration/configuration.go
+++ b/setup/configuration/configuration.go
@@ -182,6 +182,14 @@ func homeDir() string {
 	return os.Getenv("USERPROFILE") // windows
 }
 
+// CandidateNames returns the possible resource names for a given username.
+// The sandbox operator may add a "crt-" prefix to certain usernames via
+// compliantUsername, so downstream resources (Space, Idler, namespace)
+// may be named differently from the original UserSignup.
+func CandidateNames(name string) []string {
+	return []string{name, "crt-" + name}
+}
+
 func ResultsDir() string {
 	return resultsDir
 }

--- a/setup/idlers/update_idler.go
+++ b/setup/idlers/update_idler.go
@@ -34,16 +34,18 @@ func UpdateTimeout(cl client.Client, username string, timeout time.Duration) err
 func getIdler(cl client.Client, name string) (*toolchainv1alpha1.Idler, error) {
 	idler := &toolchainv1alpha1.Idler{}
 	err := k8swait.PollUntilContextTimeout(context.TODO(), cfg.DefaultRetryInterval, cfg.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
-		err := cl.Get(context.TODO(), types.NamespacedName{
-			Name: name,
-		}, idler)
-		if errors.IsNotFound(err) {
-			return false, nil
-		} else if err != nil {
-			return false, err
+		for _, candidate := range cfg.CandidateNames(name) {
+			err := cl.Get(context.TODO(), types.NamespacedName{
+				Name: candidate,
+			}, idler)
+			if errors.IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return false, err
+			}
+			return test.ContainsCondition(idler.Status.Conditions, wait.Running()), nil
 		}
-		// check the status conditions, wait until the idler is "Ready/True"
-		return test.ContainsCondition(idler.Status.Conditions, wait.Running()), nil
+		return false, nil
 	})
 	return idler, err
 }

--- a/setup/idlers/update_idler_test.go
+++ b/setup/idlers/update_idler_test.go
@@ -1,0 +1,86 @@
+package idlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	cfg "github.com/codeready-toolchain/toolchain-e2e/setup/configuration"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUpdateTimeout(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		cfg.DefaultTimeout = time.Second * 1
+		idler := &toolchainv1alpha1.Idler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "user0001-dev",
+			},
+			Spec: toolchainv1alpha1.IdlerSpec{
+				TimeoutSeconds: 43200,
+			},
+			Status: toolchainv1alpha1.IdlerStatus{
+				Conditions: []toolchainv1alpha1.Condition{
+					{
+						Type:   toolchainv1alpha1.ConditionReady,
+						Status: corev1.ConditionTrue,
+						Reason: "Running",
+					},
+				},
+			},
+		}
+		cl := commontest.NewFakeClient(t, idler)
+
+		// when
+		err := UpdateTimeout(cl, "user0001", 15*time.Second)
+
+		// then
+		require.NoError(t, err)
+		updatedIdler := &toolchainv1alpha1.Idler{}
+		require.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: "user0001-dev"}, updatedIdler))
+		assert.Equal(t, int32(15), updatedIdler.Spec.TimeoutSeconds)
+	})
+
+	t.Run("compliant username differs from usersignup name", func(t *testing.T) {
+		// given
+		// Reproduces issue #1308: when the sandbox operator transforms
+		// the username (e.g. "default-0005" -> "crt-default-0005"),
+		// the Idler is named "crt-default-0005-dev", not "default-0005-dev".
+		cfg.DefaultTimeout = time.Millisecond * 100
+		idler := &toolchainv1alpha1.Idler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "crt-default-0005-dev",
+			},
+			Spec: toolchainv1alpha1.IdlerSpec{
+				TimeoutSeconds: 43200,
+			},
+			Status: toolchainv1alpha1.IdlerStatus{
+				Conditions: []toolchainv1alpha1.Condition{
+					{
+						Type:   toolchainv1alpha1.ConditionReady,
+						Status: corev1.ConditionTrue,
+						Reason: "Running",
+					},
+				},
+			},
+		}
+		cl := commontest.NewFakeClient(t, idler)
+
+		// when - using the original username (not the compliant one)
+		err := UpdateTimeout(cl, "default-0005", 15*time.Second)
+
+		// then - should find the idler even when the name was transformed
+		require.NoError(t, err)
+		updatedIdler := &toolchainv1alpha1.Idler{}
+		require.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: "crt-default-0005-dev"}, updatedIdler))
+		assert.Equal(t, int32(15), updatedIdler.Spec.TimeoutSeconds)
+	})
+}

--- a/setup/resources/create_resources.go
+++ b/setup/resources/create_resources.go
@@ -18,22 +18,24 @@ const userNSParam = "CURRENT_USER_NAMESPACE"
 var tmpls map[string]*templatev1.Template = make(map[string]*templatev1.Template)
 
 func CreateUserResourcesFromTemplateFiles(ctx context.Context, cl runtimeclient.Client, s *runtime.Scheme, username string, templatePaths []string) error {
-	userNS := fmt.Sprintf("%s-dev", username)
-	combinedObjsToProcess := []runtimeclient.Object{}
+	// load and validate all templates first so errors surface before the space wait
 	for _, templatePath := range templatePaths {
-		// get the template from the file if it hasn't been processed already
 		if _, ok := tmpls[templatePath]; !ok {
 			var err error
 			if tmpls[templatePath], err = templates.GetTemplateFromFile(templatePath); err != nil {
 				return fmt.Errorf("invalid template file: '%s': %w", templatePath, err)
 			}
 		}
-		tmpl := tmpls[templatePath]
+	}
 
-		// waiting for each space here prevents some edge cases where the setup job can progress beyond the usersignup job and fail with a timeout
-		if err := wait.ForSpace(cl, username); err != nil {
-			return err
-		}
+	resolvedName, err := wait.ForSpaceWithName(cl, username)
+	if err != nil {
+		return err
+	}
+	userNS := fmt.Sprintf("%s-dev", resolvedName)
+	combinedObjsToProcess := []runtimeclient.Object{}
+	for _, templatePath := range templatePaths {
+		tmpl := tmpls[templatePath]
 		processor := ctemplate.NewProcessor(s)
 		objsToProcess, err := processor.Process(tmpl.DeepCopy(), map[string]string{
 			userNSParam: userNS,

--- a/setup/resources/create_resources_test.go
+++ b/setup/resources/create_resources_test.go
@@ -61,6 +61,42 @@ func TestCreateUserResourcesFromTemplateFiles(t *testing.T) {
 			&corev1.Service{}))
 	})
 
+	t.Run("compliant username differs from usersignup name", func(t *testing.T) {
+		// given
+		// Reproduces issue #1308: when the sandbox operator transforms
+		// the username (e.g. "default-0005" -> "crt-default-0005"),
+		// the Space and namespace are named after the compliantUsername.
+		// The tool should resolve the compliant username and use it
+		// for Space lookup and namespace derivation.
+		t.Cleanup(func() {
+			tmpls = make(map[string]*templatev1.Template)
+		})
+		configuration.DefaultTimeout = time.Millisecond * 100
+
+		// Space exists under compliant name, not original username
+		space := testspace.NewSpace(configuration.HostOperatorNamespace, "crt-default-0005", testspace.WithCondition(
+			toolchainv1alpha1.Condition{
+				Type:   toolchainv1alpha1.ConditionReady,
+				Status: corev1.ConditionTrue,
+				Reason: "Provisioned",
+			}))
+		cl := commontest.NewFakeClient(t, space)
+		username := "default-0005"
+		templatePath := "user-workloads.yaml"
+
+		// when
+		err := CreateUserResourcesFromTemplateFiles(context.TODO(), cl, s, username, []string{templatePath})
+
+		// then - should succeed: resources deployed into crt-default-0005-dev
+		require.NoError(t, err)
+		assert.NoError(t, cl.Get(context.TODO(),
+			types.NamespacedName{
+				Namespace: "crt-default-0005-dev",
+				Name:      "nginx-deployment",
+			},
+			&appsv1.Deployment{}))
+	})
+
 	t.Run("failures", func(t *testing.T) {
 		t.Run("invalid template", func(t *testing.T) {
 			t.Run("file not found", func(t *testing.T) {

--- a/setup/wait/wait.go
+++ b/setup/wait/wait.go
@@ -18,6 +18,11 @@ import (
 )
 
 func ForSpace(cl client.Client, space string) error {
+	_, err := ForSpaceWithName(cl, space)
+	return err
+}
+
+func ForSpaceWithName(cl client.Client, space string) (string, error) {
 	sp := &toolchainv1alpha1.Space{}
 	expectedConditions := []toolchainv1alpha1.Condition{
 		{
@@ -26,24 +31,30 @@ func ForSpace(cl client.Client, space string) error {
 			Reason: "Provisioned",
 		},
 	}
+	var resolvedName string
 
 	if err := k8swait.PollUntilContextTimeout(context.TODO(), configuration.DefaultRetryInterval, configuration.DefaultTimeout, true, func(ctx context.Context) (bool, error) {
-		err := cl.Get(context.TODO(), types.NamespacedName{
-			Name:      space,
-			Namespace: configuration.HostOperatorNamespace,
-		}, sp)
-		if k8serrors.IsNotFound(err) {
-			return false, nil
-		} else if err != nil {
-			return false, err
-		} else if !test.ConditionsMatch(sp.Status.Conditions, expectedConditions...) {
-			return false, nil
+		for _, name := range configuration.CandidateNames(space) {
+			err := cl.Get(context.TODO(), types.NamespacedName{
+				Name:      name,
+				Namespace: configuration.HostOperatorNamespace,
+			}, sp)
+			if k8serrors.IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return false, err
+			} else if !test.ConditionsMatch(sp.Status.Conditions, expectedConditions...) {
+				resolvedName = name
+				return false, nil
+			}
+			resolvedName = name
+			return true, nil
 		}
-		return true, nil
+		return false, nil
 	}); err != nil {
-		return fmt.Errorf("space '%s' is not ready yet: %w", space, err)
+		return "", fmt.Errorf("space '%s' is not ready yet: %w", space, err)
 	}
-	return nil
+	return resolvedName, nil
 }
 
 func HasSubscriptionWithCriteria(cl client.Client, name, namespace string, criteria ...subCriteria) (bool, error) {

--- a/setup/wait/wait_test.go
+++ b/setup/wait/wait_test.go
@@ -40,6 +40,29 @@ func TestForSpace(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("compliant username differs from usersignup name", func(t *testing.T) {
+		// given
+		// Reproduces issue #1308: when the sandbox operator transforms
+		// the username (e.g. "default-0005" -> "crt-default-0005"),
+		// the Space is named after the compliantUsername, not the
+		// original UserSignup name.
+		configuration.DefaultTimeout = time.Millisecond * 100
+		space := testspace.NewSpace(configuration.HostOperatorNamespace, "crt-default-0005", testspace.WithCondition(
+			toolchainv1alpha1.Condition{
+				Type:   toolchainv1alpha1.ConditionReady,
+				Status: corev1.ConditionTrue,
+				Reason: "Provisioned",
+			}))
+		cl := test.NewFakeClient(t, space)
+
+		// when - looking up by the original username (not the compliant one)
+		err := wait.ForSpace(cl, "default-0005")
+
+		// then - ForSpace should find the space even when the name
+		// was transformed by the sandbox operator
+		require.NoError(t, err)
+	})
+
 	t.Run("failures", func(t *testing.T) {
 		t.Run("timeout", func(t *testing.T) {
 			// given


### PR DESCRIPTION
## Summary
- The sandbox operator transforms certain usernames via `compliantUsername` (adding a `crt-` prefix for names starting with `default`, `sandbox`, `redhat`, `kube`, `openshift`), but the perf setup tool assumed resource names always match the UserSignup name
- Adds fallback `crt-` prefix lookups in `ForSpace`, `getIdler`, and `CreateUserResourcesFromTemplateFiles` so the tool works regardless of username transformation
- Adds `ForSpaceWithName` to return the resolved space name for correct namespace derivation

Fixes #1308

## Test plan
- [x] New tests for all three affected paths (wait, idlers, resources) — TDD: tests written first, verified red, then implementation made them green
- [x] All existing tests still pass
- [ ] Manual verification with `--username default` on a live cluster

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability when usernames are transformed into compliant resource names.
  * Space and Idler detection now recognizes both requested and transformed names.
  * Resource creation waits for a resolved space once before deploying resources, reducing unnecessary delays.
  * Preserved existing space-waiting behavior while providing the resolved space name for setup operations.
* **Tests**
  * Added coverage for transformed usernames, Idler timeout updates, space resolution, and resource deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->