### PR TITLE
feat: idling after 24h for Claw namespaces

### DIFF
--- a/testsupport/tiers/checks.go
+++ b/testsupport/tiers/checks.go
@@ -590,7 +590,7 @@ func (a *clawTierChecks) GetClusterObjectChecks() []clusterObjectsCheck {
 	return clusterObjectsChecks(
 		clusterResourceQuotaClaw(),
 		numberOfClusterResourceQuotas(1),
-		idlers(0, "claw"))
+		idlers(24*3600, "claw")) // 24hrs timeout
 }
 
 func clusterResourceQuotaClaw() clusterObjectsCheckCreator {


### PR DESCRIPTION
kinda revert of #1280, but allow running for 24h instead of default 12h

e2e tests for https://github.com/codeready-toolchain/host-operator/pull/1292

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Claw tier’s idle timeout expectation to 24 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->