### PR TITLE
avoid non-constant format string in calls

### DIFF
--- a/setup/cmd/root.go
+++ b/setup/cmd/root.go
@@ -155,9 +155,9 @@ func setup(cmd *cobra.Command, _ []string) { // nolint:gocyclo
 			tokenRequestURI, err := auth.GetTokenRequestURI(cl)
 			errMsg := "a token is required to capture metrics, use oc login with token to log into the cluster. eg. `oc login --token=<token> --server=<server>`"
 			if err != nil {
-				term.Fatalf(err, errMsg)
+				term.Fatal(err, errMsg)
 			}
-			term.Fatalf(fmt.Errorf("a token can be requested from %s", tokenRequestURI), errMsg)
+			term.Fatal(fmt.Errorf("a token can be requested from %s", tokenRequestURI), errMsg)
 		}
 	}
 

--- a/setup/metrics/gather_test.go
+++ b/setup/metrics/gather_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/toolchain-e2e/setup/metrics/queries"
+	"github.com/codeready-toolchain/toolchain-e2e/setup/terminal"
 	"github.com/stretchr/testify/require"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -237,11 +238,16 @@ func TestComputeResultsZeroSamples(t *testing.T) {
 
 type noopTerminal struct{}
 
+var _ terminal.Terminal = &noopTerminal{}
+
 func (t *noopTerminal) InOrStdin() io.Reader                              { return nil }
 func (t *noopTerminal) OutOrStdout() io.Writer                            { return io.Discard }
 func (t *noopTerminal) Debugf(msg string, args ...interface{})            {}
+func (t *noopTerminal) Info(msg string)                                   {}
 func (t *noopTerminal) Infof(msg string, args ...interface{})             {}
+func (t *noopTerminal) Error(err error, msg string)                       {}
 func (t *noopTerminal) Errorf(err error, msg string, args ...interface{}) {}
 func (t *noopTerminal) Fatalf(err error, msg string, args ...interface{}) { panic("unexpected Fatalf") }
+func (t *noopTerminal) Fatal(err error, msg string)                       { panic("unexpected Fatal") }
 func (t *noopTerminal) PromptBoolf(msg string, args ...interface{}) bool  { return false }
 func (t *noopTerminal) AddPreFatalExitHook(func())                        {}

--- a/setup/results/results.go
+++ b/setup/results/results.go
@@ -82,5 +82,5 @@ func (r *Results) OutputResults() {
 		r.term.Fatalf(err, "failed to write results")
 	}
 
-	r.term.Infof("\nResults file: " + cfg.ResultsFilepath())
+	r.term.Info("\nResults file: " + cfg.ResultsFilepath())
 }

--- a/setup/terminal/terminal.go
+++ b/setup/terminal/terminal.go
@@ -17,8 +17,11 @@ type Terminal interface {
 	InOrStdin() io.Reader
 	OutOrStdout() io.Writer
 	Debugf(msg string, args ...interface{})
+	Info(msg string)
 	Infof(msg string, args ...interface{})
+	Error(err error, msg string)
 	Errorf(err error, msg string, args ...interface{})
+	Fatal(err error, msg string)
 	Fatalf(err error, msg string, args ...interface{})
 	PromptBoolf(msg string, args ...interface{}) bool
 	AddPreFatalExitHook(func())
@@ -65,6 +68,15 @@ func (t *DefaultTerminal) Debugf(msg string, args ...interface{}) {
 	fmt.Fprintln(t.OutOrStdout(), fmt.Sprintf(msg, args...))
 }
 
+// Info displays a message with the default color
+func (t *DefaultTerminal) Info(msg string) {
+	if msg == "" {
+		fmt.Fprintln(t.OutOrStdout(), "")
+		return
+	}
+	fmt.Fprintln(t.OutOrStdout(), msg)
+}
+
 // Infof displays a message with the default color
 func (t *DefaultTerminal) Infof(msg string, args ...interface{}) {
 	if msg == "" {
@@ -74,9 +86,23 @@ func (t *DefaultTerminal) Infof(msg string, args ...interface{}) {
 	fmt.Fprintln(t.OutOrStdout(), fmt.Sprintf(msg, args...))
 }
 
+// Error prints a message with the red color
+func (t *DefaultTerminal) Error(err error, msg string) {
+	color.New(color.FgRed).Fprintln(t.OutOrStdout(), fmt.Sprintf("%s: %s", msg, err.Error())) // nolint:errcheck
+}
+
 // Errorf prints a message with the red color
 func (t *DefaultTerminal) Errorf(err error, msg string, args ...interface{}) {
 	color.New(color.FgRed).Fprintln(t.OutOrStdout(), fmt.Sprintf("%s: %s", fmt.Sprintf(msg, args...), err.Error())) // nolint:errcheck
+}
+
+// Fatal prints a message with the red color and exits the program with a `1` return code
+func (t *DefaultTerminal) Fatal(err error, msg string) {
+	defer os.Exit(1)
+	for _, hook := range t.fatalExitHooks {
+		hook()
+	}
+	t.Error(err, msg)
 }
 
 // Fatalf prints a message with the red color and exits the program with a `1` return code


### PR DESCRIPTION
add method that do not need extra variadic args to format the message (causing build failures in Go 1.26)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal messaging for token acquisition failures and results-file reporting.
  * Prevented error messages from being interpreted as formatting strings.
  * Fatal errors now run registered cleanup actions before exiting.

* **Enhancements**
  * Added consistent informational, error, and fatal terminal output handling.
  * Improved clarity and reliability of command-line feedback during setup and results reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->