### PR TITLE
refactor: update toolchain-common with renamed ServerSideApplyClient type

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,9 +25,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.1.6
-        skip-pkg-cache: true
-        skip-build-cache: true
+        version: v2.12.2
         args: --config=./.golangci.yml --verbose
   
   unit-tests:

--- a/.govulncheck.yaml
+++ b/.govulncheck.yaml
@@ -1,67 +1,79 @@
 ignored-vulnerabilities:
-  # Incorrect parsing of IPv6 host literals in net/url
-  # Found in: net/url@go1.24.13
-  # Fixed in: net/url@go1.25.8
-  - id: GO-2026-4601
-    info: https://pkg.go.dev/vuln/GO-2026-4601
-    silence-until: 2026-07-17
-  # FileInfo can escape from a Root in os
-  # Found in: os@go1.24.13
-  # Fixed in: os@go1.25.8
-  - id: GO-2026-4602
-    info: https://pkg.go.dev/vuln/GO-2026-4602
-    silence-until: 2026-07-17
-  # Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls
-  # Found in: crypto/tls@go1.24.13
-  # Fixed in: crypto/tls@go1.25.9
-  - id: GO-2026-4870
-    info: https://pkg.go.dev/vuln/GO-2026-4870
-    silence-until: 2026-07-17
-  # Inefficient policy validation in crypto/x509
-  # Found in: crypto/x509@go1.24.13
-  # Fixed in: crypto/x509@go1.25.9
-  - id: GO-2026-4946
-    info: https://pkg.go.dev/vuln/GO-2026-4946
-    silence-until: 2026-07-17
-  # Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net
-  # Found in: golang.org/x/net/http2@v0.47.0
-  # Fixed in: golang.org/x/net/http2@v0.53.0
-  - id: GO-2026-4918
-    info: https://pkg.go.dev/vuln/GO-2026-4918
-    silence-until: 2026-07-17
-  # Unexpected work during chain building in crypto/x509
-  # Found in: crypto/x509@go1.24.13
-  # Fixed in: crypto/x509@go1.25.9
-  - id: GO-2026-4947
-    info: https://pkg.go.dev/vuln/GO-2026-4947
-    silence-until: 2026-07-17
-  # Panic in Dial and LookupPort when handling NUL byte on Windows in net
-  # Found in: net@go1.24.13
-  # Fixed in: net@go1.25.10
-  - id: GO-2026-4971
-    info: https://pkg.go.dev/vuln/GO-2026-4971
-    silence-until: 2026-07-17
-  # Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
-  # Found in: golang.org/x/net/idna@v0.47.0
-  # Fixed in: golang.org/x/net/idna@v0.55.0
-  - id: GO-2026-5026
-    info: https://pkg.go.dev/vuln/GO-2026-5026
-    silence-until: 2026-07-17
-  # Inefficient candidate hostname parsing in crypto/x509
-  # Found in: crypto/x509@go1.24.13
-  # Fixed in: crypto/x509@go1.25.11
-  - id: GO-2026-5037
-    info: https://pkg.go.dev/vuln/GO-2026-5037
-    silence-until: 2026-07-17
-  # Quadratic complexity in WordDecoder.DecodeHeader in mime
-  # Found in: mime@go1.24.13
-  # Fixed in: mime@go1.25.11
-  - id: GO-2026-5038
-    info: https://pkg.go.dev/vuln/GO-2026-5038
-    silence-until: 2026-07-17
-  # Arbitrary inputs are included in errors without any escaping in net/textproto
-  # Found in: net/textproto@go1.24.13
-  # Fixed in: net/textproto@go1.25.11
-  - id: GO-2026-5039
-    info: https://pkg.go.dev/vuln/GO-2026-5039
-    silence-until: 2026-07-17
+    # Incorrect parsing of IPv6 host literals in net/url
+    # Found in: net/url@go1.24.13
+    # Fixed in: net/url@go1.25.8
+    - id: GO-2026-4601
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4601
+    # FileInfo can escape from a Root in os
+    # Found in: os@go1.24.13
+    # Fixed in: os@go1.25.8
+    - id: GO-2026-4602
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4602
+    # Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls
+    # Found in: crypto/tls@go1.24.13
+    # Fixed in: crypto/tls@go1.25.9
+    - id: GO-2026-4870
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4870
+    # Inefficient policy validation in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.9
+    - id: GO-2026-4946
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4946
+    # Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net
+    # Found in: golang.org/x/net/http2@v0.47.0
+    # Fixed in: golang.org/x/net/http2@v0.53.0
+    - id: GO-2026-4918
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4918
+    # Unexpected work during chain building in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.9
+    - id: GO-2026-4947
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4947
+    # Panic in Dial and LookupPort when handling NUL byte on Windows in net
+    # Found in: net@go1.24.13
+    # Fixed in: net@go1.25.10
+    - id: GO-2026-4971
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-4971
+    # Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
+    # Found in: golang.org/x/net/idna@v0.47.0
+    # Fixed in: golang.org/x/net/idna@v0.55.0
+    - id: GO-2026-5026
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5026
+    # Inefficient candidate hostname parsing in crypto/x509
+    # Found in: crypto/x509@go1.24.13
+    # Fixed in: crypto/x509@go1.25.11
+    - id: GO-2026-5037
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5037
+    # Quadratic complexity in WordDecoder.DecodeHeader in mime
+    # Found in: mime@go1.24.13
+    # Fixed in: mime@go1.25.11
+    - id: GO-2026-5038
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5038
+    # Arbitrary inputs are included in errors without any escaping in net/textproto
+    # Found in: net/textproto@go1.24.13
+    # Fixed in: net/textproto@go1.25.11
+    - id: GO-2026-5039
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5039
+    # Invoking Encrypted Client Hello privacy leak in crypto/tls
+    # Found in: crypto/tls@go1.24.13
+    # Fixed in: crypto/tls@go1.25.12
+    - id: GO-2026-5856
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5856
+    # Infinite loop on invalid input in golang.org/x/text
+    # Found in: golang.org/x/text/unicode/norm@v0.31.0
+    # Fixed in: golang.org/x/text/unicode/norm@v0.39.0
+    - id: GO-2026-5970
+      silence-until: 2026-09-02
+      info: https://pkg.go.dev/vuln/GO-2026-5970

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-e2e
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20260804130313-0d4161d82454
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.18.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace
-
 require (
 	github.com/google/uuid v1.6.0
 	github.com/mxschmitt/playwright-go v0.6100.0

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace
+
 require (
 	github.com/google/uuid v1.6.0
 	github.com/mxschmitt/playwright-go v0.6100.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2 h1:i5izQYQWwi0Dbc2Mv/sDOJ5GIMH69O3n0jRwQaAWo9o=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a h1:3t4cvcI/6ZUxUSRZoGS/Q9jH9OFu6Sg26PMTtOPRok4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260804130313-0d4161d82454 h1:D3+dc9mEmLrq0XiG6xXDVJoZ+YChF7eX1OTKZ62ydfU=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260804130313-0d4161d82454/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2 h1:i5izQYQWwi0Dbc2Mv/sDOJ5GIMH69O3n0jRwQaAWo9o=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a h1:3t4cvcI/6ZUxUSRZoGS/Q9jH9OFu6Sg26PMTtOPRok4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -247,8 +249,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace h1:aW/k32FZO9wr4IcCR6adbdXdamiazxdEDV0VY16MU7w=
-github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2 h1:i5izQYQWwi0Dbc2Mv/sDOJ5GIMH69O3n0jRwQaAWo9o=
 github.com/codeready-toolchain/api v0.0.0-20260731065234-734640c901d2/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a h1:3t4cvcI/6ZUxUSRZoGS/Q9jH9OFu6Sg26PMTtOPRok4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20260731071123-c63091456f4a/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -249,6 +247,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace h1:aW/k32FZO9wr4IcCR6adbdXdamiazxdEDV0VY16MU7w=
+github.com/xcoulon/toolchain-common v0.0.0-20260803142641-2756b24ebace/go.mod h1:j4xJuhNtqEuZW7VR6BB5V6h/oDJ0dIwSh5iijUSwwdM=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/setup/configuration/configuration.go
+++ b/setup/configuration/configuration.go
@@ -164,7 +164,7 @@ func getKubeconfigFile(kubeconfigPath string) (*os.File, error) {
 	} else {
 		path = filepath.Join(homeDir(), ".kube", "config")
 	}
-	return os.Open(path)
+	return os.Open(filepath.Clean(path))
 }
 
 func newKubeConfig(r io.Reader) (clientcmd.ClientConfig, error) {

--- a/setup/metrics/client.go
+++ b/setup/metrics/client.go
@@ -30,6 +30,12 @@ func Client(address, token string) (api.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return nil, fmt.Errorf("unsupported scheme %q in address %q", u.Scheme, address)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("missing host in address %q", address)
+	}
 	u.Path = strings.TrimRight(u.Path, "/")
 
 	cl := http.Client{
@@ -65,7 +71,10 @@ func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 		req = req.WithContext(ctx)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
-	resp, err := c.client.Do(req)
+	if req.URL.Scheme != "https" && req.URL.Scheme != "http" {
+		return nil, nil, fmt.Errorf("unsupported scheme %q in request URL", req.URL.Scheme)
+	}
+	resp, err := c.client.Do(req) // nolint:gosec
 	defer func() {
 		if resp != nil {
 			resp.Body.Close()

--- a/setup/templates/template.go
+++ b/setup/templates/template.go
@@ -43,7 +43,7 @@ func GetTemplateFromContent(content []byte) (*templatev1.Template, error) {
 
 // ApplyObjects applies the given objects in order
 func ApplyObjects(ctx context.Context, cl runtimeclient.Client, objsToApply []runtimeclient.Object, modifiers ...ClientObjectModifier) error {
-	applycl := applyclientlib.NewSSAApplyClient(cl, fieldManager)
+	applycl := applyclientlib.NewServerSideApplyClient(cl, fieldManager)
 	for _, obj := range objsToApply {
 		fmt.Printf("Applying %s object with name '%s' in namespace '%s'\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName(), obj.GetNamespace())
 		if err := applyObject(ctx, applycl, obj, modifiers...); err != nil {
@@ -111,7 +111,7 @@ func combineResults(results ...<-chan error) <-chan error {
 func startObjectProcessor(ctx context.Context, cl runtimeclient.Client, objSource <-chan runtimeclient.Object, modifiers ...ClientObjectModifier) <-chan error {
 	out := make(chan error)
 	go func() {
-		applycl := applyclientlib.NewSSAApplyClient(cl, fieldManager)
+		applycl := applyclientlib.NewServerSideApplyClient(cl, fieldManager)
 		for obj := range objSource {
 			out <- applyObject(ctx, applycl, obj, modifiers...)
 			time.Sleep(100 * time.Millisecond)
@@ -131,7 +131,7 @@ func NamespaceModifier(userNS string) ClientObjectModifier {
 	}
 }
 
-func applyObject(ctx context.Context, applycl *applyclientlib.SSAApplyClient, obj runtimeclient.Object, modifiers ...ClientObjectModifier) error {
+func applyObject(ctx context.Context, applycl *applyclientlib.ServerSideApplyClient, obj runtimeclient.Object, modifiers ...ClientObjectModifier) error {
 	// apply any modifiers before applying the object
 	for _, modifier := range modifiers {
 		if err := modifier(obj); err != nil {


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource application to use the current server-side apply client while preserving retry and error-handling behavior.
  * Improved kubeconfig path handling and validation.
  * Added validation for metrics endpoints to require supported URL schemes and a host.
* **Chores**
  * Improved compatibility with the updated toolchain.
  * Updated continuous integration linting and validation workflows.
  * Refreshed vulnerability scanning exclusions and expiration dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->